### PR TITLE
Add YT Links to all episode notes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,175 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/
+
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+*.code-workspace
+
+# Local History for Visual Studio Code
+.history/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,17 @@
+repos:
+-   repo: https://github.com/python/black
+    rev: 20.8b1
+    hooks:
+    - id: black
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v2.3.0
+    hooks:
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: trailing-whitespace
+-   repo: https://github.com/pycqa/pylint
+    rev: pylint-2.7.1
+    hooks:
+    -   id: pylint
+        name: pylint (library code)
+        types: [python]

--- a/2020/2020-09-24.md
+++ b/2020/2020-09-24.md
@@ -13,16 +13,16 @@ Housekeeping
 
 
 Topics of the day:
-* 02:23 Fede2: requested puzzle discussion. ( twitter / Wikipedia Intel_8008 - hires  ) 
-* 26:23 CircuitPython naming history
-* 30:26 Mach XO2 stemma board status ( wikipedia 7400 series Mach X02)
-* 50:32 UF2 discussion
-* 57:24 Talk about requests library.
-* 1:04:27 detour to push symbol for stemma mach32 board
-* 1:17:45 back to requests
-   * 1:39:15 file size/ module
-* 1:49:24 Deep sleep from microdev
-* 2:00:58 Double I2C on Stemma Mach32
+* [02:23](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=143) Fede2: requested puzzle discussion. ( twitter / Wikipedia Intel_8008 - hires  )
+* [26:23](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=1583) CircuitPython naming history
+* [30:26](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=1826) Mach XO2 stemma board status ( wikipedia 7400 series Mach X02)
+* [50:32](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=3032) UF2 discussion
+* [57:24](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=3444) Talk about requests library.
+* [1:04:27](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=3867) detour to push symbol for stemma mach32 board
+* [1:17:45](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=4665) back to requests
+   * [1:39:15](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=5955) file size/ module
+* [1:49:24](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=6564) Deep sleep from microdev
+* [2:00:58](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=7258) Double I2C on Stemma Mach32
 
 Puzzle story embedded in twitter feed - @RavensburgerNA took the hires that Scott sent.
 Many thanks to @kenshirriff

--- a/2020/2020-09-24.md
+++ b/2020/2020-09-24.md
@@ -20,7 +20,7 @@ Topics of the day:
 * [57:24](https://www.youtube.com/watch?v=S-SdQFhxeHM&t=3444) Talk about requests library.
 * [1:04:27](https://www.youtube.com/watch?v=S-SdQFhxeHM&t=3867) detour to push symbol for stemma mach32 board
 * [1:17:45](https://www.youtube.com/watch?v=S-SdQFhxeHM&t=4665) back to requests
-   * [1:39:15](https://www.youtube.com/watch?v=S-SdQFhxeHM&t=5955) file size/ module
+* [1:39:15](https://www.youtube.com/watch?v=S-SdQFhxeHM&t=5955) file size/ module
 * [1:49:24](https://www.youtube.com/watch?v=S-SdQFhxeHM&t=6564) Deep sleep from microdev
 * [2:00:58](https://www.youtube.com/watch?v=S-SdQFhxeHM&t=7258) Double I2C on Stemma Mach32
 

--- a/2020/2020-09-24.md
+++ b/2020/2020-09-24.md
@@ -13,16 +13,16 @@ Housekeeping
 
 
 Topics of the day:
-* [02:23](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=143) Fede2: requested puzzle discussion. ( twitter / Wikipedia Intel_8008 - hires  )
-* [26:23](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=1583) CircuitPython naming history
-* [30:26](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=1826) Mach XO2 stemma board status ( wikipedia 7400 series Mach X02)
-* [50:32](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=3032) UF2 discussion
-* [57:24](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=3444) Talk about requests library.
-* [1:04:27](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=3867) detour to push symbol for stemma mach32 board
-* [1:17:45](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=4665) back to requests
-   * [1:39:15](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=5955) file size/ module
-* [1:49:24](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=6564) Deep sleep from microdev
-* [2:00:58](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=7258) Double I2C on Stemma Mach32
+* [02:23](https://www.youtube.com/watch?v=S-SdQFhxeHM&t=143) Fede2: requested puzzle discussion. ( twitter / Wikipedia Intel_8008 - hires  )
+* [26:23](https://www.youtube.com/watch?v=S-SdQFhxeHM&t=1583) CircuitPython naming history
+* [30:26](https://www.youtube.com/watch?v=S-SdQFhxeHM&t=1826) Mach XO2 stemma board status ( wikipedia 7400 series Mach X02)
+* [50:32](https://www.youtube.com/watch?v=S-SdQFhxeHM&t=3032) UF2 discussion
+* [57:24](https://www.youtube.com/watch?v=S-SdQFhxeHM&t=3444) Talk about requests library.
+* [1:04:27](https://www.youtube.com/watch?v=S-SdQFhxeHM&t=3867) detour to push symbol for stemma mach32 board
+* [1:17:45](https://www.youtube.com/watch?v=S-SdQFhxeHM&t=4665) back to requests
+   * [1:39:15](https://www.youtube.com/watch?v=S-SdQFhxeHM&t=5955) file size/ module
+* [1:49:24](https://www.youtube.com/watch?v=S-SdQFhxeHM&t=6564) Deep sleep from microdev
+* [2:00:58](https://www.youtube.com/watch?v=S-SdQFhxeHM&t=7258) Double I2C on Stemma Mach32
 
 Puzzle story embedded in twitter feed - @RavensburgerNA took the hires that Scott sent.
 Many thanks to @kenshirriff

--- a/2020/2020-09-24.md
+++ b/2020/2020-09-24.md
@@ -13,16 +13,16 @@ Housekeeping
 
 
 Topics of the day:
-* [02:23](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=143) Fede2: requested puzzle discussion. ( twitter / Wikipedia Intel_8008 - hires  )
-* [26:23](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=1583) CircuitPython naming history
-* [30:26](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=1826) Mach XO2 stemma board status ( wikipedia 7400 series Mach X02)
-* [50:32](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=3032) UF2 discussion
-* [57:24](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=3444) Talk about requests library.
-* [1:04:27](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=3867) detour to push symbol for stemma mach32 board
-* [1:17:45](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=4665) back to requests
-   * [1:39:15](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=5955) file size/ module
-* [1:49:24](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=6564) Deep sleep from microdev
-* [2:00:58](https://www.youtube.com/watch?v=VIDEO_2020_09_24?t=7258) Double I2C on Stemma Mach32
+* [02:23](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=143) Fede2: requested puzzle discussion. ( twitter / Wikipedia Intel_8008 - hires  )
+* [26:23](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=1583) CircuitPython naming history
+* [30:26](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=1826) Mach XO2 stemma board status ( wikipedia 7400 series Mach X02)
+* [50:32](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=3032) UF2 discussion
+* [57:24](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=3444) Talk about requests library.
+* [1:04:27](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=3867) detour to push symbol for stemma mach32 board
+* [1:17:45](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=4665) back to requests
+   * [1:39:15](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=5955) file size/ module
+* [1:49:24](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=6564) Deep sleep from microdev
+* [2:00:58](https://www.youtube.com/watch?v=VIDEO_2020_09_24&t=7258) Double I2C on Stemma Mach32
 
 Puzzle story embedded in twitter feed - @RavensburgerNA took the hires that Scott sent.
 Many thanks to @kenshirriff

--- a/2020/2020-10-02.md
+++ b/2020/2020-10-02.md
@@ -8,7 +8,7 @@ Housekeeping
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After I’ll unmute and continue.
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Next week’s stream is on Thursday!
-11:35 Topics
+[11:35](https://www.youtube.com/watch?v=vAPOZrG8pBo&t=695) Topics
 * Particle sensing / air quality
 * [13:30](https://www.youtube.com/watch?v=vAPOZrG8pBo&t=810) Fixed digitalio issues for upcoming Metro ESP32S2
 * [18:53](https://www.youtube.com/watch?v=vAPOZrG8pBo&t=1133) Released Beta 1. Please check it out and file issues

--- a/2020/2020-10-02.md
+++ b/2020/2020-10-02.md
@@ -10,16 +10,16 @@ Housekeeping
 * Next week’s stream is on Thursday!
 11:35 Topics
 * Particle sensing / air quality
-* [13:30](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=810) Fixed digitalio issues for upcoming Metro ESP32S2
-* [18:53](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=1133) Released Beta 1. Please check it out and file issues
-* [21:30](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=1290) Been working imx flash as a break from ESP32-S2
-* [22:00](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=1320) Common mistake of not updating submodules after changing branches and then committing the change.
-   * [25:25](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=1525)
-* [35:20](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=2120) Check email and code reviews.
+* [13:30](https://www.youtube.com/watch?v=vAPOZrG8pBo&t=810) Fixed digitalio issues for upcoming Metro ESP32S2
+* [18:53](https://www.youtube.com/watch?v=vAPOZrG8pBo&t=1133) Released Beta 1. Please check it out and file issues
+* [21:30](https://www.youtube.com/watch?v=vAPOZrG8pBo&t=1290) Been working imx flash as a break from ESP32-S2
+* [22:00](https://www.youtube.com/watch?v=vAPOZrG8pBo&t=1320) Common mistake of not updating submodules after changing branches and then committing the change.
+   * [25:25](https://www.youtube.com/watch?v=vAPOZrG8pBo&t=1525)
+* [35:20](https://www.youtube.com/watch?v=vAPOZrG8pBo&t=2120) Check email and code reviews.
    * Working in Public: https://www.amazon.com/Working-Public-Making-Maintenance-Software/dp/0578675862
-   * [1:06:39](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=3999) Onto the forum.
-   * [1:57:08](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=7028) https://github.com/adafruit/circuitpython/pull/3505
-   * [2:10:10](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=7810) https://github.com/adafruit/circuitpython/issues/1084#issuecomment-702627327
-   * [2:14:29](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=8069) https://github.com/adafruit/circuitpython/pull/3501
-   * [2:23:08](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=8588) https://github.com/adafruit/Adafruit_CircuitPython_Register/pull/35#discussion_r498447585
-* [2:31:40](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=9100)
+   * [1:06:39](https://www.youtube.com/watch?v=vAPOZrG8pBo&t=3999) Onto the forum.
+   * [1:57:08](https://www.youtube.com/watch?v=vAPOZrG8pBo&t=7028) https://github.com/adafruit/circuitpython/pull/3505
+   * [2:10:10](https://www.youtube.com/watch?v=vAPOZrG8pBo&t=7810) https://github.com/adafruit/circuitpython/issues/1084#issuecomment-702627327
+   * [2:14:29](https://www.youtube.com/watch?v=vAPOZrG8pBo&t=8069) https://github.com/adafruit/circuitpython/pull/3501
+   * [2:23:08](https://www.youtube.com/watch?v=vAPOZrG8pBo&t=8588) https://github.com/adafruit/Adafruit_CircuitPython_Register/pull/35#discussion_r498447585
+* [2:31:40](https://www.youtube.com/watch?v=vAPOZrG8pBo&t=9100)

--- a/2020/2020-10-02.md
+++ b/2020/2020-10-02.md
@@ -10,16 +10,16 @@ Housekeeping
 * Next week’s stream is on Thursday!
 11:35 Topics
 * Particle sensing / air quality
-* 13:30 Fixed digitalio issues for upcoming Metro ESP32S2
-* 18:53 Released Beta 1. Please check it out and file issues
-* 21:30 Been working imx flash as a break from ESP32-S2
-* 22:00 Common mistake of not updating submodules after changing branches and then committing the change.
-   * 25:25
-* 35:20 Check email and code reviews.
+* [13:30](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=810) Fixed digitalio issues for upcoming Metro ESP32S2
+* [18:53](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=1133) Released Beta 1. Please check it out and file issues
+* [21:30](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=1290) Been working imx flash as a break from ESP32-S2
+* [22:00](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=1320) Common mistake of not updating submodules after changing branches and then committing the change.
+   * [25:25](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=1525)
+* [35:20](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=2120) Check email and code reviews.
    * Working in Public: https://www.amazon.com/Working-Public-Making-Maintenance-Software/dp/0578675862
-   * 1:06:39 Onto the forum.
-   * 1:57:08 https://github.com/adafruit/circuitpython/pull/3505
-   * 2:10:10 https://github.com/adafruit/circuitpython/issues/1084#issuecomment-702627327
-   * 2:14:29 https://github.com/adafruit/circuitpython/pull/3501
-   * 2:23:08 https://github.com/adafruit/Adafruit_CircuitPython_Register/pull/35#discussion_r498447585
-* 2:31:40
+   * [1:06:39](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=3999) Onto the forum.
+   * [1:57:08](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=7028) https://github.com/adafruit/circuitpython/pull/3505
+   * [2:10:10](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=7810) https://github.com/adafruit/circuitpython/issues/1084#issuecomment-702627327
+   * [2:14:29](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=8069) https://github.com/adafruit/circuitpython/pull/3501
+   * [2:23:08](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=8588) https://github.com/adafruit/Adafruit_CircuitPython_Register/pull/35#discussion_r498447585
+* [2:31:40](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=9100)

--- a/2020/2020-10-02.md
+++ b/2020/2020-10-02.md
@@ -10,16 +10,16 @@ Housekeeping
 * Next week’s stream is on Thursday!
 11:35 Topics
 * Particle sensing / air quality
-* [13:30](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=810) Fixed digitalio issues for upcoming Metro ESP32S2
-* [18:53](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=1133) Released Beta 1. Please check it out and file issues
-* [21:30](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=1290) Been working imx flash as a break from ESP32-S2
-* [22:00](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=1320) Common mistake of not updating submodules after changing branches and then committing the change.
-   * [25:25](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=1525)
-* [35:20](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=2120) Check email and code reviews.
+* [13:30](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=810) Fixed digitalio issues for upcoming Metro ESP32S2
+* [18:53](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=1133) Released Beta 1. Please check it out and file issues
+* [21:30](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=1290) Been working imx flash as a break from ESP32-S2
+* [22:00](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=1320) Common mistake of not updating submodules after changing branches and then committing the change.
+   * [25:25](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=1525)
+* [35:20](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=2120) Check email and code reviews.
    * Working in Public: https://www.amazon.com/Working-Public-Making-Maintenance-Software/dp/0578675862
-   * [1:06:39](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=3999) Onto the forum.
-   * [1:57:08](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=7028) https://github.com/adafruit/circuitpython/pull/3505
-   * [2:10:10](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=7810) https://github.com/adafruit/circuitpython/issues/1084#issuecomment-702627327
-   * [2:14:29](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=8069) https://github.com/adafruit/circuitpython/pull/3501
-   * [2:23:08](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=8588) https://github.com/adafruit/Adafruit_CircuitPython_Register/pull/35#discussion_r498447585
-* [2:31:40](https://www.youtube.com/watch?v=VIDEO_2020_10_02?t=9100)
+   * [1:06:39](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=3999) Onto the forum.
+   * [1:57:08](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=7028) https://github.com/adafruit/circuitpython/pull/3505
+   * [2:10:10](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=7810) https://github.com/adafruit/circuitpython/issues/1084#issuecomment-702627327
+   * [2:14:29](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=8069) https://github.com/adafruit/circuitpython/pull/3501
+   * [2:23:08](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=8588) https://github.com/adafruit/Adafruit_CircuitPython_Register/pull/35#discussion_r498447585
+* [2:31:40](https://www.youtube.com/watch?v=VIDEO_2020_10_02&t=9100)

--- a/2020/2020-10-08.md
+++ b/2020/2020-10-08.md
@@ -4,7 +4,7 @@
 Hi all, this doc is try and track topics and timecodes for my deep dive stream. These notes will end up in the YouTube video’s description. Any help keeping them groomed as I stream is welcome.
 
 
-6:05 Housekeeping
+[6:05](https://www.youtube.com/watch?v=oSFgB2xhJCk&t=365) Housekeeping
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After I’ll unmute and continue.
@@ -12,18 +12,15 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 * Next week will be on Friday!
 
 
-11:26 Plan
+[11:26](https://www.youtube.com/watch?v=oSFgB2xhJCk&t=686) Plan
 * [13:11](https://www.youtube.com/watch?v=oSFgB2xhJCk&t=791) Hacktoberfest https://hacktoberfest.digitalocean.com/
 * [19:49](https://www.youtube.com/watch?v=oSFgB2xhJCk&t=1189) Show OSH Park boards.
 Mention of #debug_edge connector
 * [25:28](https://www.youtube.com/watch?v=oSFgB2xhJCk&t=1528) Talk about iMX RT metro and plug Logic2 SPI Flash analyzer.
 Link to SOIC clip https://www.digikey.com/en/products/detail/pomona-electronics/5250/745102
 * Plug for software volunteer to assist: https://github.com/tannewt/tinylogicfriend
-* BitMagic Basic Logic Analyzer
-https://1bitsquared.com/products/bitmagic-basic
-* Mentioned also: Glasgow Interface Explorer?
- https://www.crowdsupply.com/1bitsquared/glasgow
-* 1;16:13 Dig into 6.0.0 issues.
+* BitMagic Basic Logic Analyzer https://1bitsquared.com/products/bitmagic-basic
+* Mentioned also: Glasgow Interface Explorer? https://www.crowdsupply.com/1bitsquared/glasgow
+* [1:16:13](https://www.youtube.com/watch?v=oSFgB2xhJCk&t=4573) Dig into 6.0.0 issues.
    * [1:29:50](https://www.youtube.com/watch?v=oSFgB2xhJCk&t=5390) Issue triage
    * [1:40:00](https://www.youtube.com/watch?v=oSFgB2xhJCk&t=6000) https://github.com/adafruit/circuitpython/issues/3502
-   *

--- a/2020/2020-10-08.md
+++ b/2020/2020-10-08.md
@@ -13,10 +13,10 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 11:26 Plan
-* [13:11](https://www.youtube.com/watch?v=VIDEO_2020_10_08?t=791) Hacktoberfest https://hacktoberfest.digitalocean.com/
-* [19:49](https://www.youtube.com/watch?v=VIDEO_2020_10_08?t=1189) Show OSH Park boards.
+* [13:11](https://www.youtube.com/watch?v=VIDEO_2020_10_08&t=791) Hacktoberfest https://hacktoberfest.digitalocean.com/
+* [19:49](https://www.youtube.com/watch?v=VIDEO_2020_10_08&t=1189) Show OSH Park boards.
 Mention of #debug_edge connector
-* [25:28](https://www.youtube.com/watch?v=VIDEO_2020_10_08?t=1528) Talk about iMX RT metro and plug Logic2 SPI Flash analyzer.
+* [25:28](https://www.youtube.com/watch?v=VIDEO_2020_10_08&t=1528) Talk about iMX RT metro and plug Logic2 SPI Flash analyzer.
 Link to SOIC clip https://www.digikey.com/en/products/detail/pomona-electronics/5250/745102
 * Plug for software volunteer to assist: https://github.com/tannewt/tinylogicfriend
 * BitMagic Basic Logic Analyzer
@@ -24,6 +24,6 @@ https://1bitsquared.com/products/bitmagic-basic
 * Mentioned also: Glasgow Interface Explorer?
  https://www.crowdsupply.com/1bitsquared/glasgow
 * 1;16:13 Dig into 6.0.0 issues.
-   * [1:29:50](https://www.youtube.com/watch?v=VIDEO_2020_10_08?t=5390) Issue triage
-   * [1:40:00](https://www.youtube.com/watch?v=VIDEO_2020_10_08?t=6000) https://github.com/adafruit/circuitpython/issues/3502
+   * [1:29:50](https://www.youtube.com/watch?v=VIDEO_2020_10_08&t=5390) Issue triage
+   * [1:40:00](https://www.youtube.com/watch?v=VIDEO_2020_10_08&t=6000) https://github.com/adafruit/circuitpython/issues/3502
    *

--- a/2020/2020-10-08.md
+++ b/2020/2020-10-08.md
@@ -13,10 +13,10 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 11:26 Plan
-* [13:11](https://www.youtube.com/watch?v=VIDEO_2020_10_08&t=791) Hacktoberfest https://hacktoberfest.digitalocean.com/
-* [19:49](https://www.youtube.com/watch?v=VIDEO_2020_10_08&t=1189) Show OSH Park boards.
+* [13:11](https://www.youtube.com/watch?v=oSFgB2xhJCk&t=791) Hacktoberfest https://hacktoberfest.digitalocean.com/
+* [19:49](https://www.youtube.com/watch?v=oSFgB2xhJCk&t=1189) Show OSH Park boards.
 Mention of #debug_edge connector
-* [25:28](https://www.youtube.com/watch?v=VIDEO_2020_10_08&t=1528) Talk about iMX RT metro and plug Logic2 SPI Flash analyzer.
+* [25:28](https://www.youtube.com/watch?v=oSFgB2xhJCk&t=1528) Talk about iMX RT metro and plug Logic2 SPI Flash analyzer.
 Link to SOIC clip https://www.digikey.com/en/products/detail/pomona-electronics/5250/745102
 * Plug for software volunteer to assist: https://github.com/tannewt/tinylogicfriend
 * BitMagic Basic Logic Analyzer
@@ -24,6 +24,6 @@ https://1bitsquared.com/products/bitmagic-basic
 * Mentioned also: Glasgow Interface Explorer?
  https://www.crowdsupply.com/1bitsquared/glasgow
 * 1;16:13 Dig into 6.0.0 issues.
-   * [1:29:50](https://www.youtube.com/watch?v=VIDEO_2020_10_08&t=5390) Issue triage
-   * [1:40:00](https://www.youtube.com/watch?v=VIDEO_2020_10_08&t=6000) https://github.com/adafruit/circuitpython/issues/3502
+   * [1:29:50](https://www.youtube.com/watch?v=oSFgB2xhJCk&t=5390) Issue triage
+   * [1:40:00](https://www.youtube.com/watch?v=oSFgB2xhJCk&t=6000) https://github.com/adafruit/circuitpython/issues/3502
    *

--- a/2020/2020-10-08.md
+++ b/2020/2020-10-08.md
@@ -13,18 +13,17 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 11:26 Plan
-* 13:11 Hacktoberfest https://hacktoberfest.digitalocean.com/
-* 19:49 Show OSH Park boards.
-Mention of #debug_edge connector 
-* 25:28 Talk about iMX RT metro and plug Logic2 SPI Flash analyzer.
+* [13:11](https://www.youtube.com/watch?v=VIDEO_2020_10_08?t=791) Hacktoberfest https://hacktoberfest.digitalocean.com/
+* [19:49](https://www.youtube.com/watch?v=VIDEO_2020_10_08?t=1189) Show OSH Park boards.
+Mention of #debug_edge connector
+* [25:28](https://www.youtube.com/watch?v=VIDEO_2020_10_08?t=1528) Talk about iMX RT metro and plug Logic2 SPI Flash analyzer.
 Link to SOIC clip https://www.digikey.com/en/products/detail/pomona-electronics/5250/745102
-* Plug for software volunteer to assist: https://github.com/tannewt/tinylogicfriend 
+* Plug for software volunteer to assist: https://github.com/tannewt/tinylogicfriend
 * BitMagic Basic Logic Analyzer
 https://1bitsquared.com/products/bitmagic-basic
 * Mentioned also: Glasgow Interface Explorer?
  https://www.crowdsupply.com/1bitsquared/glasgow
 * 1;16:13 Dig into 6.0.0 issues.
-   * 1:29:50 Issue triage
-   * 1:40:00 https://github.com/adafruit/circuitpython/issues/3502
+   * [1:29:50](https://www.youtube.com/watch?v=VIDEO_2020_10_08?t=5390) Issue triage
+   * [1:40:00](https://www.youtube.com/watch?v=VIDEO_2020_10_08?t=6000) https://github.com/adafruit/circuitpython/issues/3502
    *
-   

--- a/2020/2020-10-16.md
+++ b/2020/2020-10-16.md
@@ -13,49 +13,49 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 8:05 Plan
-* [9:17](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=557) - 17:23 6.0.0-rc.0 is out! Please help us test.
+* [9:17](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=557) - 17:23 6.0.0-rc.0 is out! Please help us test.
 https://github.com/adafruit/circuitpython/releases
-* [42:43](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=2563)
-   * [45:20](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=2720)
+* [42:43](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=2563)
+   * [45:20](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=2720)
 https://medium.com/bhdynamics/dynossat-edu-newspace-at-your-reach-9c2f88ca52e6
-   * [49:45](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=2985) - getting the cp 6.0 release onto circuitpython-org
-   * [51:20](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=3080) - ( but first - check the release notes and the green CI )
-   * [1:05:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=3900) - checking on release
-   * [1:06:40](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=4000) - blog and forum posts announce release
+   * [49:45](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=2985) - getting the cp 6.0 release onto circuitpython-org
+   * [51:20](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=3080) - ( but first - check the release notes and the green CI )
+   * [1:05:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=3900) - checking on release
+   * [1:06:40](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=4000) - blog and forum posts announce release
 ( use convert*releasenotes*md tool )
-   * [1:12:05](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=4325) blog post ( blog.adafruit.com )
+   * [1:12:05](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=4325) blog post ( blog.adafruit.com )
 ( copy html and URL )
-   * [1:15:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=4500) tweet - https://twitter.com/adafruit/status/1317226793473085440
+   * [1:15:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=4500) tweet - https://twitter.com/adafruit/status/1317226793473085440
    * SAMD21 auto-reload issues.
-   * [1:30:52](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=5452) SAMD21 _pew issue.
+   * [1:30:52](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=5452) SAMD21 _pew issue.
    * STM32 timekeeping going backwards causing I2C timeout.
-   * [1:31:52](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=5512) Suggestion for starting point/tutorials to learn how to start translating over from arduino sensors to python, so I can pitch in to the circuitpython effort? I am an enterprise dev using C#, js, etc
+   * [1:31:52](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=5512) Suggestion for starting point/tutorials to learn how to start translating over from arduino sensors to python, so I can pitch in to the circuitpython effort? I am an enterprise dev using C#, js, etc
       * https://learn.adafruit.com/creating-and-sharing-a-circuitpython-library
       * https://learn.adafruit.com/circuitpython-essentials/
       * https://www.youtube.com/watch?v=DdB3QS4_QQU
       * https://www.adafruit.com/product/4777
-      * [17:45](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=1065) UF2 on ESP32-S2
-      * [18:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=1080) LED filter purple / yellow / green states of the RGB LED
+      * [17:45](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=1065) UF2 on ESP32-S2
+      * [18:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=1080) LED filter purple / yellow / green states of the RGB LED
       * Red light indicates UF2-Boot
-      * [20:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=1200) Free RTOS
-      * [21:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=1260) Partition Layout -
+      * [20:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=1200) Free RTOS
+      * [21:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=1260) Partition Layout -
 Purple - Stage 2 boot loader… (decides between ota_0 and ota_1)
-      * [24:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=1440) - download latest CP from s3 ( absolute latest )
-      * [27:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=1620) new product idea - feather sized LED acrylic
+      * [24:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=1440) - download latest CP from s3 ( absolute latest )
+      * [27:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=1620) new product idea - feather sized LED acrylic
       * 4 versions of boot loaders
-      * [29:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=1740) Uf2-esp32s branch /generalize-bootloader
-      * [31:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=1860) PIN_NEOPIXEL in board_led_state
-         * [35:29](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=2129) RTS, CTS in UART
-         * [41:07](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=2467) Arduino libraries in CircuitPython
+      * [29:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=1740) Uf2-esp32s branch /generalize-bootloader
+      * [31:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=1860) PIN_NEOPIXEL in board_led_state
+         * [35:29](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=2129) RTS, CTS in UART
+         * [41:07](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=2467) Arduino libraries in CircuitPython
          * https://wiki.seeedstudio.com/ArduPy/
-         * [52:55](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=3175) RTOS
+         * [52:55](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=3175) RTOS
 https://zephyrproject.org/
-         * [1:01:57](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=3717) - super-loop in circuitpython
+         * [1:01:57](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=3717) - super-loop in circuitpython
 See CP main.c for (;;) { }
-         * [1:18:50](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=4730) https://jaycarlson.net/embedded-linux/
-         * [1:26:13](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=5173) Go Runtime on bare metal ?
-         * [1:27:20](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=5240) Recently close pull requests ( see above in the plan )
-         * [1:32:34](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=5554)  - getting started topics
+         * [1:18:50](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=4730) https://jaycarlson.net/embedded-linux/
+         * [1:26:13](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=5173) Go Runtime on bare metal ?
+         * [1:27:20](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=5240) Recently close pull requests ( see above in the plan )
+         * [1:32:34](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=5554)  - getting started topics
          * Read the docs - latest drivers ( all adafruit products )
          * Circuitpython community bundle ( non adafruit supported stuff )
          * Creating and sharing a circuit python library
@@ -70,26 +70,26 @@ Accelerating driver development with circuitpython - Bryan Siepert
 
 
 
-               * [1:39:23](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=5963) More sleepio API work
-               * [1:42:49](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=6169) hibernate / sleep #2796
+               * [1:39:23](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=5963) More sleepio API work
+               * [1:42:49](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=6169) hibernate / sleep #2796
                * Light sleep - everything is still on, but cpu is not clocked
-               * [1:48:19](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=6499) - sleep until alarm ( till someone presses a button ) #2795
+               * [1:48:19](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=6499) - sleep until alarm ( till someone presses a button ) #2795
                * Deep sleep / hibernate - turn power off to parts of the chip ( loose ram and cpu state )
-               * [1:44:52](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=6292) sleep until alarm
-               * [1:54:01](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=6841) Deep Diving into shared bindings alarm/__init__.h
+               * [1:44:52](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=6292) sleep until alarm
+               * [1:54:01](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=6841) Deep Diving into shared bindings alarm/__init__.h
                * Compare between microdev1 and tannewt’s further work
 https://github.com/microDev1/circuitpython/compare/sleepCPY...tannewt:sleepio
-                  * [1:56:55](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=7015) IMXRT1011 - what do the buttons do? ( pet peeve )
+                  * [1:56:55](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=7015) IMXRT1011 - what do the buttons do? ( pet peeve )
 Start by thinking about how you are going to use it!
 Google docs spreadsheet MCU Sleep Alarms - deep sleep research
                      * E.g. can USB wake uProc from deep sleep
-                     * [2:04:34](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=7474) - SAM D5x/E5X Family Data Sheet
+                     * [2:04:34](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=7474) - SAM D5x/E5X Family Data Sheet
 Sleep Mode entry and exit table
-                        * [2:10:01](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=7801) Continued discussion of API design approaches
-                        * [2:11:01](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=7861) discussion of line 42 - flashing the error LED, and impact on power
-                        * [2:12:45](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=7965) gui library question - displayio - the core of the display work in CP
+                        * [2:10:01](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=7801) Continued discussion of API design approaches
+                        * [2:11:01](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=7861) discussion of line 42 - flashing the error LED, and impact on power
+                        * [2:12:45](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=7965) gui library question - displayio - the core of the display work in CP
                         * FoamyGuy display layouts / json - https://github.com/FoamyGuy/circuitpython_display_layouts
-                        * [1:45:54](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=6354) - out of stack space ( c-stack vs. python stack - maximum recursion limit )
+                        * [1:45:54](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=6354) - out of stack space ( c-stack vs. python stack - maximum recursion limit )
                         *
 
 

--- a/2020/2020-10-16.md
+++ b/2020/2020-10-16.md
@@ -4,7 +4,7 @@
 Hi all, this doc is try and track topics and timecodes for my deep dive stream. These notes will end up in the YouTube video’s description. Any help keeping them groomed as I stream is welcome.
 
 
-2:00 Housekeeping
+[2:00](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=120) Housekeeping
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After, I’ll unmute and continue.
@@ -12,7 +12,7 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 * Next week’s stream is on Friday.
 
 
-8:05 Plan
+[8:05](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=485) Plan
 * [9:17](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=557) - 17:23 6.0.0-rc.0 is out! Please help us test.
 https://github.com/adafruit/circuitpython/releases
 * [42:43](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=2563)
@@ -66,10 +66,6 @@ Accelerating driver development with circuitpython - Bryan Siepert
             * Adafruit register
             * Join discord #help with circuitpython, #circuitpython ( more development )
             * revistaSG on twitter  https://twitter.com/mesheryio/status/1317116337123098624
-
-
-
-
                * [1:39:23](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=5963) More sleepio API work
                * [1:42:49](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=6169) hibernate / sleep #2796
                * Light sleep - everything is still on, but cpu is not clocked
@@ -77,8 +73,7 @@ Accelerating driver development with circuitpython - Bryan Siepert
                * Deep sleep / hibernate - turn power off to parts of the chip ( loose ram and cpu state )
                * [1:44:52](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=6292) sleep until alarm
                * [1:54:01](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=6841) Deep Diving into shared bindings alarm/__init__.h
-               * Compare between microdev1 and tannewt’s further work
-https://github.com/microDev1/circuitpython/compare/sleepCPY...tannewt:sleepio
+               * Compare between microdev1 and tannewt’s further work https://github.com/microDev1/circuitpython/compare/sleepCPY...tannewt:sleepio
                   * [1:56:55](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=7015) IMXRT1011 - what do the buttons do? ( pet peeve )
 Start by thinking about how you are going to use it!
 Google docs spreadsheet MCU Sleep Alarms - deep sleep research
@@ -90,11 +85,7 @@ Sleep Mode entry and exit table
                         * [2:12:45](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=7965) gui library question - displayio - the core of the display work in CP
                         * FoamyGuy display layouts / json - https://github.com/FoamyGuy/circuitpython_display_layouts
                         * [1:45:54](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=6354) - out of stack space ( c-stack vs. python stack - maximum recursion limit )
-                        *
-
-
-
-2:15:09 Wrap up
+[2:15:09](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=81:09) Wrap up
 
 
 ( the *:00 timecode are probably off by 3 minutes )

--- a/2020/2020-10-16.md
+++ b/2020/2020-10-16.md
@@ -13,49 +13,49 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 8:05 Plan
-* [9:17](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=557) - 17:23 6.0.0-rc.0 is out! Please help us test.
+* [9:17](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=557) - 17:23 6.0.0-rc.0 is out! Please help us test.
 https://github.com/adafruit/circuitpython/releases
-* [42:43](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=2563)
-   * [45:20](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=2720)
+* [42:43](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=2563)
+   * [45:20](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=2720)
 https://medium.com/bhdynamics/dynossat-edu-newspace-at-your-reach-9c2f88ca52e6
-   * [49:45](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=2985) - getting the cp 6.0 release onto circuitpython-org
-   * [51:20](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=3080) - ( but first - check the release notes and the green CI )
-   * [1:05:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=3900) - checking on release
-   * [1:06:40](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=4000) - blog and forum posts announce release
+   * [49:45](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=2985) - getting the cp 6.0 release onto circuitpython-org
+   * [51:20](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=3080) - ( but first - check the release notes and the green CI )
+   * [1:05:00](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=3900) - checking on release
+   * [1:06:40](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=4000) - blog and forum posts announce release
 ( use convert*releasenotes*md tool )
-   * [1:12:05](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=4325) blog post ( blog.adafruit.com )
+   * [1:12:05](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=4325) blog post ( blog.adafruit.com )
 ( copy html and URL )
-   * [1:15:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=4500) tweet - https://twitter.com/adafruit/status/1317226793473085440
+   * [1:15:00](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=4500) tweet - https://twitter.com/adafruit/status/1317226793473085440
    * SAMD21 auto-reload issues.
-   * [1:30:52](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=5452) SAMD21 _pew issue.
+   * [1:30:52](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=5452) SAMD21 _pew issue.
    * STM32 timekeeping going backwards causing I2C timeout.
-   * [1:31:52](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=5512) Suggestion for starting point/tutorials to learn how to start translating over from arduino sensors to python, so I can pitch in to the circuitpython effort? I am an enterprise dev using C#, js, etc
+   * [1:31:52](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=5512) Suggestion for starting point/tutorials to learn how to start translating over from arduino sensors to python, so I can pitch in to the circuitpython effort? I am an enterprise dev using C#, js, etc
       * https://learn.adafruit.com/creating-and-sharing-a-circuitpython-library
       * https://learn.adafruit.com/circuitpython-essentials/
       * https://www.youtube.com/watch?v=DdB3QS4_QQU
       * https://www.adafruit.com/product/4777
-      * [17:45](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=1065) UF2 on ESP32-S2
-      * [18:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=1080) LED filter purple / yellow / green states of the RGB LED
+      * [17:45](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=1065) UF2 on ESP32-S2
+      * [18:00](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=1080) LED filter purple / yellow / green states of the RGB LED
       * Red light indicates UF2-Boot
-      * [20:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=1200) Free RTOS
-      * [21:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=1260) Partition Layout -
+      * [20:00](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=1200) Free RTOS
+      * [21:00](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=1260) Partition Layout -
 Purple - Stage 2 boot loader… (decides between ota_0 and ota_1)
-      * [24:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=1440) - download latest CP from s3 ( absolute latest )
-      * [27:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=1620) new product idea - feather sized LED acrylic
+      * [24:00](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=1440) - download latest CP from s3 ( absolute latest )
+      * [27:00](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=1620) new product idea - feather sized LED acrylic
       * 4 versions of boot loaders
-      * [29:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=1740) Uf2-esp32s branch /generalize-bootloader
-      * [31:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=1860) PIN_NEOPIXEL in board_led_state
-         * [35:29](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=2129) RTS, CTS in UART
-         * [41:07](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=2467) Arduino libraries in CircuitPython
+      * [29:00](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=1740) Uf2-esp32s branch /generalize-bootloader
+      * [31:00](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=1860) PIN_NEOPIXEL in board_led_state
+         * [35:29](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=2129) RTS, CTS in UART
+         * [41:07](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=2467) Arduino libraries in CircuitPython
          * https://wiki.seeedstudio.com/ArduPy/
-         * [52:55](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=3175) RTOS
+         * [52:55](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=3175) RTOS
 https://zephyrproject.org/
-         * [1:01:57](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=3717) - super-loop in circuitpython
+         * [1:01:57](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=3717) - super-loop in circuitpython
 See CP main.c for (;;) { }
-         * [1:18:50](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=4730) https://jaycarlson.net/embedded-linux/
-         * [1:26:13](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=5173) Go Runtime on bare metal ?
-         * [1:27:20](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=5240) Recently close pull requests ( see above in the plan )
-         * [1:32:34](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=5554)  - getting started topics
+         * [1:18:50](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=4730) https://jaycarlson.net/embedded-linux/
+         * [1:26:13](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=5173) Go Runtime on bare metal ?
+         * [1:27:20](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=5240) Recently close pull requests ( see above in the plan )
+         * [1:32:34](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=5554)  - getting started topics
          * Read the docs - latest drivers ( all adafruit products )
          * Circuitpython community bundle ( non adafruit supported stuff )
          * Creating and sharing a circuit python library
@@ -70,26 +70,26 @@ Accelerating driver development with circuitpython - Bryan Siepert
 
 
 
-               * [1:39:23](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=5963) More sleepio API work
-               * [1:42:49](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=6169) hibernate / sleep #2796
+               * [1:39:23](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=5963) More sleepio API work
+               * [1:42:49](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=6169) hibernate / sleep #2796
                * Light sleep - everything is still on, but cpu is not clocked
-               * [1:48:19](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=6499) - sleep until alarm ( till someone presses a button ) #2795
+               * [1:48:19](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=6499) - sleep until alarm ( till someone presses a button ) #2795
                * Deep sleep / hibernate - turn power off to parts of the chip ( loose ram and cpu state )
-               * [1:44:52](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=6292) sleep until alarm
-               * [1:54:01](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=6841) Deep Diving into shared bindings alarm/__init__.h
+               * [1:44:52](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=6292) sleep until alarm
+               * [1:54:01](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=6841) Deep Diving into shared bindings alarm/__init__.h
                * Compare between microdev1 and tannewt’s further work
 https://github.com/microDev1/circuitpython/compare/sleepCPY...tannewt:sleepio
-                  * [1:56:55](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=7015) IMXRT1011 - what do the buttons do? ( pet peeve )
+                  * [1:56:55](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=7015) IMXRT1011 - what do the buttons do? ( pet peeve )
 Start by thinking about how you are going to use it!
 Google docs spreadsheet MCU Sleep Alarms - deep sleep research
                      * E.g. can USB wake uProc from deep sleep
-                     * [2:04:34](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=7474) - SAM D5x/E5X Family Data Sheet
+                     * [2:04:34](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=7474) - SAM D5x/E5X Family Data Sheet
 Sleep Mode entry and exit table
-                        * [2:10:01](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=7801) Continued discussion of API design approaches
-                        * [2:11:01](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=7861) discussion of line 42 - flashing the error LED, and impact on power
-                        * [2:12:45](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=7965) gui library question - displayio - the core of the display work in CP
+                        * [2:10:01](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=7801) Continued discussion of API design approaches
+                        * [2:11:01](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=7861) discussion of line 42 - flashing the error LED, and impact on power
+                        * [2:12:45](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=7965) gui library question - displayio - the core of the display work in CP
                         * FoamyGuy display layouts / json - https://github.com/FoamyGuy/circuitpython_display_layouts
-                        * [1:45:54](https://www.youtube.com/watch?v=VIDEO_2020_10_16&t=6354) - out of stack space ( c-stack vs. python stack - maximum recursion limit )
+                        * [1:45:54](https://www.youtube.com/watch?v=XW-C6DsOJc8&t=6354) - out of stack space ( c-stack vs. python stack - maximum recursion limit )
                         *
 
 

--- a/2020/2020-10-16.md
+++ b/2020/2020-10-16.md
@@ -13,49 +13,49 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 8:05 Plan
-* 9:17 - 17:23 6.0.0-rc.0 is out! Please help us test.
+* [9:17](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=557) - 17:23 6.0.0-rc.0 is out! Please help us test.
 https://github.com/adafruit/circuitpython/releases
-* 42:43 
-   * 45:20 
+* [42:43](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=2563)
+   * [45:20](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=2720)
 https://medium.com/bhdynamics/dynossat-edu-newspace-at-your-reach-9c2f88ca52e6
-   * 49:45 - getting the cp 6.0 release onto circuitpython-org 
-   * 51:20 - ( but first - check the release notes and the green CI )
-   * 1:05:00 - checking on release
-   * 1:06:40 - blog and forum posts announce release
+   * [49:45](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=2985) - getting the cp 6.0 release onto circuitpython-org
+   * [51:20](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=3080) - ( but first - check the release notes and the green CI )
+   * [1:05:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=3900) - checking on release
+   * [1:06:40](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=4000) - blog and forum posts announce release
 ( use convert*releasenotes*md tool )
-   * 1:12:05 blog post ( blog.adafruit.com )
+   * [1:12:05](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=4325) blog post ( blog.adafruit.com )
 ( copy html and URL )
-   * 1:15:00 tweet - https://twitter.com/adafruit/status/1317226793473085440 
+   * [1:15:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=4500) tweet - https://twitter.com/adafruit/status/1317226793473085440
    * SAMD21 auto-reload issues.
-   * 1:30:52 SAMD21 _pew issue.
+   * [1:30:52](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=5452) SAMD21 _pew issue.
    * STM32 timekeeping going backwards causing I2C timeout.
-   * 1:31:52 Suggestion for starting point/tutorials to learn how to start translating over from arduino sensors to python, so I can pitch in to the circuitpython effort? I am an enterprise dev using C#, js, etc
+   * [1:31:52](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=5512) Suggestion for starting point/tutorials to learn how to start translating over from arduino sensors to python, so I can pitch in to the circuitpython effort? I am an enterprise dev using C#, js, etc
       * https://learn.adafruit.com/creating-and-sharing-a-circuitpython-library
       * https://learn.adafruit.com/circuitpython-essentials/
       * https://www.youtube.com/watch?v=DdB3QS4_QQU
       * https://www.adafruit.com/product/4777
-      * 17:45 UF2 on ESP32-S2
-      * 18:00 LED filter purple / yellow / green states of the RGB LED
+      * [17:45](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=1065) UF2 on ESP32-S2
+      * [18:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=1080) LED filter purple / yellow / green states of the RGB LED
       * Red light indicates UF2-Boot
-      * 20:00 Free RTOS
-      * 21:00 Partition Layout - 
+      * [20:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=1200) Free RTOS
+      * [21:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=1260) Partition Layout -
 Purple - Stage 2 boot loader… (decides between ota_0 and ota_1)
-      * 24:00 - download latest CP from s3 ( absolute latest )
-      * 27:00 new product idea - feather sized LED acrylic
+      * [24:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=1440) - download latest CP from s3 ( absolute latest )
+      * [27:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=1620) new product idea - feather sized LED acrylic
       * 4 versions of boot loaders
-      * 29:00 Uf2-esp32s branch /generalize-bootloader
-      * 31:00 PIN_NEOPIXEL in board_led_state
-         * 35:29 RTS, CTS in UART
-         * 41:07 Arduino libraries in CircuitPython
+      * [29:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=1740) Uf2-esp32s branch /generalize-bootloader
+      * [31:00](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=1860) PIN_NEOPIXEL in board_led_state
+         * [35:29](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=2129) RTS, CTS in UART
+         * [41:07](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=2467) Arduino libraries in CircuitPython
          * https://wiki.seeedstudio.com/ArduPy/
-         * 52:55 RTOS
+         * [52:55](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=3175) RTOS
 https://zephyrproject.org/
-         * 1:01:57 - super-loop in circuitpython
+         * [1:01:57](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=3717) - super-loop in circuitpython
 See CP main.c for (;;) { }
-         * 1:18:50 https://jaycarlson.net/embedded-linux/
-         * 1:26:13 Go Runtime on bare metal ?
-         * 1:27:20 Recently close pull requests ( see above in the plan )
-         * 1:32:34  - getting started topics
+         * [1:18:50](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=4730) https://jaycarlson.net/embedded-linux/
+         * [1:26:13](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=5173) Go Runtime on bare metal ?
+         * [1:27:20](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=5240) Recently close pull requests ( see above in the plan )
+         * [1:32:34](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=5554)  - getting started topics
          * Read the docs - latest drivers ( all adafruit products )
          * Circuitpython community bundle ( non adafruit supported stuff )
          * Creating and sharing a circuit python library
@@ -65,32 +65,32 @@ Circuit python essentials guide
 Accelerating driver development with circuitpython - Bryan Siepert
             * Adafruit register
             * Join discord #help with circuitpython, #circuitpython ( more development )
-            * revistaSG on twitter  https://twitter.com/mesheryio/status/1317116337123098624 
+            * revistaSG on twitter  https://twitter.com/mesheryio/status/1317116337123098624
 
 
 
 
-               * 1:39:23 More sleepio API work
-               * 1:42:49 hibernate / sleep #2796
-               * Light sleep - everything is still on, but cpu is not clocked 
-               * 1:48:19 - sleep until alarm ( till someone presses a button ) #2795
+               * [1:39:23](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=5963) More sleepio API work
+               * [1:42:49](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=6169) hibernate / sleep #2796
+               * Light sleep - everything is still on, but cpu is not clocked
+               * [1:48:19](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=6499) - sleep until alarm ( till someone presses a button ) #2795
                * Deep sleep / hibernate - turn power off to parts of the chip ( loose ram and cpu state )
-               * 1:44:52 sleep until alarm
-               * 1:54:01 Deep Diving into shared bindings alarm/__init__.h
+               * [1:44:52](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=6292) sleep until alarm
+               * [1:54:01](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=6841) Deep Diving into shared bindings alarm/__init__.h
                * Compare between microdev1 and tannewt’s further work
 https://github.com/microDev1/circuitpython/compare/sleepCPY...tannewt:sleepio
-                  * 1:56:55 IMXRT1011 - what do the buttons do? ( pet peeve )
+                  * [1:56:55](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=7015) IMXRT1011 - what do the buttons do? ( pet peeve )
 Start by thinking about how you are going to use it!
 Google docs spreadsheet MCU Sleep Alarms - deep sleep research
-                     * E.g. can USB wake uProc from deep sleep 
-                     * 2:04:34 - SAM D5x/E5X Family Data Sheet 
+                     * E.g. can USB wake uProc from deep sleep
+                     * [2:04:34](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=7474) - SAM D5x/E5X Family Data Sheet
 Sleep Mode entry and exit table
-                        * 2:10:01 Continued discussion of API design approaches
-                        * 2:11:01 discussion of line 42 - flashing the error LED, and impact on power
-                        * 2:12:45 gui library question - displayio - the core of the display work in CP
+                        * [2:10:01](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=7801) Continued discussion of API design approaches
+                        * [2:11:01](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=7861) discussion of line 42 - flashing the error LED, and impact on power
+                        * [2:12:45](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=7965) gui library question - displayio - the core of the display work in CP
                         * FoamyGuy display layouts / json - https://github.com/FoamyGuy/circuitpython_display_layouts
-                        * 1:45:54 - out of stack space ( c-stack vs. python stack - maximum recursion limit )
-                        * 
+                        * [1:45:54](https://www.youtube.com/watch?v=VIDEO_2020_10_16?t=6354) - out of stack space ( c-stack vs. python stack - maximum recursion limit )
+                        *
 
 
 

--- a/2020/2020-10-23.md
+++ b/2020/2020-10-23.md
@@ -4,23 +4,23 @@
 Hi all, this doc is try and track topics and timecodes for my deep dive stream. These notes will end up in the YouTube video’s description. Any help keeping them groomed as I stream is welcome.
 
 
-11:17 Housekeeping
+[11:17](https://www.youtube.com/watch?v=87BRiyWf1u8&t=677) Housekeeping
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After I’ll unmute and continue.
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Next week is on Friday! Note that the US hasn’t changed daylight savings time yet. If you are outside the US double check the time here: https://everytimezone.com/&t=5f9b5780,4ec
 
-
-16:01 Plan
+[16:01](https://www.youtube.com/watch?v=87BRiyWf1u8&t=961) Plan
 * [17:56](https://www.youtube.com/watch?v=87BRiyWf1u8&t=1076) cricket questions
 * [18:40](https://www.youtube.com/watch?v=87BRiyWf1u8&t=1120) Electronics youtube recommendations
 * [20:24](https://www.youtube.com/watch?v=87BRiyWf1u8&t=1224) prototype
 * [25:58](https://www.youtube.com/watch?v=87BRiyWf1u8&t=1558) Metro S2 is in the store! https://www.adafruit.com/product/4775
 * [34:54](https://www.youtube.com/watch?v=87BRiyWf1u8&t=2094) Let’s talk pinouts. Maybe SparkFun m.2 unboxing.
    * [43:15](https://www.youtube.com/watch?v=87BRiyWf1u8&t=2595) unboxing
-   * ~58:00 MicroMod: https://www.sparkfun.com/micromod
+   * [58:00](https://www.youtube.com/watch?v=87BRiyWf1u8&t=3480) MicroMod: https://www.sparkfun.com/micromod
    * [1:19:59](https://www.youtube.com/watch?v=87BRiyWf1u8&t=4799) RPi4 compute module: https://www.adafruit.com/product/4782
+* [1:30:10](https://www.youtube.com/watch?v=87BRiyWf1u8&t=2595) Circuit Python 6
 * EInk discussion.
    * [1:35:10](https://www.youtube.com/watch?v=87BRiyWf1u8&t=5710) New grayscale display: https://www.adafruit.com/product/4777
    * [1:45:54](https://www.youtube.com/watch?v=87BRiyWf1u8&t=6354) adding displayio
@@ -29,4 +29,3 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
       * [2:02:10](https://www.youtube.com/watch?v=87BRiyWf1u8&t=7330) Wikipedia - HSL & HSV
       * [2:12:30](https://www.youtube.com/watch?v=87BRiyWf1u8&t=7950) ESP-32 SPI issues….
       * [2:16:00](https://www.youtube.com/watch?v=87BRiyWf1u8&t=8160) begin wrap up...2:20:30
-      * * ? 1:30:10 Circuit Python 6

--- a/2020/2020-10-23.md
+++ b/2020/2020-10-23.md
@@ -13,20 +13,20 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 16:01 Plan
-* [17:56](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=1076) cricket questions
-* [18:40](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=1120) Electronics youtube recommendations
-* [20:24](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=1224) prototype
-* [25:58](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=1558) Metro S2 is in the store! https://www.adafruit.com/product/4775
-* [34:54](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=2094) Let’s talk pinouts. Maybe SparkFun m.2 unboxing.
-   * [43:15](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=2595) unboxing
+* [17:56](https://www.youtube.com/watch?v=87BRiyWf1u8&t=1076) cricket questions
+* [18:40](https://www.youtube.com/watch?v=87BRiyWf1u8&t=1120) Electronics youtube recommendations
+* [20:24](https://www.youtube.com/watch?v=87BRiyWf1u8&t=1224) prototype
+* [25:58](https://www.youtube.com/watch?v=87BRiyWf1u8&t=1558) Metro S2 is in the store! https://www.adafruit.com/product/4775
+* [34:54](https://www.youtube.com/watch?v=87BRiyWf1u8&t=2094) Let’s talk pinouts. Maybe SparkFun m.2 unboxing.
+   * [43:15](https://www.youtube.com/watch?v=87BRiyWf1u8&t=2595) unboxing
    * ~58:00 MicroMod: https://www.sparkfun.com/micromod
-   * [1:19:59](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=4799) RPi4 compute module: https://www.adafruit.com/product/4782
+   * [1:19:59](https://www.youtube.com/watch?v=87BRiyWf1u8&t=4799) RPi4 compute module: https://www.adafruit.com/product/4782
 * EInk discussion.
-   * [1:35:10](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=5710) New grayscale display: https://www.adafruit.com/product/4777
-   * [1:45:54](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=6354) adding displayio
-   * [1:54:52](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=6892) dive into the code
-   * [2:00:00](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=7200) abstraction of 2 colors question…
-      * [2:02:10](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=7330) Wikipedia - HSL & HSV
-      * [2:12:30](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=7950) ESP-32 SPI issues….
-      * [2:16:00](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=8160) begin wrap up...2:20:30
+   * [1:35:10](https://www.youtube.com/watch?v=87BRiyWf1u8&t=5710) New grayscale display: https://www.adafruit.com/product/4777
+   * [1:45:54](https://www.youtube.com/watch?v=87BRiyWf1u8&t=6354) adding displayio
+   * [1:54:52](https://www.youtube.com/watch?v=87BRiyWf1u8&t=6892) dive into the code
+   * [2:00:00](https://www.youtube.com/watch?v=87BRiyWf1u8&t=7200) abstraction of 2 colors question…
+      * [2:02:10](https://www.youtube.com/watch?v=87BRiyWf1u8&t=7330) Wikipedia - HSL & HSV
+      * [2:12:30](https://www.youtube.com/watch?v=87BRiyWf1u8&t=7950) ESP-32 SPI issues….
+      * [2:16:00](https://www.youtube.com/watch?v=87BRiyWf1u8&t=8160) begin wrap up...2:20:30
       * * ? 1:30:10 Circuit Python 6

--- a/2020/2020-10-23.md
+++ b/2020/2020-10-23.md
@@ -9,24 +9,24 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After I’ll unmute and continue.
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
-* Next week is on Friday! Note that the US hasn’t changed daylight savings time yet. If you are outside the US double check the time here: https://everytimezone.com/?t=5f9b5780,4ec
+* Next week is on Friday! Note that the US hasn’t changed daylight savings time yet. If you are outside the US double check the time here: https://everytimezone.com/&t=5f9b5780,4ec
 
 
 16:01 Plan
-* [17:56](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=1076) cricket questions
-* [18:40](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=1120) Electronics youtube recommendations
-* [20:24](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=1224) prototype
-* [25:58](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=1558) Metro S2 is in the store! https://www.adafruit.com/product/4775
-* [34:54](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=2094) Let’s talk pinouts. Maybe SparkFun m.2 unboxing.
-   * [43:15](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=2595) unboxing
+* [17:56](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=1076) cricket questions
+* [18:40](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=1120) Electronics youtube recommendations
+* [20:24](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=1224) prototype
+* [25:58](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=1558) Metro S2 is in the store! https://www.adafruit.com/product/4775
+* [34:54](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=2094) Let’s talk pinouts. Maybe SparkFun m.2 unboxing.
+   * [43:15](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=2595) unboxing
    * ~58:00 MicroMod: https://www.sparkfun.com/micromod
-   * [1:19:59](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=4799) RPi4 compute module: https://www.adafruit.com/product/4782
+   * [1:19:59](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=4799) RPi4 compute module: https://www.adafruit.com/product/4782
 * EInk discussion.
-   * [1:35:10](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=5710) New grayscale display: https://www.adafruit.com/product/4777
-   * [1:45:54](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=6354) adding displayio
-   * [1:54:52](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=6892) dive into the code
-   * [2:00:00](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=7200) abstraction of 2 colors question…
-      * [2:02:10](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=7330) Wikipedia - HSL & HSV
-      * [2:12:30](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=7950) ESP-32 SPI issues….
-      * [2:16:00](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=8160) begin wrap up...2:20:30
+   * [1:35:10](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=5710) New grayscale display: https://www.adafruit.com/product/4777
+   * [1:45:54](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=6354) adding displayio
+   * [1:54:52](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=6892) dive into the code
+   * [2:00:00](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=7200) abstraction of 2 colors question…
+      * [2:02:10](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=7330) Wikipedia - HSL & HSV
+      * [2:12:30](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=7950) ESP-32 SPI issues….
+      * [2:16:00](https://www.youtube.com/watch?v=VIDEO_2020_10_23&t=8160) begin wrap up...2:20:30
       * * ? 1:30:10 Circuit Python 6

--- a/2020/2020-10-23.md
+++ b/2020/2020-10-23.md
@@ -13,20 +13,20 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 16:01 Plan
-* 17:56 cricket questions
-* 18:40 Electronics youtube recommendations
-* 20:24 prototype
-* 25:58 Metro S2 is in the store! https://www.adafruit.com/product/4775
-* 34:54 Let’s talk pinouts. Maybe SparkFun m.2 unboxing.
-   * 43:15 unboxing
+* [17:56](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=1076) cricket questions
+* [18:40](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=1120) Electronics youtube recommendations
+* [20:24](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=1224) prototype
+* [25:58](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=1558) Metro S2 is in the store! https://www.adafruit.com/product/4775
+* [34:54](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=2094) Let’s talk pinouts. Maybe SparkFun m.2 unboxing.
+   * [43:15](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=2595) unboxing
    * ~58:00 MicroMod: https://www.sparkfun.com/micromod
-   * 1:19:59 RPi4 compute module: https://www.adafruit.com/product/4782
-* EInk discussion. 
-   * 1:35:10 New grayscale display: https://www.adafruit.com/product/4777
-   * 1:45:54 adding displayio 
-   * 1:54:52 dive into the code 
-   * 2:00:00 abstraction of 2 colors question…
-      * 2:02:10 Wikipedia - HSL & HSV
-      * 2:12:30 ESP-32 SPI issues….
-      * 2:16:00 begin wrap up...2:20:30
+   * [1:19:59](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=4799) RPi4 compute module: https://www.adafruit.com/product/4782
+* EInk discussion.
+   * [1:35:10](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=5710) New grayscale display: https://www.adafruit.com/product/4777
+   * [1:45:54](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=6354) adding displayio
+   * [1:54:52](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=6892) dive into the code
+   * [2:00:00](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=7200) abstraction of 2 colors question…
+      * [2:02:10](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=7330) Wikipedia - HSL & HSV
+      * [2:12:30](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=7950) ESP-32 SPI issues….
+      * [2:16:00](https://www.youtube.com/watch?v=VIDEO_2020_10_23?t=8160) begin wrap up...2:20:30
       * * ? 1:30:10 Circuit Python 6

--- a/2020/2020-10-30.md
+++ b/2020/2020-10-30.md
@@ -12,14 +12,14 @@ Housekeeping
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After I’ll unmute and continue.
 
 
-12:57 Plan
+[12:57](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=777) Plan
 * [15:00](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=900) Is there anything like displayio.release_displays() that allows us to release only a single display install of all of them?
 * [17:30](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=1050) RaspberryPi bare metal thoughts
 * [32:43](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=1963) Grayscale support is checked in. Will be in 6.1.x
-* 42;24 6.0 update
+* [42:24](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=2664) 6.0 update
 * [50:58](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=3058) CI for electronics
 * [59:08](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=3548) Update `sleepio` status
-* 1;17:54 `recv` debugging and PR creation
+* [1:17:54](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=4674) `recv` debugging and PR creation
 * [1:29:55](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=5395) UF2
-* 1;37:19 back to receive
+* [1:37:19](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=5839) back to receive
 * [1:52:56](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=6776) NTP and adding UDP support

--- a/2020/2020-10-30.md
+++ b/2020/2020-10-30.md
@@ -13,13 +13,13 @@ Housekeeping
 
 
 12:57 Plan
-* [15:00](https://www.youtube.com/watch?v=VIDEO_2020_10_30&t=900) Is there anything like displayio.release_displays() that allows us to release only a single display install of all of them?
-* [17:30](https://www.youtube.com/watch?v=VIDEO_2020_10_30&t=1050) RaspberryPi bare metal thoughts
-* [32:43](https://www.youtube.com/watch?v=VIDEO_2020_10_30&t=1963) Grayscale support is checked in. Will be in 6.1.x
+* [15:00](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=900) Is there anything like displayio.release_displays() that allows us to release only a single display install of all of them?
+* [17:30](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=1050) RaspberryPi bare metal thoughts
+* [32:43](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=1963) Grayscale support is checked in. Will be in 6.1.x
 * 42;24 6.0 update
-* [50:58](https://www.youtube.com/watch?v=VIDEO_2020_10_30&t=3058) CI for electronics
-* [59:08](https://www.youtube.com/watch?v=VIDEO_2020_10_30&t=3548) Update `sleepio` status
+* [50:58](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=3058) CI for electronics
+* [59:08](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=3548) Update `sleepio` status
 * 1;17:54 `recv` debugging and PR creation
-* [1:29:55](https://www.youtube.com/watch?v=VIDEO_2020_10_30&t=5395) UF2
+* [1:29:55](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=5395) UF2
 * 1;37:19 back to receive
-* [1:52:56](https://www.youtube.com/watch?v=VIDEO_2020_10_30&t=6776) NTP and adding UDP support
+* [1:52:56](https://www.youtube.com/watch?v=G5c7RXq5r3A&t=6776) NTP and adding UDP support

--- a/2020/2020-10-30.md
+++ b/2020/2020-10-30.md
@@ -13,13 +13,13 @@ Housekeeping
 
 
 12:57 Plan
-* 15:00 Is there anything like displayio.release_displays() that allows us to release only a single display install of all of them?
-* 17:30 RaspberryPi bare metal thoughts
-* 32:43 Grayscale support is checked in. Will be in 6.1.x
+* [15:00](https://www.youtube.com/watch?v=VIDEO_2020_10_30?t=900) Is there anything like displayio.release_displays() that allows us to release only a single display install of all of them?
+* [17:30](https://www.youtube.com/watch?v=VIDEO_2020_10_30?t=1050) RaspberryPi bare metal thoughts
+* [32:43](https://www.youtube.com/watch?v=VIDEO_2020_10_30?t=1963) Grayscale support is checked in. Will be in 6.1.x
 * 42;24 6.0 update
-* 50:58 CI for electronics
-* 59:08 Update `sleepio` status
+* [50:58](https://www.youtube.com/watch?v=VIDEO_2020_10_30?t=3058) CI for electronics
+* [59:08](https://www.youtube.com/watch?v=VIDEO_2020_10_30?t=3548) Update `sleepio` status
 * 1;17:54 `recv` debugging and PR creation
-* 1:29:55 UF2
+* [1:29:55](https://www.youtube.com/watch?v=VIDEO_2020_10_30?t=5395) UF2
 * 1;37:19 back to receive
-* 1:52:56 NTP and adding UDP support
+* [1:52:56](https://www.youtube.com/watch?v=VIDEO_2020_10_30?t=6776) NTP and adding UDP support

--- a/2020/2020-10-30.md
+++ b/2020/2020-10-30.md
@@ -7,19 +7,19 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 Housekeeping
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
-* Next week’s stream will be on Friday. The US changes time this weekend so double check next week’s time again if you are outside the US. https://everytimezone.com/?t=5fa49200,4ec
+* Next week’s stream will be on Friday. The US changes time this weekend so double check next week’s time again if you are outside the US. https://everytimezone.com/&t=5fa49200,4ec
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After I’ll unmute and continue.
 
 
 12:57 Plan
-* [15:00](https://www.youtube.com/watch?v=VIDEO_2020_10_30?t=900) Is there anything like displayio.release_displays() that allows us to release only a single display install of all of them?
-* [17:30](https://www.youtube.com/watch?v=VIDEO_2020_10_30?t=1050) RaspberryPi bare metal thoughts
-* [32:43](https://www.youtube.com/watch?v=VIDEO_2020_10_30?t=1963) Grayscale support is checked in. Will be in 6.1.x
+* [15:00](https://www.youtube.com/watch?v=VIDEO_2020_10_30&t=900) Is there anything like displayio.release_displays() that allows us to release only a single display install of all of them?
+* [17:30](https://www.youtube.com/watch?v=VIDEO_2020_10_30&t=1050) RaspberryPi bare metal thoughts
+* [32:43](https://www.youtube.com/watch?v=VIDEO_2020_10_30&t=1963) Grayscale support is checked in. Will be in 6.1.x
 * 42;24 6.0 update
-* [50:58](https://www.youtube.com/watch?v=VIDEO_2020_10_30?t=3058) CI for electronics
-* [59:08](https://www.youtube.com/watch?v=VIDEO_2020_10_30?t=3548) Update `sleepio` status
+* [50:58](https://www.youtube.com/watch?v=VIDEO_2020_10_30&t=3058) CI for electronics
+* [59:08](https://www.youtube.com/watch?v=VIDEO_2020_10_30&t=3548) Update `sleepio` status
 * 1;17:54 `recv` debugging and PR creation
-* [1:29:55](https://www.youtube.com/watch?v=VIDEO_2020_10_30?t=5395) UF2
+* [1:29:55](https://www.youtube.com/watch?v=VIDEO_2020_10_30&t=5395) UF2
 * 1;37:19 back to receive
-* [1:52:56](https://www.youtube.com/watch?v=VIDEO_2020_10_30?t=6776) NTP and adding UDP support
+* [1:52:56](https://www.youtube.com/watch?v=VIDEO_2020_10_30&t=6776) NTP and adding UDP support

--- a/2020/2020-11-06.md
+++ b/2020/2020-11-06.md
@@ -14,32 +14,32 @@ Housekeeping
 
 8:05 Plan
 * Questions
-* [10:30](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=630) Handed off 6.0.0 to Dan along with (12:42)  deep sleep work.
-* [29:31](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=1771) portenta
-* [32:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=1920) open book
-* [33:33](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=2013) instant boot - not quite - on bare metal on RPi
-* [39:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=2340) ( something heads up to order… )
-* [40:30](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=2430) Have been improving ESP32SPI and Requests.
-* [44:19](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=2659) MiniMqqt not tested yet on featherS2
-* [47:13](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=2833) weather display and requests on matrix portal
-* [25:10](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=1510) Distracted by the election.
-* [1:01:08](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=3668) Want to make an EInk Portal project today.
-* [1:10:38](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=4238) MagTag powered up
-* [1:10:57](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=4257) PR- rename product
-* [1:12:44](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=4364) Sony Z-V1 camera highlight…
-* [1:14:20](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=4460) MagTag features
-* [1:22:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=4920) first ‘make’
-* [1:27:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=5220) programming the magtag complete
-* [1:31:29](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=5489) push and request review
-* [1:32:25](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=5545) update github workflow for magtag
-* [1:37:20](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=5840) discuss disabling autoreload
-* [1:41:44](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=6104) code - wifi weather
-* [1:43:34](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=6214) download latest adafruit request
-* [1:48:59](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=6539) using openweathermap.org api with disposable key
-* [1:52:20](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=6740) retrieved weather information
-* [2:03:03](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=7383) - last call for questions ….
-* [2:04:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=7440) - electioncal future…
-* [2:05:55](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=7555) - there are bugs stil ( in the weather python test )l ….
-* [2:07:25](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=7645) - wrap up
-* [2:09:15](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=7755) - pet the cat
+* [10:30](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=630) Handed off 6.0.0 to Dan along with (12:42)  deep sleep work.
+* [29:31](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=1771) portenta
+* [32:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=1920) open book
+* [33:33](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=2013) instant boot - not quite - on bare metal on RPi
+* [39:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=2340) ( something heads up to order… )
+* [40:30](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=2430) Have been improving ESP32SPI and Requests.
+* [44:19](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=2659) MiniMqqt not tested yet on featherS2
+* [47:13](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=2833) weather display and requests on matrix portal
+* [25:10](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=1510) Distracted by the election.
+* [1:01:08](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=3668) Want to make an EInk Portal project today.
+* [1:10:38](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=4238) MagTag powered up
+* [1:10:57](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=4257) PR- rename product
+* [1:12:44](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=4364) Sony Z-V1 camera highlight…
+* [1:14:20](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=4460) MagTag features
+* [1:22:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=4920) first ‘make’
+* [1:27:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=5220) programming the magtag complete
+* [1:31:29](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=5489) push and request review
+* [1:32:25](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=5545) update github workflow for magtag
+* [1:37:20](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=5840) discuss disabling autoreload
+* [1:41:44](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=6104) code - wifi weather
+* [1:43:34](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=6214) download latest adafruit request
+* [1:48:59](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=6539) using openweathermap.org api with disposable key
+* [1:52:20](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=6740) retrieved weather information
+* [2:03:03](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=7383) - last call for questions ….
+* [2:04:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=7440) - electioncal future…
+* [2:05:55](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=7555) - there are bugs stil ( in the weather python test )l ….
+* [2:07:25](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=7645) - wrap up
+* [2:09:15](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=7755) - pet the cat
 *

--- a/2020/2020-11-06.md
+++ b/2020/2020-11-06.md
@@ -14,32 +14,32 @@ Housekeeping
 
 8:05 Plan
 * Questions
-* [10:30](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=630) Handed off 6.0.0 to Dan along with (12:42)  deep sleep work.
-* [29:31](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=1771) portenta
-* [32:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=1920) open book
-* [33:33](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=2013) instant boot - not quite - on bare metal on RPi
-* [39:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=2340) ( something heads up to order… )
-* [40:30](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=2430) Have been improving ESP32SPI and Requests.
-* [44:19](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=2659) MiniMqqt not tested yet on featherS2
-* [47:13](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=2833) weather display and requests on matrix portal
-* [25:10](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=1510) Distracted by the election.
-* [1:01:08](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=3668) Want to make an EInk Portal project today.
-* [1:10:38](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=4238) MagTag powered up
-* [1:10:57](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=4257) PR- rename product
-* [1:12:44](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=4364) Sony Z-V1 camera highlight…
-* [1:14:20](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=4460) MagTag features
-* [1:22:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=4920) first ‘make’
-* [1:27:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=5220) programming the magtag complete
-* [1:31:29](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=5489) push and request review
-* [1:32:25](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=5545) update github workflow for magtag
-* [1:37:20](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=5840) discuss disabling autoreload
-* [1:41:44](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=6104) code - wifi weather
-* [1:43:34](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=6214) download latest adafruit request
-* [1:48:59](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=6539) using openweathermap.org api with disposable key
-* [1:52:20](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=6740) retrieved weather information
-* [2:03:03](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=7383) - last call for questions ….
-* [2:04:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=7440) - electioncal future…
-* [2:05:55](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=7555) - there are bugs stil ( in the weather python test )l ….
-* [2:07:25](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=7645) - wrap up
-* [2:09:15](https://www.youtube.com/watch?v=VIDEO_2020_11_06&t=7755) - pet the cat
+* [10:30](https://www.youtube.com/watch?v=cOctKahBuDU&t=630) Handed off 6.0.0 to Dan along with (12:42)  deep sleep work.
+* [29:31](https://www.youtube.com/watch?v=cOctKahBuDU&t=1771) portenta
+* [32:00](https://www.youtube.com/watch?v=cOctKahBuDU&t=1920) open book
+* [33:33](https://www.youtube.com/watch?v=cOctKahBuDU&t=2013) instant boot - not quite - on bare metal on RPi
+* [39:00](https://www.youtube.com/watch?v=cOctKahBuDU&t=2340) ( something heads up to order… )
+* [40:30](https://www.youtube.com/watch?v=cOctKahBuDU&t=2430) Have been improving ESP32SPI and Requests.
+* [44:19](https://www.youtube.com/watch?v=cOctKahBuDU&t=2659) MiniMqqt not tested yet on featherS2
+* [47:13](https://www.youtube.com/watch?v=cOctKahBuDU&t=2833) weather display and requests on matrix portal
+* [25:10](https://www.youtube.com/watch?v=cOctKahBuDU&t=1510) Distracted by the election.
+* [1:01:08](https://www.youtube.com/watch?v=cOctKahBuDU&t=3668) Want to make an EInk Portal project today.
+* [1:10:38](https://www.youtube.com/watch?v=cOctKahBuDU&t=4238) MagTag powered up
+* [1:10:57](https://www.youtube.com/watch?v=cOctKahBuDU&t=4257) PR- rename product
+* [1:12:44](https://www.youtube.com/watch?v=cOctKahBuDU&t=4364) Sony Z-V1 camera highlight…
+* [1:14:20](https://www.youtube.com/watch?v=cOctKahBuDU&t=4460) MagTag features
+* [1:22:00](https://www.youtube.com/watch?v=cOctKahBuDU&t=4920) first ‘make’
+* [1:27:00](https://www.youtube.com/watch?v=cOctKahBuDU&t=5220) programming the magtag complete
+* [1:31:29](https://www.youtube.com/watch?v=cOctKahBuDU&t=5489) push and request review
+* [1:32:25](https://www.youtube.com/watch?v=cOctKahBuDU&t=5545) update github workflow for magtag
+* [1:37:20](https://www.youtube.com/watch?v=cOctKahBuDU&t=5840) discuss disabling autoreload
+* [1:41:44](https://www.youtube.com/watch?v=cOctKahBuDU&t=6104) code - wifi weather
+* [1:43:34](https://www.youtube.com/watch?v=cOctKahBuDU&t=6214) download latest adafruit request
+* [1:48:59](https://www.youtube.com/watch?v=cOctKahBuDU&t=6539) using openweathermap.org api with disposable key
+* [1:52:20](https://www.youtube.com/watch?v=cOctKahBuDU&t=6740) retrieved weather information
+* [2:03:03](https://www.youtube.com/watch?v=cOctKahBuDU&t=7383) - last call for questions ….
+* [2:04:00](https://www.youtube.com/watch?v=cOctKahBuDU&t=7440) - electioncal future…
+* [2:05:55](https://www.youtube.com/watch?v=cOctKahBuDU&t=7555) - there are bugs stil ( in the weather python test )l ….
+* [2:07:25](https://www.youtube.com/watch?v=cOctKahBuDU&t=7645) - wrap up
+* [2:09:15](https://www.youtube.com/watch?v=cOctKahBuDU&t=7755) - pet the cat
 *

--- a/2020/2020-11-06.md
+++ b/2020/2020-11-06.md
@@ -12,7 +12,7 @@ Housekeeping
 * Next week will be on Friday again. The week after will be on Thursday.
 
 
-8:05 Plan
+[8:05](https://www.youtube.com/watch?v=cOctKahBuDU&t=485) Plan
 * Questions
 * [10:30](https://www.youtube.com/watch?v=cOctKahBuDU&t=630) Handed off 6.0.0 to Dan along with (12:42)  deep sleep work.
 * [29:31](https://www.youtube.com/watch?v=cOctKahBuDU&t=1771) portenta
@@ -42,4 +42,3 @@ Housekeeping
 * [2:05:55](https://www.youtube.com/watch?v=cOctKahBuDU&t=7555) - there are bugs stil ( in the weather python test )l ….
 * [2:07:25](https://www.youtube.com/watch?v=cOctKahBuDU&t=7645) - wrap up
 * [2:09:15](https://www.youtube.com/watch?v=cOctKahBuDU&t=7755) - pet the cat
-*

--- a/2020/2020-11-06.md
+++ b/2020/2020-11-06.md
@@ -14,32 +14,32 @@ Housekeeping
 
 8:05 Plan
 * Questions
-* 10:30 Handed off 6.0.0 to Dan along with (12:42)  deep sleep work.
-* 29:31 portenta
-* 32:00 open book
-* 33:33 instant boot - not quite - on bare metal on RPi 
-* 39:00 ( something heads up to order… )
-* 40:30 Have been improving ESP32SPI and Requests.
-* 44:19 MiniMqqt not tested yet on featherS2
-* 47:13 weather display and requests on matrix portal
-* 25:10 Distracted by the election.
-* 1:01:08 Want to make an EInk Portal project today.
-* 1:10:38 MagTag powered up 
-* 1:10:57 PR- rename product
-* 1:12:44 Sony Z-V1 camera highlight…
-* 1:14:20 MagTag features
-* 1:22:00 first ‘make’
-* 1:27:00 programming the magtag complete
-* 1:31:29 push and request review
-* 1:32:25 update github workflow for magtag
-* 1:37:20 discuss disabling autoreload
-* 1:41:44 code - wifi weather 
-* 1:43:34 download latest adafruit request
-* 1:48:59 using openweathermap.org api with disposable key
-* 1:52:20 retrieved weather information
-* 2:03:03 - last call for questions ….
-* 2:04:00 - electioncal future… 
-* 2:05:55 - there are bugs stil ( in the weather python test )l ….
-* 2:07:25 - wrap up
-* 2:09:15 - pet the cat
+* [10:30](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=630) Handed off 6.0.0 to Dan along with (12:42)  deep sleep work.
+* [29:31](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=1771) portenta
+* [32:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=1920) open book
+* [33:33](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=2013) instant boot - not quite - on bare metal on RPi
+* [39:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=2340) ( something heads up to order… )
+* [40:30](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=2430) Have been improving ESP32SPI and Requests.
+* [44:19](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=2659) MiniMqqt not tested yet on featherS2
+* [47:13](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=2833) weather display and requests on matrix portal
+* [25:10](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=1510) Distracted by the election.
+* [1:01:08](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=3668) Want to make an EInk Portal project today.
+* [1:10:38](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=4238) MagTag powered up
+* [1:10:57](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=4257) PR- rename product
+* [1:12:44](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=4364) Sony Z-V1 camera highlight…
+* [1:14:20](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=4460) MagTag features
+* [1:22:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=4920) first ‘make’
+* [1:27:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=5220) programming the magtag complete
+* [1:31:29](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=5489) push and request review
+* [1:32:25](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=5545) update github workflow for magtag
+* [1:37:20](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=5840) discuss disabling autoreload
+* [1:41:44](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=6104) code - wifi weather
+* [1:43:34](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=6214) download latest adafruit request
+* [1:48:59](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=6539) using openweathermap.org api with disposable key
+* [1:52:20](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=6740) retrieved weather information
+* [2:03:03](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=7383) - last call for questions ….
+* [2:04:00](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=7440) - electioncal future…
+* [2:05:55](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=7555) - there are bugs stil ( in the weather python test )l ….
+* [2:07:25](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=7645) - wrap up
+* [2:09:15](https://www.youtube.com/watch?v=VIDEO_2020_11_06?t=7755) - pet the cat
 *

--- a/2020/2020-11-13.md
+++ b/2020/2020-11-13.md
@@ -14,16 +14,16 @@ Housekeeping
 
 
 11:25 Plan
-* [41:00](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=2460) MiniMqTT
-* [42:20](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=2540) Grayscale bug in init code
+* [41:00](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=2460) MiniMqTT
+* [42:20](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=2540) Grayscale bug in init code
 https://github.com/adafruit/Adafruit_CircuitPython_IL0373/pull/14/files
 https://www.youtube.com/watch?v=58ns93IoHpQ&ab_channel=AdafruitIndustries
-* [1:00:39](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=3639) Luma bug in circuitpython
+* [1:00:39](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=3639) Luma bug in circuitpython
 https://github.com/adafruit/circuitpython/pull/3680/files
-* [14:35](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=875) TLS bug in ESP32-S2
+* [14:35](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=875) TLS bug in ESP32-S2
 17:45 root certificates
-* [31:48](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=1908) ssl API https://docs.python.org/3/library/ssl.html
-* [1:09:57](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=4197) Pending PRs
-* [1:20:31](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=4831) Electioncal.us stats?
-* [1:45:18](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=6318) clang
-* [1:58:44](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=7124) baremetal.ninja
+* [31:48](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=1908) ssl API https://docs.python.org/3/library/ssl.html
+* [1:09:57](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=4197) Pending PRs
+* [1:20:31](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=4831) Electioncal.us stats?
+* [1:45:18](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=6318) clang
+* [1:58:44](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=7124) baremetal.ninja

--- a/2020/2020-11-13.md
+++ b/2020/2020-11-13.md
@@ -14,16 +14,16 @@ Housekeeping
 
 
 11:25 Plan
-* 41:00 MiniMqTT
-* 42:20 Grayscale bug in init code
+* [41:00](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=2460) MiniMqTT
+* [42:20](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=2540) Grayscale bug in init code
 https://github.com/adafruit/Adafruit_CircuitPython_IL0373/pull/14/files
-https://www.youtube.com/watch?v=58ns93IoHpQ&ab_channel=AdafruitIndustries        
-* 1:00:39 Luma bug in circuitpython
-https://github.com/adafruit/circuitpython/pull/3680/files        
-* 14:35 TLS bug in ESP32-S2
+https://www.youtube.com/watch?v=58ns93IoHpQ&ab_channel=AdafruitIndustries
+* [1:00:39](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=3639) Luma bug in circuitpython
+https://github.com/adafruit/circuitpython/pull/3680/files
+* [14:35](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=875) TLS bug in ESP32-S2
 17:45 root certificates
-* 31:48 ssl API https://docs.python.org/3/library/ssl.html
-* 1:09:57 Pending PRs
-* 1:20:31 Electioncal.us stats?
-* 1:45:18 clang
-* 1:58:44 baremetal.ninja
+* [31:48](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=1908) ssl API https://docs.python.org/3/library/ssl.html
+* [1:09:57](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=4197) Pending PRs
+* [1:20:31](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=4831) Electioncal.us stats?
+* [1:45:18](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=6318) clang
+* [1:58:44](https://www.youtube.com/watch?v=VIDEO_2020_11_13?t=7124) baremetal.ninja

--- a/2020/2020-11-13.md
+++ b/2020/2020-11-13.md
@@ -13,7 +13,7 @@ Housekeeping
 * Thanks to David for the timer code for clue. Didn’t have time to set up today but hope to for next week.
 
 
-11:25 Plan
+[11:25](https://www.youtube.com/watch?v=-rtBgh9fgfA&t=685) Plan
 * [41:00](https://www.youtube.com/watch?v=-rtBgh9fgfA&t=2460) MiniMqTT
 * [42:20](https://www.youtube.com/watch?v=-rtBgh9fgfA&t=2540) Grayscale bug in init code
 https://github.com/adafruit/Adafruit_CircuitPython_IL0373/pull/14/files

--- a/2020/2020-11-13.md
+++ b/2020/2020-11-13.md
@@ -14,16 +14,16 @@ Housekeeping
 
 
 11:25 Plan
-* [41:00](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=2460) MiniMqTT
-* [42:20](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=2540) Grayscale bug in init code
+* [41:00](https://www.youtube.com/watch?v=-rtBgh9fgfA&t=2460) MiniMqTT
+* [42:20](https://www.youtube.com/watch?v=-rtBgh9fgfA&t=2540) Grayscale bug in init code
 https://github.com/adafruit/Adafruit_CircuitPython_IL0373/pull/14/files
 https://www.youtube.com/watch?v=58ns93IoHpQ&ab_channel=AdafruitIndustries
-* [1:00:39](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=3639) Luma bug in circuitpython
+* [1:00:39](https://www.youtube.com/watch?v=-rtBgh9fgfA&t=3639) Luma bug in circuitpython
 https://github.com/adafruit/circuitpython/pull/3680/files
-* [14:35](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=875) TLS bug in ESP32-S2
-17:45 root certificates
-* [31:48](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=1908) ssl API https://docs.python.org/3/library/ssl.html
-* [1:09:57](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=4197) Pending PRs
-* [1:20:31](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=4831) Electioncal.us stats?
-* [1:45:18](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=6318) clang
-* [1:58:44](https://www.youtube.com/watch?v=VIDEO_2020_11_13&t=7124) baremetal.ninja
+* [14:35](https://www.youtube.com/watch?v=-rtBgh9fgfA&t=875) TLS bug in ESP32-S2
+* [17:45](https://www.youtube.com/watch?v=-rtBgh9fgfA&t=1065) root certificates
+* [31:48](https://www.youtube.com/watch?v=-rtBgh9fgfA&t=1908) ssl API https://docs.python.org/3/library/ssl.html
+* [1:09:57](https://www.youtube.com/watch?v=-rtBgh9fgfA&t=4197) Pending PRs
+* [1:20:31](https://www.youtube.com/watch?v=-rtBgh9fgfA&t=4831) Electioncal.us stats?
+* [1:45:18](https://www.youtube.com/watch?v=-rtBgh9fgfA&t=6318) clang
+* [1:58:44](https://www.youtube.com/watch?v=-rtBgh9fgfA&t=7124) baremetal.ninja

--- a/2020/2020-11-19.md
+++ b/2020/2020-11-19.md
@@ -13,22 +13,22 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* 7:31 CircuitPython stability process
+* [7:31](https://www.youtube.com/watch?v=VIDEO_2020_11_19?t=451) CircuitPython stability process
 11:07 https://semver.org/  ( MAJOR / MINOR / PATCH versioning )
 17:00 https://github.com/adafruit/circuitpython/releases  6.1.0 Beta 0
 28:00 Reviewing CP pull requests
-* 32:35 ESP32-S2 debugging setup
+* [32:35](https://www.youtube.com/watch?v=VIDEO_2020_11_19?t=1955) ESP32-S2 debugging setup
 44:08 - hardware serial
- 33:22 - usb speedup for Scott’s ‘new’ computer… https://highpoint-tech.com/USA_new/series-ru1344a-overview.htm 
+ 33:22 - usb speedup for Scott’s ‘new’ computer… https://highpoint-tech.com/USA_new/series-ru1344a-overview.htm
 49:50 pi zero as a uarrt logger?
-53:37 - finding documentation for the MagTag display https://www.good-display.com/product/210.html 
-   * 59:02 Speeding up json parsing
-1:08:42 - resuming - consider 32 bytes at a time in recv_into 
-1:11:49 - measuring performance - baselines with time.monotonic 
+53:37 - finding documentation for the MagTag display https://www.good-display.com/product/210.html
+   * [59:02](https://www.youtube.com/watch?v=VIDEO_2020_11_19?t=3542) Speeding up json parsing
+1:08:42 - resuming - consider 32 bytes at a time in recv_into
+1:11:49 - measuring performance - baselines with time.monotonic
 1:14:20 --- we are into the deep dive --
 1:59:12   -- success with 32 bytes - now for 64 CIRCUITPY_JSON_READ_CHUNK_SIZE 64
 2:05:45 - backtraces   tools/decode_decodebacktrace.py  ( using elf file )
 2:11:12 - artifacts on a pull request
 2:17:40 - signing off…
 
-   * 1:03:52 - which python board is right for you ( plug for learn guide )
+   * [1:03:52](https://www.youtube.com/watch?v=VIDEO_2020_11_19?t=3832) - which python board is right for you ( plug for learn guide )

--- a/2020/2020-11-19.md
+++ b/2020/2020-11-19.md
@@ -13,22 +13,21 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* [7:31](https://www.youtube.com/watch?v=VIDEO_2020_11_19&t=451) CircuitPython stability process
-11:07 https://semver.org/  ( MAJOR / MINOR / PATCH versioning )
-17:00 https://github.com/adafruit/circuitpython/releases  6.1.0 Beta 0
-28:00 Reviewing CP pull requests
-* [32:35](https://www.youtube.com/watch?v=VIDEO_2020_11_19&t=1955) ESP32-S2 debugging setup
-44:08 - hardware serial
- 33:22 - usb speedup for Scott’s ‘new’ computer… https://highpoint-tech.com/USA_new/series-ru1344a-overview.htm
-49:50 pi zero as a uarrt logger?
-53:37 - finding documentation for the MagTag display https://www.good-display.com/product/210.html
-   * [59:02](https://www.youtube.com/watch?v=VIDEO_2020_11_19&t=3542) Speeding up json parsing
-1:08:42 - resuming - consider 32 bytes at a time in recv_into
-1:11:49 - measuring performance - baselines with time.monotonic
-1:14:20 --- we are into the deep dive --
-1:59:12   -- success with 32 bytes - now for 64 CIRCUITPY_JSON_READ_CHUNK_SIZE 64
-2:05:45 - backtraces   tools/decode_decodebacktrace.py  ( using elf file )
-2:11:12 - artifacts on a pull request
-2:17:40 - signing off…
-
-   * [1:03:52](https://www.youtube.com/watch?v=VIDEO_2020_11_19&t=3832) - which python board is right for you ( plug for learn guide )
+* [7:31](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=451) CircuitPython stability process
+* [11:07](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=667) https://semver.org/  ( MAJOR / MINOR / PATCH versioning )
+* [17:00](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=1020) https://github.com/adafruit/circuitpython/releases  6.1.0 Beta 0
+* [28:00](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=1680) Reviewing CP pull requests
+* [32:35](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=1955) ESP32-S2 debugging setup
+* [44:08](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=2648) - hardware serial
+* [33:22](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=2002) - usb speedup for Scott’s ‘new’ computer… https://highpoint-tech.com/USA_new/series-ru1344a-overview.htm
+* [49:50](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=2990) pi zero as a uarrt logger?
+* [53:37](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=3217) - finding documentation for the MagTag display https://www.good-display.com/product/210.html
+* [59:02](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=3542) Speeding up json parsing
+* [1:03:52](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=3832) - which python board is right for you ( plug for learn guide )
+* [1:08:42](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=4122) - resuming - consider 32 bytes at a time in recv_into
+* [1:11:49](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=4309) - measuring performance - baselines with time.monotonic
+* [1:14:20](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=4460) --- we are into the deep dive --
+* [1:59:12](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=7152)   -- success with 32 bytes - now for 64 CIRCUITPY_JSON_READ_CHUNK_SIZE 64
+* [2:05:45](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=7545) - backtraces   tools/decode_decodebacktrace.py  ( using elf file )
+* [2:11:12](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=7872) - artifacts on a pull request
+* [2:17:40](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=8260) - signing off…

--- a/2020/2020-11-19.md
+++ b/2020/2020-11-19.md
@@ -13,16 +13,16 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* [7:31](https://www.youtube.com/watch?v=VIDEO_2020_11_19?t=451) CircuitPython stability process
+* [7:31](https://www.youtube.com/watch?v=VIDEO_2020_11_19&t=451) CircuitPython stability process
 11:07 https://semver.org/  ( MAJOR / MINOR / PATCH versioning )
 17:00 https://github.com/adafruit/circuitpython/releases  6.1.0 Beta 0
 28:00 Reviewing CP pull requests
-* [32:35](https://www.youtube.com/watch?v=VIDEO_2020_11_19?t=1955) ESP32-S2 debugging setup
+* [32:35](https://www.youtube.com/watch?v=VIDEO_2020_11_19&t=1955) ESP32-S2 debugging setup
 44:08 - hardware serial
  33:22 - usb speedup for Scott’s ‘new’ computer… https://highpoint-tech.com/USA_new/series-ru1344a-overview.htm
 49:50 pi zero as a uarrt logger?
 53:37 - finding documentation for the MagTag display https://www.good-display.com/product/210.html
-   * [59:02](https://www.youtube.com/watch?v=VIDEO_2020_11_19?t=3542) Speeding up json parsing
+   * [59:02](https://www.youtube.com/watch?v=VIDEO_2020_11_19&t=3542) Speeding up json parsing
 1:08:42 - resuming - consider 32 bytes at a time in recv_into
 1:11:49 - measuring performance - baselines with time.monotonic
 1:14:20 --- we are into the deep dive --
@@ -31,4 +31,4 @@ Plan
 2:11:12 - artifacts on a pull request
 2:17:40 - signing off…
 
-   * [1:03:52](https://www.youtube.com/watch?v=VIDEO_2020_11_19?t=3832) - which python board is right for you ( plug for learn guide )
+   * [1:03:52](https://www.youtube.com/watch?v=VIDEO_2020_11_19&t=3832) - which python board is right for you ( plug for learn guide )

--- a/2020/2020-11-19.md
+++ b/2020/2020-11-19.md
@@ -4,7 +4,7 @@
 Hi all, this doc is try and track topics and timecodes for my deep dive stream. These notes will end up in the YouTube video’s description. Any help keeping them groomed as I stream is welcome.
 
 
-4:00 Housekeeping
+[4:00](https://www.youtube.com/watch?v=uEy2mrgmoAk&t=240) Housekeeping
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.

--- a/2020/2020-12-04.md
+++ b/2020/2020-12-04.md
@@ -13,40 +13,40 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 06:45 Plan
-* [12:06](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=726) debugging process for SAMD21
-* [14:28](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=868) power monitoring tools
-* [17:01](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=1021) debugging the hang
+* [12:06](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=726) debugging process for SAMD21
+* [14:28](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=868) power monitoring tools
+* [17:01](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=1021) debugging the hang
    * git submodule update --init ../..
-   * [21:04](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=1264) git push    --force-with-lease
+   * [21:04](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=1264) git push    --force-with-lease
 * Micro:bit v2
-* [24:33](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=1473) ESP32-S2 tweaks - Beta 2 is out w/ preliminary sleep support
+* [24:33](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=1473) ESP32-S2 tweaks - Beta 2 is out w/ preliminary sleep support
    * Using print on control-c when half-hung ( rtos/usb running, but CP is hung )
-   * [28:56](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=1736) RTOS …
-   * [31:20](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=1880) UF2 on nrf52840
-   * [32:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=1920) Back to the tls debugging code
-   * [37:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=2220) Nina firmware - adafruit branch
-   * [41:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=2460) Print a backtrace code ( for each thread )
+   * [28:56](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=1736) RTOS …
+   * [31:20](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=1880) UF2 on nrf52840
+   * [32:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=1920) Back to the tls debugging code
+   * [37:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=2220) Nina firmware - adafruit branch
+   * [41:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=2460) Print a backtrace code ( for each thread )
    * Json parsing speedup is merged in
    * No task switching during flash erase: https://github.com/adafruit/circuitpython/pull/3780
    * Switch to nina-fw certs: https://github.com/adafruit/circuitpython/pull/3775
    * Socket timeout and no broken socket error: https://github.com/adafruit/circuitpython/pull/3776
    * Exit earlier from closed sockets: https://github.com/adafruit/circuitpython/pull/3759
-* [43:49](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=2629) Lots of Sleep
+* [43:49](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=2629) Lots of Sleep
    * First implementation: https://github.com/adafruit/circuitpython/pull/3767
-   * [1:10:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=4200) Question about External Interrupt - ( next week ? )
-   * [1:13:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=4380) - watching Joulescope - ( a hang has occurred )
-   * [1:25:28](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=5128) - another crash - while in pretend deep sleep ( safe mode crash )
-   * [1:29:32](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=5372) - back to boot loader ( boot & reset )
-   * [1:31:49](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=5509) - rebuild after adding backtrace in sleep_tweaks branch
-   * [1:35:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=5700) - b.r.b…
-   * [1:41:52](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=6112) - reset and back in pretend deep sleep....
-   * [1:47:41](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=6461) - save to file during fake deep sleep - needed to be tested
-   * [1:49:46](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=6586) - perhaps the display is not re-initialized ?? investigating…
-   * [1:50:30](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=6630) - main.c dive ( fix board display while in deep sleep )
-   * [1:55:52](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=6952) - wrap up …...
-   * [50:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=3000) shared-bindings ( reason codes for waking up / restarting )
-   * [1:02:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=3720) Recommending starting projects with python
+   * [1:10:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=4200) Question about External Interrupt - ( next week ? )
+   * [1:13:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=4380) - watching Joulescope - ( a hang has occurred )
+   * [1:25:28](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=5128) - another crash - while in pretend deep sleep ( safe mode crash )
+   * [1:29:32](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=5372) - back to boot loader ( boot & reset )
+   * [1:31:49](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=5509) - rebuild after adding backtrace in sleep_tweaks branch
+   * [1:35:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=5700) - b.r.b…
+   * [1:41:52](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=6112) - reset and back in pretend deep sleep....
+   * [1:47:41](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=6461) - save to file during fake deep sleep - needed to be tested
+   * [1:49:46](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=6586) - perhaps the display is not re-initialized ?? investigating…
+   * [1:50:30](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=6630) - main.c dive ( fix board display while in deep sleep )
+   * [1:55:52](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=6952) - wrap up …...
+   * [50:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=3000) shared-bindings ( reason codes for waking up / restarting )
+   * [1:02:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=3720) Recommending starting projects with python
 Questions:
-* [1:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=60) - Distributors in India
+* [1:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=60) - Distributors in India
 
 ( all manually entered time codes are also off by the same 6 minute offset  )

--- a/2020/2020-12-04.md
+++ b/2020/2020-12-04.md
@@ -13,40 +13,40 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 06:45 Plan
-* 12:06 debugging process for SAMD21
-* 14:28 power monitoring tools
-* 17:01 debugging the hang
+* [12:06](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=726) debugging process for SAMD21
+* [14:28](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=868) power monitoring tools
+* [17:01](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=1021) debugging the hang
    * git submodule update --init ../..
-   * 21:04 git push    --force-with-lease
+   * [21:04](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=1264) git push    --force-with-lease
 * Micro:bit v2
-* 24:33 ESP32-S2 tweaks - Beta 2 is out w/ preliminary sleep support
+* [24:33](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=1473) ESP32-S2 tweaks - Beta 2 is out w/ preliminary sleep support
    * Using print on control-c when half-hung ( rtos/usb running, but CP is hung )
-   * 28:56 RTOS …
-   * 31:20 UF2 on nrf52840
-   * 32:00 Back to the tls debugging code
-   * 37:00 Nina firmware - adafruit branch
-   * 41:00 Print a backtrace code ( for each thread )
+   * [28:56](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=1736) RTOS …
+   * [31:20](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=1880) UF2 on nrf52840
+   * [32:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=1920) Back to the tls debugging code
+   * [37:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=2220) Nina firmware - adafruit branch
+   * [41:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=2460) Print a backtrace code ( for each thread )
    * Json parsing speedup is merged in
    * No task switching during flash erase: https://github.com/adafruit/circuitpython/pull/3780
    * Switch to nina-fw certs: https://github.com/adafruit/circuitpython/pull/3775
    * Socket timeout and no broken socket error: https://github.com/adafruit/circuitpython/pull/3776
    * Exit earlier from closed sockets: https://github.com/adafruit/circuitpython/pull/3759
-* 43:49 Lots of Sleep
+* [43:49](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=2629) Lots of Sleep
    * First implementation: https://github.com/adafruit/circuitpython/pull/3767
-   * 1:10:00 Question about External Interrupt - ( next week ? )
-   * 1:13:00 - watching Joulescope - ( a hang has occurred )
-   * 1:25:28 - another crash - while in pretend deep sleep ( safe mode crash )
-   * 1:29:32 - back to boot loader ( boot & reset )
-   * 1:31:49 - rebuild after adding backtrace in sleep_tweaks branch
-   * 1:35:00 - b.r.b…
-   * 1:41:52 - reset and back in pretend deep sleep....
-   * 1:47:41 - save to file during fake deep sleep - needed to be tested
-   * 1:49:46 - perhaps the display is not re-initialized ?? investigating…
-   * 1:50:30 - main.c dive ( fix board display while in deep sleep )
-   * 1:55:52 - wrap up …...
-   * 50:00 shared-bindings ( reason codes for waking up / restarting )
-   * 1:02:00 Recommending starting projects with python
+   * [1:10:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=4200) Question about External Interrupt - ( next week ? )
+   * [1:13:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=4380) - watching Joulescope - ( a hang has occurred )
+   * [1:25:28](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=5128) - another crash - while in pretend deep sleep ( safe mode crash )
+   * [1:29:32](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=5372) - back to boot loader ( boot & reset )
+   * [1:31:49](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=5509) - rebuild after adding backtrace in sleep_tweaks branch
+   * [1:35:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=5700) - b.r.b…
+   * [1:41:52](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=6112) - reset and back in pretend deep sleep....
+   * [1:47:41](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=6461) - save to file during fake deep sleep - needed to be tested
+   * [1:49:46](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=6586) - perhaps the display is not re-initialized ?? investigating…
+   * [1:50:30](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=6630) - main.c dive ( fix board display while in deep sleep )
+   * [1:55:52](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=6952) - wrap up …...
+   * [50:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=3000) shared-bindings ( reason codes for waking up / restarting )
+   * [1:02:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=3720) Recommending starting projects with python
 Questions:
-* 1:00 - Distributors in India
+* [1:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04?t=60) - Distributors in India
 
 ( all manually entered time codes are also off by the same 6 minute offset  )

--- a/2020/2020-12-04.md
+++ b/2020/2020-12-04.md
@@ -4,7 +4,7 @@
 Hi all, this doc is try and track topics and timecodes for my deep dive stream. These notes will end up in the YouTube video’s description. Any help keeping them groomed as I stream is welcome.
 
 
-02:06 Housekeeping
+[02:06](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=126) Housekeeping
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
@@ -12,41 +12,41 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 * Next week is on Friday too.
 
 
-06:45 Plan
-* [12:06](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=726) debugging process for SAMD21
-* [14:28](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=868) power monitoring tools
-* [17:01](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=1021) debugging the hang
+[06:45](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=405) Plan
+* [12:06](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=726) debugging process for SAMD21
+* [14:28](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=868) power monitoring tools
+* [17:01](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=1021) debugging the hang
    * git submodule update --init ../..
-   * [21:04](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=1264) git push    --force-with-lease
+   * [21:04](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=1264) git push    --force-with-lease
 * Micro:bit v2
-* [24:33](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=1473) ESP32-S2 tweaks - Beta 2 is out w/ preliminary sleep support
+* [24:33](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=1473) ESP32-S2 tweaks - Beta 2 is out w/ preliminary sleep support
    * Using print on control-c when half-hung ( rtos/usb running, but CP is hung )
-   * [28:56](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=1736) RTOS …
-   * [31:20](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=1880) UF2 on nrf52840
-   * [32:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=1920) Back to the tls debugging code
-   * [37:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=2220) Nina firmware - adafruit branch
-   * [41:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=2460) Print a backtrace code ( for each thread )
+   * [28:56](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=1736) RTOS …
+   * [31:20](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=1880) UF2 on nrf52840
+   * [32:00](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=1920) Back to the tls debugging code
+   * [37:00](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=2220) Nina firmware - adafruit branch
+   * [41:00](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=2460) Print a backtrace code ( for each thread )
    * Json parsing speedup is merged in
    * No task switching during flash erase: https://github.com/adafruit/circuitpython/pull/3780
    * Switch to nina-fw certs: https://github.com/adafruit/circuitpython/pull/3775
    * Socket timeout and no broken socket error: https://github.com/adafruit/circuitpython/pull/3776
    * Exit earlier from closed sockets: https://github.com/adafruit/circuitpython/pull/3759
-* [43:49](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=2629) Lots of Sleep
+* [43:49](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=2629) Lots of Sleep
    * First implementation: https://github.com/adafruit/circuitpython/pull/3767
-   * [1:10:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=4200) Question about External Interrupt - ( next week ? )
-   * [1:13:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=4380) - watching Joulescope - ( a hang has occurred )
-   * [1:25:28](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=5128) - another crash - while in pretend deep sleep ( safe mode crash )
-   * [1:29:32](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=5372) - back to boot loader ( boot & reset )
-   * [1:31:49](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=5509) - rebuild after adding backtrace in sleep_tweaks branch
-   * [1:35:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=5700) - b.r.b…
-   * [1:41:52](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=6112) - reset and back in pretend deep sleep....
-   * [1:47:41](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=6461) - save to file during fake deep sleep - needed to be tested
-   * [1:49:46](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=6586) - perhaps the display is not re-initialized ?? investigating…
-   * [1:50:30](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=6630) - main.c dive ( fix board display while in deep sleep )
-   * [1:55:52](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=6952) - wrap up …...
-   * [50:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=3000) shared-bindings ( reason codes for waking up / restarting )
-   * [1:02:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=3720) Recommending starting projects with python
+   * [1:10:00](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=4200) Question about External Interrupt - ( next week ? )
+   * [1:13:00](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=4380) - watching Joulescope - ( a hang has occurred )
+   * [1:25:28](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=5128) - another crash - while in pretend deep sleep ( safe mode crash )
+   * [1:29:32](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=5372) - back to boot loader ( boot & reset )
+   * [1:31:49](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=5509) - rebuild after adding backtrace in sleep_tweaks branch
+   * [1:35:00](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=5700) - b.r.b…
+   * [1:41:52](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=6112) - reset and back in pretend deep sleep....
+   * [1:47:41](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=6461) - save to file during fake deep sleep - needed to be tested
+   * [1:49:46](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=6586) - perhaps the display is not re-initialized ?? investigating…
+   * [1:50:30](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=6630) - main.c dive ( fix board display while in deep sleep )
+   * [1:55:52](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=6952) - wrap up …...
+   * [50:00](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=3000) shared-bindings ( reason codes for waking up / restarting )
+   * [1:02:00](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=3720) Recommending starting projects with python
 Questions:
-* [1:00](https://www.youtube.com/watch?v=VIDEO_2020_12_04&t=60) - Distributors in India
+* [1:00](https://www.youtube.com/watch?v=NJXvKJ0qFHQ&t=60) - Distributors in India
 
 ( all manually entered time codes are also off by the same 6 minute offset  )

--- a/2020/2020-12-11.md
+++ b/2020/2020-12-11.md
@@ -4,7 +4,7 @@
 Hi all, this doc is try and track topics and timecodes for my deep dive stream. These notes will end up in the YouTube video’s description. Any help keeping them groomed as I stream is welcome.
 
 
-05:17 Housekeeping
+[05:17](https://www.youtube.com/watch?v=SlD2dLHkbPg&t=317) Housekeeping
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
@@ -12,17 +12,17 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 * Next week is on Thursday and the last stream of the year.
 
 
-10:53 Plan
-* [11:22](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=682) What is it about the S2 that allows for sleep? Is there anything blocking the M4 or M0 feathers?
-* [16:27](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=987) For lowest power, can we reduce the current draw with the 'power' LED in software ( or is it surgery with a soldering iron? )
-* [20:16](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=1216) nice. where do you think the NRF52840 boards will be in the pipeline for sleep functionality?
-* [21:40](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=1300) circuitpython2020
-* [30:24](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=1824) a quick question Scott.. when it’s a good idea to use BLE over WiFi?..thanks
-* [33:17](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=1997) The CIRCUITPY disk I now have in the Kaluga has only approx 1MB of space. Can that be increased?
-* [43:55](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=2635) Where did the name MagTag come from?
-* [47:41](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=2861) one minor question. i noticed that in the i2c code you use the Freertos static semaphore in a way that works but isnt really documented. Using the static buffer as the semaphore handle. the api doesnt document that, i found random notes somewhere.
-* [53:27](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=3207) To further distract you before we dive in, what happened with the space requirements for those error statements? (I got distracted and missed updates over the past two weeks?)
-* [55:25](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=3325) Just a random question Scott(tangent alert) ...can an E ink display be used as a memory storage?.. since they are a persistant display...🤔
-* [59:37](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=3577) multicore
-* [1:13:29](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=4409) Pin alarm!
-* [1:26:16](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=5176) circuitpython on new chips
+[10:53](https://www.youtube.com/watch?v=SlD2dLHkbPg&t=653) Plan
+* [11:22](https://www.youtube.com/watch?v=SlD2dLHkbPg&t=682) What is it about the S2 that allows for sleep? Is there anything blocking the M4 or M0 feathers?
+* [16:27](https://www.youtube.com/watch?v=SlD2dLHkbPg&t=987) For lowest power, can we reduce the current draw with the 'power' LED in software ( or is it surgery with a soldering iron? )
+* [20:16](https://www.youtube.com/watch?v=SlD2dLHkbPg&t=1216) nice. where do you think the NRF52840 boards will be in the pipeline for sleep functionality?
+* [21:40](https://www.youtube.com/watch?v=SlD2dLHkbPg&t=1300) circuitpython2020
+* [30:24](https://www.youtube.com/watch?v=SlD2dLHkbPg&t=1824) a quick question Scott.. when it’s a good idea to use BLE over WiFi?..thanks
+* [33:17](https://www.youtube.com/watch?v=SlD2dLHkbPg&t=1997) The CIRCUITPY disk I now have in the Kaluga has only approx 1MB of space. Can that be increased?
+* [43:55](https://www.youtube.com/watch?v=SlD2dLHkbPg&t=2635) Where did the name MagTag come from?
+* [47:41](https://www.youtube.com/watch?v=SlD2dLHkbPg&t=2861) one minor question. i noticed that in the i2c code you use the Freertos static semaphore in a way that works but isnt really documented. Using the static buffer as the semaphore handle. the api doesnt document that, i found random notes somewhere.
+* [53:27](https://www.youtube.com/watch?v=SlD2dLHkbPg&t=3207) To further distract you before we dive in, what happened with the space requirements for those error statements? (I got distracted and missed updates over the past two weeks?)
+* [55:25](https://www.youtube.com/watch?v=SlD2dLHkbPg&t=3325) Just a random question Scott(tangent alert) ...can an E ink display be used as a memory storage?.. since they are a persistant display...🤔
+* [59:37](https://www.youtube.com/watch?v=SlD2dLHkbPg&t=3577) multicore
+* [1:13:29](https://www.youtube.com/watch?v=SlD2dLHkbPg&t=4409) Pin alarm!
+* [1:26:16](https://www.youtube.com/watch?v=SlD2dLHkbPg&t=5176) circuitpython on new chips

--- a/2020/2020-12-11.md
+++ b/2020/2020-12-11.md
@@ -13,16 +13,16 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 10:53 Plan
-* [11:22](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=682) What is it about the S2 that allows for sleep? Is there anything blocking the M4 or M0 feathers?
-* [16:27](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=987) For lowest power, can we reduce the current draw with the 'power' LED in software ( or is it surgery with a soldering iron? )
-* [20:16](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=1216) nice. where do you think the NRF52840 boards will be in the pipeline for sleep functionality?
-* [21:40](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=1300) circuitpython2020
-* [30:24](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=1824) a quick question Scott.. when it’s a good idea to use BLE over WiFi?..thanks
-* [33:17](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=1997) The CIRCUITPY disk I now have in the Kaluga has only approx 1MB of space. Can that be increased?
-* [43:55](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=2635) Where did the name MagTag come from?
-* [47:41](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=2861) one minor question. i noticed that in the i2c code you use the Freertos static semaphore in a way that works but isnt really documented. Using the static buffer as the semaphore handle. the api doesnt document that, i found random notes somewhere.
-* [53:27](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=3207) To further distract you before we dive in, what happened with the space requirements for those error statements? (I got distracted and missed updates over the past two weeks?)
-* [55:25](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=3325) Just a random question Scott(tangent alert) ...can an E ink display be used as a memory storage?.. since they are a persistant display...🤔
-* [59:37](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=3577) multicore
-* [1:13:29](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=4409) Pin alarm!
-* [1:26:16](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=5176) circuitpython on new chips
+* [11:22](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=682) What is it about the S2 that allows for sleep? Is there anything blocking the M4 or M0 feathers?
+* [16:27](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=987) For lowest power, can we reduce the current draw with the 'power' LED in software ( or is it surgery with a soldering iron? )
+* [20:16](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=1216) nice. where do you think the NRF52840 boards will be in the pipeline for sleep functionality?
+* [21:40](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=1300) circuitpython2020
+* [30:24](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=1824) a quick question Scott.. when it’s a good idea to use BLE over WiFi?..thanks
+* [33:17](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=1997) The CIRCUITPY disk I now have in the Kaluga has only approx 1MB of space. Can that be increased?
+* [43:55](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=2635) Where did the name MagTag come from?
+* [47:41](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=2861) one minor question. i noticed that in the i2c code you use the Freertos static semaphore in a way that works but isnt really documented. Using the static buffer as the semaphore handle. the api doesnt document that, i found random notes somewhere.
+* [53:27](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=3207) To further distract you before we dive in, what happened with the space requirements for those error statements? (I got distracted and missed updates over the past two weeks?)
+* [55:25](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=3325) Just a random question Scott(tangent alert) ...can an E ink display be used as a memory storage?.. since they are a persistant display...🤔
+* [59:37](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=3577) multicore
+* [1:13:29](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=4409) Pin alarm!
+* [1:26:16](https://www.youtube.com/watch?v=VIDEO_2020_12_11&t=5176) circuitpython on new chips

--- a/2020/2020-12-11.md
+++ b/2020/2020-12-11.md
@@ -13,16 +13,16 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 10:53 Plan
-* 11:22 What is it about the S2 that allows for sleep? Is there anything blocking the M4 or M0 feathers?
-* 16:27 For lowest power, can we reduce the current draw with the 'power' LED in software ( or is it surgery with a soldering iron? )
-* 20:16 nice. where do you think the NRF52840 boards will be in the pipeline for sleep functionality?
-* 21:40 circuitpython2020
-* 30:24 a quick question Scott.. when it’s a good idea to use BLE over WiFi?..thanks
-* 33:17 The CIRCUITPY disk I now have in the Kaluga has only approx 1MB of space. Can that be increased?
-* 43:55 Where did the name MagTag come from?
-* 47:41 one minor question. i noticed that in the i2c code you use the Freertos static semaphore in a way that works but isnt really documented. Using the static buffer as the semaphore handle. the api doesnt document that, i found random notes somewhere.
-* 53:27 To further distract you before we dive in, what happened with the space requirements for those error statements? (I got distracted and missed updates over the past two weeks?)
-* 55:25 Just a random question Scott(tangent alert) ...can an E ink display be used as a memory storage?.. since they are a persistant display...🤔
-* 59:37 multicore
-* 1:13:29 Pin alarm!
-* 1:26:16 circuitpython on new chips
+* [11:22](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=682) What is it about the S2 that allows for sleep? Is there anything blocking the M4 or M0 feathers?
+* [16:27](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=987) For lowest power, can we reduce the current draw with the 'power' LED in software ( or is it surgery with a soldering iron? )
+* [20:16](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=1216) nice. where do you think the NRF52840 boards will be in the pipeline for sleep functionality?
+* [21:40](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=1300) circuitpython2020
+* [30:24](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=1824) a quick question Scott.. when it’s a good idea to use BLE over WiFi?..thanks
+* [33:17](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=1997) The CIRCUITPY disk I now have in the Kaluga has only approx 1MB of space. Can that be increased?
+* [43:55](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=2635) Where did the name MagTag come from?
+* [47:41](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=2861) one minor question. i noticed that in the i2c code you use the Freertos static semaphore in a way that works but isnt really documented. Using the static buffer as the semaphore handle. the api doesnt document that, i found random notes somewhere.
+* [53:27](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=3207) To further distract you before we dive in, what happened with the space requirements for those error statements? (I got distracted and missed updates over the past two weeks?)
+* [55:25](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=3325) Just a random question Scott(tangent alert) ...can an E ink display be used as a memory storage?.. since they are a persistant display...🤔
+* [59:37](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=3577) multicore
+* [1:13:29](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=4409) Pin alarm!
+* [1:26:16](https://www.youtube.com/watch?v=VIDEO_2020_12_11?t=5176) circuitpython on new chips

--- a/2020/2020-12-17.md
+++ b/2020/2020-12-17.md
@@ -4,7 +4,7 @@
 Hi all, this doc is try and track topics and timecodes for my deep dive stream. These notes will end up in the YouTube video’s description. Any help keeping them groomed as I stream is welcome.
 
 
-5:00 Housekeeping
+[5:00](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=300) Housekeeping
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
@@ -12,24 +12,24 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 * Last stream of the year. Tentatively starting again January 8th. Keep an eye on the blog.
 
 
-11:02 Plan
-* * [16:44](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=1004) ​Which products are you most excited about that will be released in 2021??
-* [20:24](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=1224) ​SAMD51 version of the CPE in the works?
-* 22;38 is that an external antenna on your magtag ?
-* [23:22](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=1402) Do you know if MakeCode support will come to the CPB?
-* [23:51](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=1431) Do you think there will ever be a graphical version of CircuitPython, similar to MakeCode?
-* [26:30](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=1590) Espressif acknowledged the country.cc issue we discussed on Discord. Do you want the PR that adds country to wifi as a draft before espressif fix is available?
-* * [33:10](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=1990) Unboxing of CM4 module and PPK2
-* [43:45](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=2625) Live unboxing of Digikey order
-* [46:35](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=2795) Compute Module board on the overhead!
-* [52:47](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=3167) Second unboxing.. Power Profiler Kit II
-* [57:45](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=3465) Learn guide from Dan! (Alarms and Sleep)
-* [1:00:17](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=3617) visit the URL on the box…
-* [1:04:41](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=3881) Installing NRF connect on arch
-* [1:10:58](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=4258) Link to Digikey NRF-PPK2  https://www.digikey.com/short/z1b4dc
-* [1:12:00](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=4320) Will it work - select device - LED turns red...
-* [1:16:05](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=4565) How to find adafruit product schematic!
-* [1:20:15](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=4815) finding the right wire ( silicone wires from adafruit )
-* [1:24:20](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=5060) Plugging to the MagTag
-* [1:25:55](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=5155) Collecting power data!
-* [1:32:09](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=5529) backtrace crash
+[11:02](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=662) Plan
+* [16:44](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=1004) ​Which products are you most excited about that will be released in 2021??
+* [20:24](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=1224) ​SAMD51 version of the CPE in the works?
+* [22:38](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=1358) is that an external antenna on your magtag ?
+* [23:22](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=1402) Do you know if MakeCode support will come to the CPB?
+* [23:51](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=1431) Do you think there will ever be a graphical version of CircuitPython, similar to MakeCode?
+* [26:30](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=1590) Espressif acknowledged the country.cc issue we discussed on Discord. Do you want the PR that adds country to wifi as a draft before espressif fix is available?
+* [33:10](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=1990) Unboxing of CM4 module and PPK2
+* [43:45](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=2625) Live unboxing of Digikey order
+* [46:35](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=2795) Compute Module board on the overhead!
+* [52:47](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=3167) Second unboxing.. Power Profiler Kit II
+* [57:45](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=3465) Learn guide from Dan! (Alarms and Sleep)
+* [1:00:17](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=3617) visit the URL on the box…
+* [1:04:41](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=3881) Installing NRF connect on arch
+* [1:10:58](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=4258) Link to Digikey NRF-PPK2  https://www.digikey.com/short/z1b4dc
+* [1:12:00](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=4320) Will it work - select device - LED turns red...
+* [1:16:05](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=4565) How to find adafruit product schematic!
+* [1:20:15](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=4815) finding the right wire ( silicone wires from adafruit )
+* [1:24:20](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=5060) Plugging to the MagTag
+* [1:25:55](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=5155) Collecting power data!
+* [1:32:09](https://www.youtube.com/watch?v=aOWp1GwT7Fs&t=5529) backtrace crash

--- a/2020/2020-12-17.md
+++ b/2020/2020-12-17.md
@@ -13,23 +13,23 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 11:02 Plan
-* * 16:44 ​Which products are you most excited about that will be released in 2021??
-* 20:24 ​SAMD51 version of the CPE in the works?
+* * [16:44](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=1004) ​Which products are you most excited about that will be released in 2021??
+* [20:24](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=1224) ​SAMD51 version of the CPE in the works?
 * 22;38 is that an external antenna on your magtag ?
-* 23:22 Do you know if MakeCode support will come to the CPB?
-* 23:51 Do you think there will ever be a graphical version of CircuitPython, similar to MakeCode?
-* 26:30 Espressif acknowledged the country.cc issue we discussed on Discord. Do you want the PR that adds country to wifi as a draft before espressif fix is available?
-* * 33:10 Unboxing of CM4 module and PPK2
-* 43:45 Live unboxing of Digikey order
-* 46:35 Compute Module board on the overhead!
-* 52:47 Second unboxing.. Power Profiler Kit II
-* 57:45 Learn guide from Dan! (Alarms and Sleep)
-* 1:00:17 visit the URL on the box…
-* 1:04:41 Installing NRF connect on arch
-* 1:10:58 Link to Digikey NRF-PPK2  https://www.digikey.com/short/z1b4dc
-* 1:12:00 Will it work - select device - LED turns red...
-* 1:16:05 How to find adafruit product schematic!
-* 1:20:15 finding the right wire ( silicone wires from adafruit )
-* 1:24:20 Plugging to the MagTag
-* 1:25:55 Collecting power data!
-* 1:32:09 backtrace crash
+* [23:22](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=1402) Do you know if MakeCode support will come to the CPB?
+* [23:51](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=1431) Do you think there will ever be a graphical version of CircuitPython, similar to MakeCode?
+* [26:30](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=1590) Espressif acknowledged the country.cc issue we discussed on Discord. Do you want the PR that adds country to wifi as a draft before espressif fix is available?
+* * [33:10](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=1990) Unboxing of CM4 module and PPK2
+* [43:45](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=2625) Live unboxing of Digikey order
+* [46:35](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=2795) Compute Module board on the overhead!
+* [52:47](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=3167) Second unboxing.. Power Profiler Kit II
+* [57:45](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=3465) Learn guide from Dan! (Alarms and Sleep)
+* [1:00:17](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=3617) visit the URL on the box…
+* [1:04:41](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=3881) Installing NRF connect on arch
+* [1:10:58](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=4258) Link to Digikey NRF-PPK2  https://www.digikey.com/short/z1b4dc
+* [1:12:00](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=4320) Will it work - select device - LED turns red...
+* [1:16:05](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=4565) How to find adafruit product schematic!
+* [1:20:15](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=4815) finding the right wire ( silicone wires from adafruit )
+* [1:24:20](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=5060) Plugging to the MagTag
+* [1:25:55](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=5155) Collecting power data!
+* [1:32:09](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=5529) backtrace crash

--- a/2020/2020-12-17.md
+++ b/2020/2020-12-17.md
@@ -13,23 +13,23 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 11:02 Plan
-* * [16:44](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=1004) ​Which products are you most excited about that will be released in 2021??
-* [20:24](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=1224) ​SAMD51 version of the CPE in the works?
+* * [16:44](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=1004) ​Which products are you most excited about that will be released in 2021??
+* [20:24](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=1224) ​SAMD51 version of the CPE in the works?
 * 22;38 is that an external antenna on your magtag ?
-* [23:22](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=1402) Do you know if MakeCode support will come to the CPB?
-* [23:51](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=1431) Do you think there will ever be a graphical version of CircuitPython, similar to MakeCode?
-* [26:30](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=1590) Espressif acknowledged the country.cc issue we discussed on Discord. Do you want the PR that adds country to wifi as a draft before espressif fix is available?
-* * [33:10](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=1990) Unboxing of CM4 module and PPK2
-* [43:45](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=2625) Live unboxing of Digikey order
-* [46:35](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=2795) Compute Module board on the overhead!
-* [52:47](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=3167) Second unboxing.. Power Profiler Kit II
-* [57:45](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=3465) Learn guide from Dan! (Alarms and Sleep)
-* [1:00:17](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=3617) visit the URL on the box…
-* [1:04:41](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=3881) Installing NRF connect on arch
-* [1:10:58](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=4258) Link to Digikey NRF-PPK2  https://www.digikey.com/short/z1b4dc
-* [1:12:00](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=4320) Will it work - select device - LED turns red...
-* [1:16:05](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=4565) How to find adafruit product schematic!
-* [1:20:15](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=4815) finding the right wire ( silicone wires from adafruit )
-* [1:24:20](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=5060) Plugging to the MagTag
-* [1:25:55](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=5155) Collecting power data!
-* [1:32:09](https://www.youtube.com/watch?v=VIDEO_2020_12_17?t=5529) backtrace crash
+* [23:22](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=1402) Do you know if MakeCode support will come to the CPB?
+* [23:51](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=1431) Do you think there will ever be a graphical version of CircuitPython, similar to MakeCode?
+* [26:30](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=1590) Espressif acknowledged the country.cc issue we discussed on Discord. Do you want the PR that adds country to wifi as a draft before espressif fix is available?
+* * [33:10](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=1990) Unboxing of CM4 module and PPK2
+* [43:45](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=2625) Live unboxing of Digikey order
+* [46:35](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=2795) Compute Module board on the overhead!
+* [52:47](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=3167) Second unboxing.. Power Profiler Kit II
+* [57:45](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=3465) Learn guide from Dan! (Alarms and Sleep)
+* [1:00:17](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=3617) visit the URL on the box…
+* [1:04:41](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=3881) Installing NRF connect on arch
+* [1:10:58](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=4258) Link to Digikey NRF-PPK2  https://www.digikey.com/short/z1b4dc
+* [1:12:00](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=4320) Will it work - select device - LED turns red...
+* [1:16:05](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=4565) How to find adafruit product schematic!
+* [1:20:15](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=4815) finding the right wire ( silicone wires from adafruit )
+* [1:24:20](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=5060) Plugging to the MagTag
+* [1:25:55](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=5155) Collecting power data!
+* [1:32:09](https://www.youtube.com/watch?v=VIDEO_2020_12_17&t=5529) backtrace crash

--- a/2021/2021-01-08.md
+++ b/2021/2021-01-08.md
@@ -16,19 +16,19 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* 08:10 is circuitpython as powerful as c++ ?
-* 13:01 Is Adriano something totally different from python?
-* 14:20 Is CircuitPython designed for real-time computing?
-* 17:02 Can you doing threading or multitasking with circuitpython?
-* 19:57 What program do I want for my raspberry pi game boy for button inputs?
-* 22:16 Why can't we create a language that's easy to use like python, as fast as C or C++, & is efficiently garbage-collected and memory-managed to be able to do real-time work? Hypothetical question.
-* 29:08 More in depth question (feel free to skip it) what is a QSTR? I've got a vague idea and see them everyone in the core code but haven't had a chance to dive into them yet
-* 34:49 USB switch PCB for PPK2
-* 36:35 Look back on annual thoughts.
-* 53:03 I forget if you had already answered this in past streams. But how does CP versioning workk? At what point does work on 6.x just become 7.0?
-* 57:53 When, if at all, do CircuitPython changes go into MicroPython? And the same for MicroPython changes being merged into CircuitPython?
-* 1:03:30 Would you/Adafruit ever consider making CircuitPython an organization on github rather than an Adafruit subproject? Might make it psychologically easier for other orgs to contribute to CircuitPy
-* 1:05:55 ​Having cpy as a fork of mpy means it’s awkward forking/checking out each repo and contributing to both
-* 1:15:40 Scott, could you please elaborate a bit on how someone might best contribute to the documentation? 
+* [08:10](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=490) is circuitpython as powerful as c++ ?
+* [13:01](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=781) Is Adriano something totally different from python?
+* [14:20](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=860) Is CircuitPython designed for real-time computing?
+* [17:02](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=1022) Can you doing threading or multitasking with circuitpython?
+* [19:57](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=1197) What program do I want for my raspberry pi game boy for button inputs?
+* [22:16](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=1336) Why can't we create a language that's easy to use like python, as fast as C or C++, & is efficiently garbage-collected and memory-managed to be able to do real-time work? Hypothetical question.
+* [29:08](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=1748) More in depth question (feel free to skip it) what is a QSTR? I've got a vague idea and see them everyone in the core code but haven't had a chance to dive into them yet
+* [34:49](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=2089) USB switch PCB for PPK2
+* [36:35](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=2195) Look back on annual thoughts.
+* [53:03](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=3183) I forget if you had already answered this in past streams. But how does CP versioning workk? At what point does work on 6.x just become 7.0?
+* [57:53](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=3473) When, if at all, do CircuitPython changes go into MicroPython? And the same for MicroPython changes being merged into CircuitPython?
+* [1:03:30](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=3810) Would you/Adafruit ever consider making CircuitPython an organization on github rather than an Adafruit subproject? Might make it psychologically easier for other orgs to contribute to CircuitPy
+* [1:05:55](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=3955) ​Having cpy as a fork of mpy means it’s awkward forking/checking out each repo and contributing to both
+* [1:15:40](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=4540) Scott, could you please elaborate a bit on how someone might best contribute to the documentation?
 * #circuitpython2021
-* 2:37:23 wrap up
+* [2:37:23](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=9443) wrap up

--- a/2021/2021-01-08.md
+++ b/2021/2021-01-08.md
@@ -16,19 +16,19 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* [08:10](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=490) is circuitpython as powerful as c++ ?
-* [13:01](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=781) Is Adriano something totally different from python?
-* [14:20](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=860) Is CircuitPython designed for real-time computing?
-* [17:02](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=1022) Can you doing threading or multitasking with circuitpython?
-* [19:57](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=1197) What program do I want for my raspberry pi game boy for button inputs?
-* [22:16](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=1336) Why can't we create a language that's easy to use like python, as fast as C or C++, & is efficiently garbage-collected and memory-managed to be able to do real-time work? Hypothetical question.
-* [29:08](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=1748) More in depth question (feel free to skip it) what is a QSTR? I've got a vague idea and see them everyone in the core code but haven't had a chance to dive into them yet
-* [34:49](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=2089) USB switch PCB for PPK2
-* [36:35](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=2195) Look back on annual thoughts.
-* [53:03](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=3183) I forget if you had already answered this in past streams. But how does CP versioning workk? At what point does work on 6.x just become 7.0?
-* [57:53](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=3473) When, if at all, do CircuitPython changes go into MicroPython? And the same for MicroPython changes being merged into CircuitPython?
-* [1:03:30](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=3810) Would you/Adafruit ever consider making CircuitPython an organization on github rather than an Adafruit subproject? Might make it psychologically easier for other orgs to contribute to CircuitPy
-* [1:05:55](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=3955) ​Having cpy as a fork of mpy means it’s awkward forking/checking out each repo and contributing to both
-* [1:15:40](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=4540) Scott, could you please elaborate a bit on how someone might best contribute to the documentation?
+* [08:10](https://www.youtube.com/watch?v=Lh7umSOoMqo&t=490) is circuitpython as powerful as c++ ?
+* [13:01](https://www.youtube.com/watch?v=Lh7umSOoMqo&t=781) Is Adriano something totally different from python?
+* [14:20](https://www.youtube.com/watch?v=Lh7umSOoMqo&t=860) Is CircuitPython designed for real-time computing?
+* [17:02](https://www.youtube.com/watch?v=Lh7umSOoMqo&t=1022) Can you doing threading or multitasking with circuitpython?
+* [19:57](https://www.youtube.com/watch?v=Lh7umSOoMqo&t=1197) What program do I want for my raspberry pi game boy for button inputs?
+* [22:16](https://www.youtube.com/watch?v=Lh7umSOoMqo&t=1336) Why can't we create a language that's easy to use like python, as fast as C or C++, & is efficiently garbage-collected and memory-managed to be able to do real-time work? Hypothetical question.
+* [29:08](https://www.youtube.com/watch?v=Lh7umSOoMqo&t=1748) More in depth question (feel free to skip it) what is a QSTR? I've got a vague idea and see them everyone in the core code but haven't had a chance to dive into them yet
+* [34:49](https://www.youtube.com/watch?v=Lh7umSOoMqo&t=2089) USB switch PCB for PPK2
+* [36:35](https://www.youtube.com/watch?v=Lh7umSOoMqo&t=2195) Look back on annual thoughts.
+* [53:03](https://www.youtube.com/watch?v=Lh7umSOoMqo&t=3183) I forget if you had already answered this in past streams. But how does CP versioning workk? At what point does work on 6.x just become 7.0?
+* [57:53](https://www.youtube.com/watch?v=Lh7umSOoMqo&t=3473) When, if at all, do CircuitPython changes go into MicroPython? And the same for MicroPython changes being merged into CircuitPython?
+* [1:03:30](https://www.youtube.com/watch?v=Lh7umSOoMqo&t=3810) Would you/Adafruit ever consider making CircuitPython an organization on github rather than an Adafruit subproject? Might make it psychologically easier for other orgs to contribute to CircuitPy
+* [1:05:55](https://www.youtube.com/watch?v=Lh7umSOoMqo&t=3955) ​Having cpy as a fork of mpy means it’s awkward forking/checking out each repo and contributing to both
+* [1:15:40](https://www.youtube.com/watch?v=Lh7umSOoMqo&t=4540) Scott, could you please elaborate a bit on how someone might best contribute to the documentation?
 * #circuitpython2021
-* [2:37:23](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=9443) wrap up
+* [2:37:23](https://www.youtube.com/watch?v=Lh7umSOoMqo&t=9443) wrap up

--- a/2021/2021-01-08.md
+++ b/2021/2021-01-08.md
@@ -16,19 +16,19 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* [08:10](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=490) is circuitpython as powerful as c++ ?
-* [13:01](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=781) Is Adriano something totally different from python?
-* [14:20](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=860) Is CircuitPython designed for real-time computing?
-* [17:02](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=1022) Can you doing threading or multitasking with circuitpython?
-* [19:57](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=1197) What program do I want for my raspberry pi game boy for button inputs?
-* [22:16](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=1336) Why can't we create a language that's easy to use like python, as fast as C or C++, & is efficiently garbage-collected and memory-managed to be able to do real-time work? Hypothetical question.
-* [29:08](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=1748) More in depth question (feel free to skip it) what is a QSTR? I've got a vague idea and see them everyone in the core code but haven't had a chance to dive into them yet
-* [34:49](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=2089) USB switch PCB for PPK2
-* [36:35](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=2195) Look back on annual thoughts.
-* [53:03](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=3183) I forget if you had already answered this in past streams. But how does CP versioning workk? At what point does work on 6.x just become 7.0?
-* [57:53](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=3473) When, if at all, do CircuitPython changes go into MicroPython? And the same for MicroPython changes being merged into CircuitPython?
-* [1:03:30](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=3810) Would you/Adafruit ever consider making CircuitPython an organization on github rather than an Adafruit subproject? Might make it psychologically easier for other orgs to contribute to CircuitPy
-* [1:05:55](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=3955) ​Having cpy as a fork of mpy means it’s awkward forking/checking out each repo and contributing to both
-* [1:15:40](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=4540) Scott, could you please elaborate a bit on how someone might best contribute to the documentation?
+* [08:10](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=490) is circuitpython as powerful as c++ ?
+* [13:01](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=781) Is Adriano something totally different from python?
+* [14:20](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=860) Is CircuitPython designed for real-time computing?
+* [17:02](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=1022) Can you doing threading or multitasking with circuitpython?
+* [19:57](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=1197) What program do I want for my raspberry pi game boy for button inputs?
+* [22:16](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=1336) Why can't we create a language that's easy to use like python, as fast as C or C++, & is efficiently garbage-collected and memory-managed to be able to do real-time work? Hypothetical question.
+* [29:08](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=1748) More in depth question (feel free to skip it) what is a QSTR? I've got a vague idea and see them everyone in the core code but haven't had a chance to dive into them yet
+* [34:49](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=2089) USB switch PCB for PPK2
+* [36:35](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=2195) Look back on annual thoughts.
+* [53:03](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=3183) I forget if you had already answered this in past streams. But how does CP versioning workk? At what point does work on 6.x just become 7.0?
+* [57:53](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=3473) When, if at all, do CircuitPython changes go into MicroPython? And the same for MicroPython changes being merged into CircuitPython?
+* [1:03:30](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=3810) Would you/Adafruit ever consider making CircuitPython an organization on github rather than an Adafruit subproject? Might make it psychologically easier for other orgs to contribute to CircuitPy
+* [1:05:55](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=3955) ​Having cpy as a fork of mpy means it’s awkward forking/checking out each repo and contributing to both
+* [1:15:40](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=4540) Scott, could you please elaborate a bit on how someone might best contribute to the documentation?
 * #circuitpython2021
-* [2:37:23](https://www.youtube.com/watch?v=VIDEO_2021_01_08?t=9443) wrap up
+* [2:37:23](https://www.youtube.com/watch?v=VIDEO_2021_01_08&t=9443) wrap up

--- a/2021/2021-01-15.md
+++ b/2021/2021-01-15.md
@@ -13,34 +13,34 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* 05:34 Any further work or investigation on pinalarm and current use?
-* 06:57 @danh Will you have time to work on https://github.com/adafruit/Adafruit_CircuitPython_BLE/issues/37 to support Serial over BLE with other UUID than the Nordic.
-* 11:14 Dan intro
-* 17:19 ​node-red? interested in your opinion Dan!
-* 19:49 ParallelBus request from kmatch98: https://github.com/adafruit/circuitpython/issues/3600
-* 38:16 IDF and vendor SDKs
-* 43:31 So how much work would be required to setup an eink display that requires parallel interface? Would one just have to enable ParallelBus (for a custom board,) or will it require more deep coding in CircuitPython codebase?
-* 45:58 I have the motor shield v2 module, what is the best compatible SOC module except for Adruino the best platform for circuit python 
-* 46:45 So basically for the displays Adafruit sells, you guys basically had to write something like a "driver" for it? There are no standard ways to talk to displays?
-* 47:55 Maybe an interesting question on ESP32S2 and the variation on CP maturity. What are the "special hardware support" that you have on older platform that are not there on ESP32S2 yet like: (1) Fast Neopixel with DMA(?) (2) Matrix Hub75 with parallel writing byte on multiple GPIO(?) (3) Rotate IO why is this special(?).
-* 51:09 ​is it feasible to do PID with a TOF sensor and a stepper (or dc motor) feasible in CircuitPython ?
-* 52:42 CircuitPython2021: 
+* [05:34](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=334) Any further work or investigation on pinalarm and current use?
+* [06:57](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=417) @danh Will you have time to work on https://github.com/adafruit/Adafruit_CircuitPython_BLE/issues/37 to support Serial over BLE with other UUID than the Nordic.
+* [11:14](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=674) Dan intro
+* [17:19](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=1039) ​node-red? interested in your opinion Dan!
+* [19:49](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=1189) ParallelBus request from kmatch98: https://github.com/adafruit/circuitpython/issues/3600
+* [38:16](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=2296) IDF and vendor SDKs
+* [43:31](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=2611) So how much work would be required to setup an eink display that requires parallel interface? Would one just have to enable ParallelBus (for a custom board,) or will it require more deep coding in CircuitPython codebase?
+* [45:58](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=2758) I have the motor shield v2 module, what is the best compatible SOC module except for Adruino the best platform for circuit python
+* [46:45](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=2805) So basically for the displays Adafruit sells, you guys basically had to write something like a "driver" for it? There are no standard ways to talk to displays?
+* [47:55](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=2875) Maybe an interesting question on ESP32S2 and the variation on CP maturity. What are the "special hardware support" that you have on older platform that are not there on ESP32S2 yet like: (1) Fast Neopixel with DMA(?) (2) Matrix Hub75 with parallel writing byte on multiple GPIO(?) (3) Rotate IO why is this special(?).
+* [51:09](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=3069) ​is it feasible to do PID with a TOF sensor and a stepper (or dc motor) feasible in CircuitPython ?
+* [52:42](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=3162) CircuitPython2021:
    * https://blog.adafruit.com/2021/01/15/tannewts-focus-for-circuitpython2021/
    * https://blog.adafruit.com/2021/01/13/dan-halbert-thoughts-for-circuitpython2021/
    * https://blog.adafruit.com/tag/circuitpython2021/
-* 1:16:39 Dan’s bug fixes
-   * 1:18:37 `git bisect`
-   * 1:23:00 What bug have you fixed that was the most satisfying to find and fix?
-   * 1:25:35 If you want to keep it clean, do an interactive rebase on your branch before merging
-   * 1:27:39 Is what you just discuss relate to the monotonic precision, and how it decrease over time? Should we have a way to "reset" the monotonic? Or is there a way?
-   * 1:28:57 Is bisec smart about the size of the commit? Trying to find a place where half of the change are before or after.
-   * 1:29:31 satisfying bug to fix
-   * 1:35:37 watchpoint
-   * 1:41:44 Are there Adafruit board that do USB Host. And any plan to have some kind of support in CP?
-   * 1:45:21 in progress bug hunt 1:53:42 
-1:50:00 - basic python demo 
-   * 2:04:41 6.1.0-rc.1
-   * 2:13:00 
+* [1:16:39](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=4599) Dan’s bug fixes
+   * [1:18:37](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=4717) `git bisect`
+   * [1:23:00](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=4980) What bug have you fixed that was the most satisfying to find and fix?
+   * [1:25:35](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=5135) If you want to keep it clean, do an interactive rebase on your branch before merging
+   * [1:27:39](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=5259) Is what you just discuss relate to the monotonic precision, and how it decrease over time? Should we have a way to "reset" the monotonic? Or is there a way?
+   * [1:28:57](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=5337) Is bisec smart about the size of the commit? Trying to find a place where half of the change are before or after.
+   * [1:29:31](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=5371) satisfying bug to fix
+   * [1:35:37](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=5737) watchpoint
+   * [1:41:44](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=6104) Are there Adafruit board that do USB Host. And any plan to have some kind of support in CP?
+   * [1:45:21](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=6321) in progress bug hunt 1:53:42
+1:50:00 - basic python demo
+   * [2:04:41](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=7481) 6.1.0-rc.1
+   * [2:13:00](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=7980)
 
 
 2:14:05 Wrap-up

--- a/2021/2021-01-15.md
+++ b/2021/2021-01-15.md
@@ -13,34 +13,34 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* [05:34](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=334) Any further work or investigation on pinalarm and current use?
-* [06:57](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=417) @danh Will you have time to work on https://github.com/adafruit/Adafruit_CircuitPython_BLE/issues/37 to support Serial over BLE with other UUID than the Nordic.
-* [11:14](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=674) Dan intro
-* [17:19](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=1039) ​node-red? interested in your opinion Dan!
-* [19:49](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=1189) ParallelBus request from kmatch98: https://github.com/adafruit/circuitpython/issues/3600
-* [38:16](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=2296) IDF and vendor SDKs
-* [43:31](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=2611) So how much work would be required to setup an eink display that requires parallel interface? Would one just have to enable ParallelBus (for a custom board,) or will it require more deep coding in CircuitPython codebase?
-* [45:58](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=2758) I have the motor shield v2 module, what is the best compatible SOC module except for Adruino the best platform for circuit python
-* [46:45](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=2805) So basically for the displays Adafruit sells, you guys basically had to write something like a "driver" for it? There are no standard ways to talk to displays?
-* [47:55](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=2875) Maybe an interesting question on ESP32S2 and the variation on CP maturity. What are the "special hardware support" that you have on older platform that are not there on ESP32S2 yet like: (1) Fast Neopixel with DMA(?) (2) Matrix Hub75 with parallel writing byte on multiple GPIO(?) (3) Rotate IO why is this special(?).
-* [51:09](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=3069) ​is it feasible to do PID with a TOF sensor and a stepper (or dc motor) feasible in CircuitPython ?
-* [52:42](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=3162) CircuitPython2021:
+* [05:34](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=334) Any further work or investigation on pinalarm and current use?
+* [06:57](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=417) @danh Will you have time to work on https://github.com/adafruit/Adafruit_CircuitPython_BLE/issues/37 to support Serial over BLE with other UUID than the Nordic.
+* [11:14](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=674) Dan intro
+* [17:19](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=1039) ​node-red? interested in your opinion Dan!
+* [19:49](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=1189) ParallelBus request from kmatch98: https://github.com/adafruit/circuitpython/issues/3600
+* [38:16](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=2296) IDF and vendor SDKs
+* [43:31](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=2611) So how much work would be required to setup an eink display that requires parallel interface? Would one just have to enable ParallelBus (for a custom board,) or will it require more deep coding in CircuitPython codebase?
+* [45:58](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=2758) I have the motor shield v2 module, what is the best compatible SOC module except for Adruino the best platform for circuit python
+* [46:45](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=2805) So basically for the displays Adafruit sells, you guys basically had to write something like a "driver" for it? There are no standard ways to talk to displays?
+* [47:55](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=2875) Maybe an interesting question on ESP32S2 and the variation on CP maturity. What are the "special hardware support" that you have on older platform that are not there on ESP32S2 yet like: (1) Fast Neopixel with DMA(?) (2) Matrix Hub75 with parallel writing byte on multiple GPIO(?) (3) Rotate IO why is this special(?).
+* [51:09](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=3069) ​is it feasible to do PID with a TOF sensor and a stepper (or dc motor) feasible in CircuitPython ?
+* [52:42](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=3162) CircuitPython2021:
    * https://blog.adafruit.com/2021/01/15/tannewts-focus-for-circuitpython2021/
    * https://blog.adafruit.com/2021/01/13/dan-halbert-thoughts-for-circuitpython2021/
    * https://blog.adafruit.com/tag/circuitpython2021/
-* [1:16:39](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=4599) Dan’s bug fixes
-   * [1:18:37](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=4717) `git bisect`
-   * [1:23:00](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=4980) What bug have you fixed that was the most satisfying to find and fix?
-   * [1:25:35](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=5135) If you want to keep it clean, do an interactive rebase on your branch before merging
-   * [1:27:39](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=5259) Is what you just discuss relate to the monotonic precision, and how it decrease over time? Should we have a way to "reset" the monotonic? Or is there a way?
-   * [1:28:57](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=5337) Is bisec smart about the size of the commit? Trying to find a place where half of the change are before or after.
-   * [1:29:31](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=5371) satisfying bug to fix
-   * [1:35:37](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=5737) watchpoint
-   * [1:41:44](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=6104) Are there Adafruit board that do USB Host. And any plan to have some kind of support in CP?
-   * [1:45:21](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=6321) in progress bug hunt 1:53:42
+* [1:16:39](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=4599) Dan’s bug fixes
+   * [1:18:37](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=4717) `git bisect`
+   * [1:23:00](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=4980) What bug have you fixed that was the most satisfying to find and fix?
+   * [1:25:35](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=5135) If you want to keep it clean, do an interactive rebase on your branch before merging
+   * [1:27:39](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=5259) Is what you just discuss relate to the monotonic precision, and how it decrease over time? Should we have a way to "reset" the monotonic? Or is there a way?
+   * [1:28:57](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=5337) Is bisec smart about the size of the commit? Trying to find a place where half of the change are before or after.
+   * [1:29:31](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=5371) satisfying bug to fix
+   * [1:35:37](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=5737) watchpoint
+   * [1:41:44](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=6104) Are there Adafruit board that do USB Host. And any plan to have some kind of support in CP?
+   * [1:45:21](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=6321) in progress bug hunt 1:53:42
 1:50:00 - basic python demo
-   * [2:04:41](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=7481) 6.1.0-rc.1
-   * [2:13:00](https://www.youtube.com/watch?v=VIDEO_2021_01_15?t=7980)
+   * [2:04:41](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=7481) 6.1.0-rc.1
+   * [2:13:00](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=7980)
 
 
 2:14:05 Wrap-up

--- a/2021/2021-01-15.md
+++ b/2021/2021-01-15.md
@@ -4,7 +4,7 @@
 Hi all, this doc is try and track topics and timecodes for my deep dive stream. These notes will end up in the YouTube video’s description. Any help keeping them groomed as I stream is welcome.
 
 
-08:18 Housekeeping
+[08:18](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=498) Housekeeping
 * Dan, myself and others are sponsored by Adafruit to work on CircuitPython. Support them, and by extension us, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
@@ -13,34 +13,34 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* [05:34](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=334) Any further work or investigation on pinalarm and current use?
-* [06:57](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=417) @danh Will you have time to work on https://github.com/adafruit/Adafruit_CircuitPython_BLE/issues/37 to support Serial over BLE with other UUID than the Nordic.
-* [11:14](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=674) Dan intro
-* [17:19](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=1039) ​node-red? interested in your opinion Dan!
-* [19:49](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=1189) ParallelBus request from kmatch98: https://github.com/adafruit/circuitpython/issues/3600
-* [38:16](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=2296) IDF and vendor SDKs
-* [43:31](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=2611) So how much work would be required to setup an eink display that requires parallel interface? Would one just have to enable ParallelBus (for a custom board,) or will it require more deep coding in CircuitPython codebase?
-* [45:58](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=2758) I have the motor shield v2 module, what is the best compatible SOC module except for Adruino the best platform for circuit python
-* [46:45](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=2805) So basically for the displays Adafruit sells, you guys basically had to write something like a "driver" for it? There are no standard ways to talk to displays?
-* [47:55](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=2875) Maybe an interesting question on ESP32S2 and the variation on CP maturity. What are the "special hardware support" that you have on older platform that are not there on ESP32S2 yet like: (1) Fast Neopixel with DMA(?) (2) Matrix Hub75 with parallel writing byte on multiple GPIO(?) (3) Rotate IO why is this special(?).
-* [51:09](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=3069) ​is it feasible to do PID with a TOF sensor and a stepper (or dc motor) feasible in CircuitPython ?
-* [52:42](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=3162) CircuitPython2021:
+* [05:34](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=334) Any further work or investigation on pinalarm and current use?
+* [06:57](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=417) @danh Will you have time to work on https://github.com/adafruit/Adafruit_CircuitPython_BLE/issues/37 to support Serial over BLE with other UUID than the Nordic.
+* [11:14](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=674) Dan intro
+* [17:19](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=1039) ​node-red? interested in your opinion Dan!
+* [19:49](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=1189) ParallelBus request from kmatch98: https://github.com/adafruit/circuitpython/issues/3600
+* [38:16](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=2296) IDF and vendor SDKs
+* [43:31](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=2611) So how much work would be required to setup an eink display that requires parallel interface? Would one just have to enable ParallelBus (for a custom board,) or will it require more deep coding in CircuitPython codebase?
+* [45:58](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=2758) I have the motor shield v2 module, what is the best compatible SOC module except for Adruino the best platform for circuit python
+* [46:45](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=2805) So basically for the displays Adafruit sells, you guys basically had to write something like a "driver" for it? There are no standard ways to talk to displays?
+* [47:55](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=2875) Maybe an interesting question on ESP32S2 and the variation on CP maturity. What are the "special hardware support" that you have on older platform that are not there on ESP32S2 yet like: (1) Fast Neopixel with DMA(?) (2) Matrix Hub75 with parallel writing byte on multiple GPIO(?) (3) Rotate IO why is this special(?).
+* [51:09](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=3069) ​is it feasible to do PID with a TOF sensor and a stepper (or dc motor) feasible in CircuitPython ?
+* [52:42](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=3162) CircuitPython2021:
    * https://blog.adafruit.com/2021/01/15/tannewts-focus-for-circuitpython2021/
    * https://blog.adafruit.com/2021/01/13/dan-halbert-thoughts-for-circuitpython2021/
    * https://blog.adafruit.com/tag/circuitpython2021/
-* [1:16:39](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=4599) Dan’s bug fixes
-   * [1:18:37](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=4717) `git bisect`
-   * [1:23:00](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=4980) What bug have you fixed that was the most satisfying to find and fix?
-   * [1:25:35](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=5135) If you want to keep it clean, do an interactive rebase on your branch before merging
-   * [1:27:39](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=5259) Is what you just discuss relate to the monotonic precision, and how it decrease over time? Should we have a way to "reset" the monotonic? Or is there a way?
-   * [1:28:57](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=5337) Is bisec smart about the size of the commit? Trying to find a place where half of the change are before or after.
-   * [1:29:31](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=5371) satisfying bug to fix
-   * [1:35:37](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=5737) watchpoint
-   * [1:41:44](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=6104) Are there Adafruit board that do USB Host. And any plan to have some kind of support in CP?
-   * [1:45:21](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=6321) in progress bug hunt 1:53:42
-1:50:00 - basic python demo
-   * [2:04:41](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=7481) 6.1.0-rc.1
-   * [2:13:00](https://www.youtube.com/watch?v=VIDEO_2021_01_15&t=7980)
+* [1:16:39](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=4599) Dan’s bug fixes
+   * [1:18:37](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=4717) `git bisect`
+   * [1:23:00](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=4980) What bug have you fixed that was the most satisfying to find and fix?
+   * [1:25:35](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=5135) If you want to keep it clean, do an interactive rebase on your branch before merging
+   * [1:27:39](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=5259) Is what you just discuss relate to the monotonic precision, and how it decrease over time? Should we have a way to "reset" the monotonic? Or is there a way?
+   * [1:28:57](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=5337) Is bisec smart about the size of the commit? Trying to find a place where half of the change are before or after.
+   * [1:29:31](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=5371) satisfying bug to fix
+   * [1:35:37](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=5737) watchpoint
+   * [1:41:44](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=6104) Are there Adafruit board that do USB Host. And any plan to have some kind of support in CP?
+   * [1:45:21](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=6321) in progress bug hunt 1:53:42
+   * [1:50:00](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=6600) - basic python demo
+   * [2:04:41](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=7481) 6.1.0-rc.1
+   * [2:13:00](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=7980)
 
 
-2:14:05 Wrap-up
+[2:14:05](https://www.youtube.com/watch?v=M0s_LK0K1Sk&t=8045) Wrap-up

--- a/2021/2021-01-22.md
+++ b/2021/2021-01-22.md
@@ -12,71 +12,71 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* [11:43](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=703) RP2040 and Raspberry Pi Pico board!
-* [19:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=1185) Show how to install CircuitPython on a Pico fresh out of a package.
-* [24:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=1440) Hello World
-* [27:14](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=1634) RP2040 / pico data resources
-* [28:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=1725) RP2040 data sheet
-* [32:10](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=1930) CP use of multi-core - “Not Yet”
-* [36:43](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2203) Can I use any quad SPI memory with RP2040 like an MRAM memory does UF2 support these memories or only flash memory?
+* [11:43](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=703) RP2040 and Raspberry Pi Pico board!
+* [19:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=1185) Show how to install CircuitPython on a Pico fresh out of a package.
+* [24:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=1440) Hello World
+* [27:14](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=1634) RP2040 / pico data resources
+* [28:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=1725) RP2040 data sheet
+* [32:10](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=1930) CP use of multi-core - “Not Yet”
+* [36:43](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2203) Can I use any quad SPI memory with RP2040 like an MRAM memory does UF2 support these memories or only flash memory?
 39:20 PIO ( Programmable IO )
-* [41:22](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2482) Circuit Python has a list of the supported Flash chips in the source code, easy to find.
-* [41:46](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2506) PIO ( Programmable IO ) continued
-* [44:30](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2670) IRQ PIO
-* [45:36](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2736) NeoPixel example for PIO ( 4 instructions )
-* [46:20](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2780) Micropython vs. CP PIO differences
-* [47:42](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2862) CP PIO future expansion
-* [48:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2925) CAN bus in PIO?  Possible…
-* [49:20](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2960) PIO FIFO
-* [51:50](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=3110) GPIO functions ( PIO1 and PIO2 peripherals? )
-* [53:52](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=3232) 3.2 PIO Programmer’s Model
-* [55:01](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=3301)  USB Host examples ?  ( see the sdk ? )
-* [55:28](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=3328)  back to Programmer’s Model  ( PC )
-* [56:10](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=3370) Output Shift Register
-* [56:34](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=3394) 3.3 PIO Assembler (pioasm) / 3.4 Instruction Set
-* [1:03:42](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=3822) Examples…( see the SDK chapter 3  - Thanks @Luke)
-* [1:04:06](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=3846) - live code PIO example on Feather
-* [1:06:49](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4009) CP NeoPixel code.py - not PIO
-* [1:07:40](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4060) PIO test code (pioasm)
-* [1:09:27](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4167) raspberrypi2.StateMachine
-* [1:12:13](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4333) Logic Pro 16
-* [1:13:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4395) square wave pioasm in code.py
-* [1:14:55](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4495) Hub75 example does hot patch of the instruction memory (@luke)
-* [1:15:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4545) Deinit for destroy and recreate pio scheme
-* [1:17:03](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4623) plug into channel 4 - see the blink
-* [1:18:28](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4708) update the old CP firmware - enter boot loader on the feather
-* [1:20:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4805)  PIO code goes into dedicated PIO instruction memory
-* [1:21:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4875) you can read by writing PC and reading out SMx_INSTR
-* [1:21:49](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4909) loading code.py into cleaned board ( pioasm and support libraries )
-* [1:23:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4980) switch to 800KHz  ( hmm - frequency is 400KHz )
-* [1:23:40](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5020) squarewave assembly code
-* [1:24:22](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5062) readthedocs.io/en/latest/README.html…
-* [1:25:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5100) Rp2pio API
-* [1:26:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5175) Learn.adafruit.com - for wiring tutorials
-* [1:27:19](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5239) Iterate on square wave example
-* [1:31:44](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5504) State machine “wrap” feature
-* [1:33:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5595) Alternate logic analyzers ( use an rp2040 )
-* [1:35:36](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5736) Tinlylogic friend promo
-* [1:37:40](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5860) full speed 125000000   ( 62.5 MHz on the scope? )
-* [1:39:04](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5944) Neopixel in 4 instructions
-* [1:41:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=6065) PIO resource sharing CP and user allocation
-* [1:45:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=6305) deep dive into neopixel pioasm
-* [1:46:30](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=6390) - wifi support from the airlift board via spi ( see Arduino Nano RP2040 )
-* [1:47:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=6425) back to neopixel pioasm ( out, jmp autopull, nop)
-* [1:55:40](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=6940) Assembler for the other M0 - someone needs to write it still :-)
-* [1:57:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7035) microDev - s2 risc-v low power core
-* [1:59:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7185) sm.write to get the bytes from CP to the PIO
-* [2:01:50](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7310) assembler can be run on c-python
-* [2:02:50](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7370) licensing question for @luke - compare with RISC-V / ARM
-* [2:04:11](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7451)  adadfruit_pioasm.py source
-* [2:09:35](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7775) PIO can use DMA
-* [2:10:12](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7812) back to the datasheet ( Page 14 - bus overview )
-* [2:12:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7920) state of GUI in CP
-* [2:13:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7980) One of the strengths of CP is USB support…
-* [2:14:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=8045) CP porting checklist - what to do first
-* [2:15:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=8100) DisplayIO and HDMI - look for bare metal CP on rPI
-* [2:16:30](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=8190) CP definition with respect to Micropython
-* [2:19:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=8340) VSCode extension for CP
-* [2:22:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=8520) Double tap to reset doesn’t work yet
-* [2:25](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=145);24 wrap up
-* [2:28:54](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=8934) off
+* [41:22](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2482) Circuit Python has a list of the supported Flash chips in the source code, easy to find.
+* [41:46](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2506) PIO ( Programmable IO ) continued
+* [44:30](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2670) IRQ PIO
+* [45:36](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2736) NeoPixel example for PIO ( 4 instructions )
+* [46:20](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2780) Micropython vs. CP PIO differences
+* [47:42](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2862) CP PIO future expansion
+* [48:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2925) CAN bus in PIO?  Possible…
+* [49:20](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2960) PIO FIFO
+* [51:50](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=3110) GPIO functions ( PIO1 and PIO2 peripherals? )
+* [53:52](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=3232) 3.2 PIO Programmer’s Model
+* [55:01](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=3301)  USB Host examples ?  ( see the sdk ? )
+* [55:28](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=3328)  back to Programmer’s Model  ( PC )
+* [56:10](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=3370) Output Shift Register
+* [56:34](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=3394) 3.3 PIO Assembler (pioasm) / 3.4 Instruction Set
+* [1:03:42](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=3822) Examples…( see the SDK chapter 3  - Thanks @Luke)
+* [1:04:06](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=3846) - live code PIO example on Feather
+* [1:06:49](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4009) CP NeoPixel code.py - not PIO
+* [1:07:40](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4060) PIO test code (pioasm)
+* [1:09:27](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4167) raspberrypi2.StateMachine
+* [1:12:13](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4333) Logic Pro 16
+* [1:13:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4395) square wave pioasm in code.py
+* [1:14:55](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4495) Hub75 example does hot patch of the instruction memory (@luke)
+* [1:15:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4545) Deinit for destroy and recreate pio scheme
+* [1:17:03](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4623) plug into channel 4 - see the blink
+* [1:18:28](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4708) update the old CP firmware - enter boot loader on the feather
+* [1:20:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4805)  PIO code goes into dedicated PIO instruction memory
+* [1:21:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4875) you can read by writing PC and reading out SMx_INSTR
+* [1:21:49](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4909) loading code.py into cleaned board ( pioasm and support libraries )
+* [1:23:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4980) switch to 800KHz  ( hmm - frequency is 400KHz )
+* [1:23:40](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5020) squarewave assembly code
+* [1:24:22](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5062) readthedocs.io/en/latest/README.html…
+* [1:25:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5100) Rp2pio API
+* [1:26:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5175) Learn.adafruit.com - for wiring tutorials
+* [1:27:19](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5239) Iterate on square wave example
+* [1:31:44](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5504) State machine “wrap” feature
+* [1:33:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5595) Alternate logic analyzers ( use an rp2040 )
+* [1:35:36](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5736) Tinlylogic friend promo
+* [1:37:40](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5860) full speed 125000000   ( 62.5 MHz on the scope? )
+* [1:39:04](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5944) Neopixel in 4 instructions
+* [1:41:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=6065) PIO resource sharing CP and user allocation
+* [1:45:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=6305) deep dive into neopixel pioasm
+* [1:46:30](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=6390) - wifi support from the airlift board via spi ( see Arduino Nano RP2040 )
+* [1:47:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=6425) back to neopixel pioasm ( out, jmp autopull, nop)
+* [1:55:40](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=6940) Assembler for the other M0 - someone needs to write it still :-)
+* [1:57:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7035) microDev - s2 risc-v low power core
+* [1:59:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7185) sm.write to get the bytes from CP to the PIO
+* [2:01:50](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7310) assembler can be run on c-python
+* [2:02:50](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7370) licensing question for @luke - compare with RISC-V / ARM
+* [2:04:11](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7451)  adadfruit_pioasm.py source
+* [2:09:35](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7775) PIO can use DMA
+* [2:10:12](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7812) back to the datasheet ( Page 14 - bus overview )
+* [2:12:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7920) state of GUI in CP
+* [2:13:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7980) One of the strengths of CP is USB support…
+* [2:14:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=8045) CP porting checklist - what to do first
+* [2:15:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=8100) DisplayIO and HDMI - look for bare metal CP on rPI
+* [2:16:30](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=8190) CP definition with respect to Micropython
+* [2:19:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=8340) VSCode extension for CP
+* [2:22:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=8520) Double tap to reset doesn’t work yet
+* [2:25](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=145);24 wrap up
+* [2:28:54](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=8934) off

--- a/2021/2021-01-22.md
+++ b/2021/2021-01-22.md
@@ -4,7 +4,7 @@
 Hi all, this doc is try and track topics and timecodes for my deep dive stream. These notes will end up in the YouTube video’s description. Any help keeping them groomed as I stream is welcome.
 
 
-08:41 Housekeeping
+[08:41](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=521) Housekeeping
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome. Next week is Friday as normal.
@@ -12,71 +12,71 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* [11:43](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=703) RP2040 and Raspberry Pi Pico board!
-* [19:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=1185) Show how to install CircuitPython on a Pico fresh out of a package.
-* [24:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=1440) Hello World
-* [27:14](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=1634) RP2040 / pico data resources
-* [28:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=1725) RP2040 data sheet
-* [32:10](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=1930) CP use of multi-core - “Not Yet”
-* [36:43](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2203) Can I use any quad SPI memory with RP2040 like an MRAM memory does UF2 support these memories or only flash memory?
-39:20 PIO ( Programmable IO )
-* [41:22](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2482) Circuit Python has a list of the supported Flash chips in the source code, easy to find.
-* [41:46](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2506) PIO ( Programmable IO ) continued
-* [44:30](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2670) IRQ PIO
-* [45:36](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2736) NeoPixel example for PIO ( 4 instructions )
-* [46:20](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2780) Micropython vs. CP PIO differences
-* [47:42](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2862) CP PIO future expansion
-* [48:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2925) CAN bus in PIO?  Possible…
-* [49:20](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=2960) PIO FIFO
-* [51:50](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=3110) GPIO functions ( PIO1 and PIO2 peripherals? )
-* [53:52](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=3232) 3.2 PIO Programmer’s Model
-* [55:01](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=3301)  USB Host examples ?  ( see the sdk ? )
-* [55:28](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=3328)  back to Programmer’s Model  ( PC )
-* [56:10](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=3370) Output Shift Register
-* [56:34](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=3394) 3.3 PIO Assembler (pioasm) / 3.4 Instruction Set
-* [1:03:42](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=3822) Examples…( see the SDK chapter 3  - Thanks @Luke)
-* [1:04:06](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=3846) - live code PIO example on Feather
-* [1:06:49](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4009) CP NeoPixel code.py - not PIO
-* [1:07:40](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4060) PIO test code (pioasm)
-* [1:09:27](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4167) raspberrypi2.StateMachine
-* [1:12:13](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4333) Logic Pro 16
-* [1:13:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4395) square wave pioasm in code.py
-* [1:14:55](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4495) Hub75 example does hot patch of the instruction memory (@luke)
-* [1:15:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4545) Deinit for destroy and recreate pio scheme
-* [1:17:03](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4623) plug into channel 4 - see the blink
-* [1:18:28](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4708) update the old CP firmware - enter boot loader on the feather
-* [1:20:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4805)  PIO code goes into dedicated PIO instruction memory
-* [1:21:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4875) you can read by writing PC and reading out SMx_INSTR
-* [1:21:49](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4909) loading code.py into cleaned board ( pioasm and support libraries )
-* [1:23:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=4980) switch to 800KHz  ( hmm - frequency is 400KHz )
-* [1:23:40](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5020) squarewave assembly code
-* [1:24:22](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5062) readthedocs.io/en/latest/README.html…
-* [1:25:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5100) Rp2pio API
-* [1:26:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5175) Learn.adafruit.com - for wiring tutorials
-* [1:27:19](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5239) Iterate on square wave example
-* [1:31:44](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5504) State machine “wrap” feature
-* [1:33:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5595) Alternate logic analyzers ( use an rp2040 )
-* [1:35:36](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5736) Tinlylogic friend promo
-* [1:37:40](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5860) full speed 125000000   ( 62.5 MHz on the scope? )
-* [1:39:04](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=5944) Neopixel in 4 instructions
-* [1:41:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=6065) PIO resource sharing CP and user allocation
-* [1:45:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=6305) deep dive into neopixel pioasm
-* [1:46:30](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=6390) - wifi support from the airlift board via spi ( see Arduino Nano RP2040 )
-* [1:47:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=6425) back to neopixel pioasm ( out, jmp autopull, nop)
-* [1:55:40](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=6940) Assembler for the other M0 - someone needs to write it still :-)
-* [1:57:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7035) microDev - s2 risc-v low power core
-* [1:59:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7185) sm.write to get the bytes from CP to the PIO
-* [2:01:50](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7310) assembler can be run on c-python
-* [2:02:50](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7370) licensing question for @luke - compare with RISC-V / ARM
-* [2:04:11](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7451)  adadfruit_pioasm.py source
-* [2:09:35](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7775) PIO can use DMA
-* [2:10:12](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7812) back to the datasheet ( Page 14 - bus overview )
-* [2:12:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7920) state of GUI in CP
-* [2:13:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=7980) One of the strengths of CP is USB support…
-* [2:14:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=8045) CP porting checklist - what to do first
-* [2:15:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=8100) DisplayIO and HDMI - look for bare metal CP on rPI
-* [2:16:30](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=8190) CP definition with respect to Micropython
-* [2:19:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=8340) VSCode extension for CP
-* [2:22:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=8520) Double tap to reset doesn’t work yet
-* [2:25](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=145);24 wrap up
-* [2:28:54](https://www.youtube.com/watch?v=VIDEO_2021_01_22&t=8934) off
+* [11:43](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=703) RP2040 and Raspberry Pi Pico board!
+* [19:45](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=1185) Show how to install CircuitPython on a Pico fresh out of a package.
+* [24:00](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=1440) Hello World
+* [27:14](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=1634) RP2040 / pico data resources
+* [28:45](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=1725) RP2040 data sheet
+* [32:10](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=1930) CP use of multi-core - “Not Yet”
+* [36:43](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=2203) Can I use any quad SPI memory with RP2040 like an MRAM memory does UF2 support these memories or only flash memory?
+* [39:20](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=2360) PIO ( Programmable IO )
+* [41:22](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=2482) Circuit Python has a list of the supported Flash chips in the source code, easy to find.
+* [41:46](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=2506) PIO ( Programmable IO ) continued
+* [44:30](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=2670) IRQ PIO
+* [45:36](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=2736) NeoPixel example for PIO ( 4 instructions )
+* [46:20](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=2780) Micropython vs. CP PIO differences
+* [47:42](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=2862) CP PIO future expansion
+* [48:45](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=2925) CAN bus in PIO?  Possible…
+* [49:20](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=2960) PIO FIFO
+* [51:50](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=3110) GPIO functions ( PIO1 and PIO2 peripherals? )
+* [53:52](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=3232) 3.2 PIO Programmer’s Model
+* [55:01](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=3301)  USB Host examples ?  ( see the sdk ? )
+* [55:28](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=3328)  back to Programmer’s Model  ( PC )
+* [56:10](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=3370) Output Shift Register
+* [56:34](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=3394) 3.3 PIO Assembler (pioasm) / 3.4 Instruction Set
+* [1:03:42](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=3822) Examples…( see the SDK chapter 3  - Thanks @Luke)
+* [1:04:06](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=3846) - live code PIO example on Feather
+* [1:06:49](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=4009) CP NeoPixel code.py - not PIO
+* [1:07:40](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=4060) PIO test code (pioasm)
+* [1:09:27](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=4167) raspberrypi2.StateMachine
+* [1:12:13](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=4333) Logic Pro 16
+* [1:13:15](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=4395) square wave pioasm in code.py
+* [1:14:55](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=4495) Hub75 example does hot patch of the instruction memory (@luke)
+* [1:15:45](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=4545) Deinit for destroy and recreate pio scheme
+* [1:17:03](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=4623) plug into channel 4 - see the blink
+* [1:18:28](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=4708) update the old CP firmware - enter boot loader on the feather
+* [1:20:05](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=4805)  PIO code goes into dedicated PIO instruction memory
+* [1:21:15](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=4875) you can read by writing PC and reading out SMx_INSTR
+* [1:21:49](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=4909) loading code.py into cleaned board ( pioasm and support libraries )
+* [1:23:00](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=4980) switch to 800KHz  ( hmm - frequency is 400KHz )
+* [1:23:40](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=5020) squarewave assembly code
+* [1:24:22](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=5062) readthedocs.io/en/latest/README.html…
+* [1:25:00](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=5100) Rp2pio API
+* [1:26:15](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=5175) Learn.adafruit.com - for wiring tutorials
+* [1:27:19](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=5239) Iterate on square wave example
+* [1:31:44](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=5504) State machine “wrap” feature
+* [1:33:15](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=5595) Alternate logic analyzers ( use an rp2040 )
+* [1:35:36](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=5736) Tinlylogic friend promo
+* [1:37:40](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=5860) full speed 125000000   ( 62.5 MHz on the scope? )
+* [1:39:04](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=5944) Neopixel in 4 instructions
+* [1:41:05](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=6065) PIO resource sharing CP and user allocation
+* [1:45:05](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=6305) deep dive into neopixel pioasm
+* [1:46:30](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=6390) - wifi support from the airlift board via spi ( see Arduino Nano RP2040 )
+* [1:47:05](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=6425) back to neopixel pioasm ( out, jmp autopull, nop)
+* [1:55:40](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=6940) Assembler for the other M0 - someone needs to write it still :-)
+* [1:57:15](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=7035) microDev - s2 risc-v low power core
+* [1:59:45](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=7185) sm.write to get the bytes from CP to the PIO
+* [2:01:50](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=7310) assembler can be run on c-python
+* [2:02:50](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=7370) licensing question for @luke - compare with RISC-V / ARM
+* [2:04:11](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=7451)  adadfruit_pioasm.py source
+* [2:09:35](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=7775) PIO can use DMA
+* [2:10:12](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=7812) back to the datasheet ( Page 14 - bus overview )
+* [2:12:00](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=7920) state of GUI in CP
+* [2:13:00](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=7980) One of the strengths of CP is USB support…
+* [2:14:05](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=8045) CP porting checklist - what to do first
+* [2:15:00](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=8100) DisplayIO and HDMI - look for bare metal CP on rPI
+* [2:16:30](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=8190) CP definition with respect to Micropython
+* [2:19:00](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=8340) VSCode extension for CP
+* [2:22:00](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=8520) Double tap to reset doesn’t work yet
+* [2:25:24](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=8724) wrap up
+* [2:28:54](https://www.youtube.com/watch?v=LXAwW2IYT7o&t=8934) off

--- a/2021/2021-01-22.md
+++ b/2021/2021-01-22.md
@@ -12,71 +12,71 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* 11:43 RP2040 and Raspberry Pi Pico board!
-* 19:45 Show how to install CircuitPython on a Pico fresh out of a package.
-* 24:00 Hello World
-* 27:14 RP2040 / pico data resources
-* 28:45 RP2040 data sheet
-* 32:10 CP use of multi-core - “Not Yet”
-* 36:43 Can I use any quad SPI memory with RP2040 like an MRAM memory does UF2 support these memories or only flash memory?
+* [11:43](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=703) RP2040 and Raspberry Pi Pico board!
+* [19:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=1185) Show how to install CircuitPython on a Pico fresh out of a package.
+* [24:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=1440) Hello World
+* [27:14](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=1634) RP2040 / pico data resources
+* [28:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=1725) RP2040 data sheet
+* [32:10](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=1930) CP use of multi-core - “Not Yet”
+* [36:43](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2203) Can I use any quad SPI memory with RP2040 like an MRAM memory does UF2 support these memories or only flash memory?
 39:20 PIO ( Programmable IO )
-* 41:22 Circuit Python has a list of the supported Flash chips in the source code, easy to find.
-* 41:46 PIO ( Programmable IO ) continued
-* 44:30 IRQ PIO
-* 45:36 NeoPixel example for PIO ( 4 instructions )
-* 46:20 Micropython vs. CP PIO differences
-* 47:42 CP PIO future expansion
-* 48:45 CAN bus in PIO?  Possible…
-* 49:20 PIO FIFO
-* 51:50 GPIO functions ( PIO1 and PIO2 peripherals? )
-* 53:52 3.2 PIO Programmer’s Model 
-* 55:01  USB Host examples ?  ( see the sdk ? )
-* 55:28  back to Programmer’s Model  ( PC )
-* 56:10 Output Shift Register
-* 56:34 3.3 PIO Assembler (pioasm) / 3.4 Instruction Set
-* 1:03:42 Examples…( see the SDK chapter 3  - Thanks @Luke) 
-* 1:04:06 - live code PIO example on Feather
-* 1:06:49 CP NeoPixel code.py - not PIO
-* 1:07:40 PIO test code (pioasm)
-* 1:09:27 raspberrypi2.StateMachine
-* 1:12:13 Logic Pro 16 
-* 1:13:15 square wave pioasm in code.py
-* 1:14:55 Hub75 example does hot patch of the instruction memory (@luke) 
-* 1:15:45 Deinit for destroy and recreate pio scheme
-* 1:17:03 plug into channel 4 - see the blink
-* 1:18:28 update the old CP firmware - enter boot loader on the feather
-* 1:20:05  PIO code goes into dedicated PIO instruction memory
-* 1:21:15 you can read by writing PC and reading out SMx_INSTR
-* 1:21:49 loading code.py into cleaned board ( pioasm and support libraries )
-* 1:23:00 switch to 800KHz  ( hmm - frequency is 400KHz )
-* 1:23:40 squarewave assembly code
-* 1:24:22 readthedocs.io/en/latest/README.html…
-* 1:25:00 Rp2pio API
-* 1:26:15 Learn.adafruit.com - for wiring tutorials
-* 1:27:19 Iterate on square wave example
-* 1:31:44 State machine “wrap” feature
-* 1:33:15 Alternate logic analyzers ( use an rp2040 )
-* 1:35:36 Tinlylogic friend promo
-* 1:37:40 full speed 125000000   ( 62.5 MHz on the scope? )
-* 1:39:04 Neopixel in 4 instructions
-* 1:41:05 PIO resource sharing CP and user allocation
-* 1:45:05 deep dive into neopixel pioasm
-* 1:46:30 - wifi support from the airlift board via spi ( see Arduino Nano RP2040 )
-* 1:47:05 back to neopixel pioasm ( out, jmp autopull, nop)
-* 1:55:40 Assembler for the other M0 - someone needs to write it still :-)
-* 1:57:15 microDev - s2 risc-v low power core
-* 1:59:45 sm.write to get the bytes from CP to the PIO
-* 2:01:50 assembler can be run on c-python
-* 2:02:50 licensing question for @luke - compare with RISC-V / ARM
-* 2:04:11  adadfruit_pioasm.py source
-* 2:09:35 PIO can use DMA
-* 2:10:12 back to the datasheet ( Page 14 - bus overview )
-* 2:12:00 state of GUI in CP
-* 2:13:00 One of the strengths of CP is USB support…
-* 2:14:05 CP porting checklist - what to do first
-* 2:15:00 DisplayIO and HDMI - look for bare metal CP on rPI
-* 2:16:30 CP definition with respect to Micropython
-* 2:19:00 VSCode extension for CP
-* 2:22:00 Double tap to reset doesn’t work yet
-* 2:25;24 wrap up
-* 2:28:54 off
+* [41:22](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2482) Circuit Python has a list of the supported Flash chips in the source code, easy to find.
+* [41:46](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2506) PIO ( Programmable IO ) continued
+* [44:30](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2670) IRQ PIO
+* [45:36](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2736) NeoPixel example for PIO ( 4 instructions )
+* [46:20](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2780) Micropython vs. CP PIO differences
+* [47:42](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2862) CP PIO future expansion
+* [48:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2925) CAN bus in PIO?  Possible…
+* [49:20](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=2960) PIO FIFO
+* [51:50](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=3110) GPIO functions ( PIO1 and PIO2 peripherals? )
+* [53:52](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=3232) 3.2 PIO Programmer’s Model
+* [55:01](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=3301)  USB Host examples ?  ( see the sdk ? )
+* [55:28](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=3328)  back to Programmer’s Model  ( PC )
+* [56:10](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=3370) Output Shift Register
+* [56:34](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=3394) 3.3 PIO Assembler (pioasm) / 3.4 Instruction Set
+* [1:03:42](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=3822) Examples…( see the SDK chapter 3  - Thanks @Luke)
+* [1:04:06](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=3846) - live code PIO example on Feather
+* [1:06:49](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4009) CP NeoPixel code.py - not PIO
+* [1:07:40](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4060) PIO test code (pioasm)
+* [1:09:27](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4167) raspberrypi2.StateMachine
+* [1:12:13](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4333) Logic Pro 16
+* [1:13:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4395) square wave pioasm in code.py
+* [1:14:55](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4495) Hub75 example does hot patch of the instruction memory (@luke)
+* [1:15:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4545) Deinit for destroy and recreate pio scheme
+* [1:17:03](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4623) plug into channel 4 - see the blink
+* [1:18:28](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4708) update the old CP firmware - enter boot loader on the feather
+* [1:20:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4805)  PIO code goes into dedicated PIO instruction memory
+* [1:21:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4875) you can read by writing PC and reading out SMx_INSTR
+* [1:21:49](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4909) loading code.py into cleaned board ( pioasm and support libraries )
+* [1:23:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=4980) switch to 800KHz  ( hmm - frequency is 400KHz )
+* [1:23:40](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5020) squarewave assembly code
+* [1:24:22](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5062) readthedocs.io/en/latest/README.html…
+* [1:25:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5100) Rp2pio API
+* [1:26:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5175) Learn.adafruit.com - for wiring tutorials
+* [1:27:19](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5239) Iterate on square wave example
+* [1:31:44](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5504) State machine “wrap” feature
+* [1:33:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5595) Alternate logic analyzers ( use an rp2040 )
+* [1:35:36](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5736) Tinlylogic friend promo
+* [1:37:40](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5860) full speed 125000000   ( 62.5 MHz on the scope? )
+* [1:39:04](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=5944) Neopixel in 4 instructions
+* [1:41:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=6065) PIO resource sharing CP and user allocation
+* [1:45:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=6305) deep dive into neopixel pioasm
+* [1:46:30](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=6390) - wifi support from the airlift board via spi ( see Arduino Nano RP2040 )
+* [1:47:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=6425) back to neopixel pioasm ( out, jmp autopull, nop)
+* [1:55:40](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=6940) Assembler for the other M0 - someone needs to write it still :-)
+* [1:57:15](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7035) microDev - s2 risc-v low power core
+* [1:59:45](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7185) sm.write to get the bytes from CP to the PIO
+* [2:01:50](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7310) assembler can be run on c-python
+* [2:02:50](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7370) licensing question for @luke - compare with RISC-V / ARM
+* [2:04:11](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7451)  adadfruit_pioasm.py source
+* [2:09:35](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7775) PIO can use DMA
+* [2:10:12](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7812) back to the datasheet ( Page 14 - bus overview )
+* [2:12:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7920) state of GUI in CP
+* [2:13:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=7980) One of the strengths of CP is USB support…
+* [2:14:05](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=8045) CP porting checklist - what to do first
+* [2:15:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=8100) DisplayIO and HDMI - look for bare metal CP on rPI
+* [2:16:30](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=8190) CP definition with respect to Micropython
+* [2:19:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=8340) VSCode extension for CP
+* [2:22:00](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=8520) Double tap to reset doesn’t work yet
+* [2:25](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=145);24 wrap up
+* [2:28:54](https://www.youtube.com/watch?v=VIDEO_2021_01_22?t=8934) off

--- a/2021/2021-01-29.md
+++ b/2021/2021-01-29.md
@@ -16,70 +16,70 @@ Youtube stream: https://www.youtube.com/watch?v=WS64J3BTBj0
 
 Plan
 * Questions
-* 12:22 Any plans for a ESP32 wired Ethernet feather wing?
-* 13:45 Does the Wiznet library support TLS?
-* 15:05 State of CircuitPython RP2040
-* 20:07 How'd you come to choose Arch?
-* 21:25 how to smooth library porting to and from micropython?
-* 22:49 A quick question  how feasible is to replace/upgrade to flash chip on pico?
-* 23:56 Have you ever talked about OTA (over the air updates) on a circuit python based deployment?
-* 24:53 What makes the pico better then other boards? 
-* 25:31  RP2040 as a dev board - issues
-* 27:25 Will PWM capture be supported? That would be interesting for reading ultrasonic sensors
-* 28:40 Is circuit python going to support the dual core s of the pico?
-* 29:47 will there be a Starting with Circuit Python on the PICO book?
-* 32:25 could you tell us something about Circuitpython vs Micropython?
-* 36:05 What is your guess how far the PIO's can be pushed quadrature encoder wise for CP ? (for closed loop motor control)
-* 37:43 arduino on the pico when?
-* 38:34 do you see the rp2040/pico and circuit python overtaking arduino due to python being so much easier to code for beginners or otherwise?
-* 41:11 I often get old print statements (from infinite loops) still printing in the mu serial output after saving and my code restarting. Is that due to a big buffer somewhere still pushing out text somewhere?
-* 43:16 Is CP doing QUAD SPI or QPI to flash ? (or just SPI)
-* 46:24 did you implement peek and poke from c64?
-* 46:54 Can CircuitPython take advantage of Sparkfun's proposed larger flash part ?
-* 47:43 will Firmata work on this board?
-* 48:34 Heh, just a follow up on the OTA question... what I meant was the support for changing the files (like code.py) on the mass storage and not circuit python itself. Would that still be considered OTA?
-* 50:15 how would you control a low power state entry without WFE or WFI?
-* * 53:04 From dcd: given earlier interest in FPGAs and comparing it to the focused power of the rp2040's PIO - have you followed the Glasgow Interface Explorer ? Is it the next step? Has anyone 'backed' it yet? - just 4 days left on crowd supply https://www.crowdsupply.com/1bitsquared/glasgow )
-* 56:52 Does CP have ability to toy with clock to get current lower on the new speed? How is current compared to Portenta ?
-* 59:28 Any part of the RP2040 port that would be useful for me to poke at working on that needs to be done still? Now that I have a couple picos finally.
-* 1:02:49 Will UART work over old skool pins (instead of or in addition to) through USB ?
-* 1:04:25 what does audio mean on the RP2040
-* 1:05:44 I2S out ( see wikipedia and readthedocs )
-* 1:07:04 PDM in (pulse modulation)
-* 1:07:56 Using Audacity to understand digital audio
-* 1:09:39 ( CP / wiznet / ethernet )
-* 1:11:08 using the REPL to explore the audio frequency rates …
-* 1:12:20 I2S out / CD standard rates
-* 1:13:09 Audio Core / RawSamples
-* 1:13:43 Audioio ( audio output )
-* 1:15:00 Audiomixer / MixerVoice
+* [12:22](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=742) Any plans for a ESP32 wired Ethernet feather wing?
+* [13:45](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=825) Does the Wiznet library support TLS?
+* [15:05](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=905) State of CircuitPython RP2040
+* [20:07](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1207) How'd you come to choose Arch?
+* [21:25](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1285) how to smooth library porting to and from micropython?
+* [22:49](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1369) A quick question  how feasible is to replace/upgrade to flash chip on pico?
+* [23:56](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1436) Have you ever talked about OTA (over the air updates) on a circuit python based deployment?
+* [24:53](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1493) What makes the pico better then other boards?
+* [25:31](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1531)  RP2040 as a dev board - issues
+* [27:25](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1645) Will PWM capture be supported? That would be interesting for reading ultrasonic sensors
+* [28:40](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1720) Is circuit python going to support the dual core s of the pico?
+* [29:47](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1787) will there be a Starting with Circuit Python on the PICO book?
+* [32:25](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1945) could you tell us something about Circuitpython vs Micropython?
+* [36:05](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2165) What is your guess how far the PIO's can be pushed quadrature encoder wise for CP ? (for closed loop motor control)
+* [37:43](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2263) arduino on the pico when?
+* [38:34](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2314) do you see the rp2040/pico and circuit python overtaking arduino due to python being so much easier to code for beginners or otherwise?
+* [41:11](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2471) I often get old print statements (from infinite loops) still printing in the mu serial output after saving and my code restarting. Is that due to a big buffer somewhere still pushing out text somewhere?
+* [43:16](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2596) Is CP doing QUAD SPI or QPI to flash ? (or just SPI)
+* [46:24](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2784) did you implement peek and poke from c64?
+* [46:54](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2814) Can CircuitPython take advantage of Sparkfun's proposed larger flash part ?
+* [47:43](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2863) will Firmata work on this board?
+* [48:34](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2914) Heh, just a follow up on the OTA question... what I meant was the support for changing the files (like code.py) on the mass storage and not circuit python itself. Would that still be considered OTA?
+* [50:15](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=3015) how would you control a low power state entry without WFE or WFI?
+* * [53:04](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=3184) From dcd: given earlier interest in FPGAs and comparing it to the focused power of the rp2040's PIO - have you followed the Glasgow Interface Explorer ? Is it the next step? Has anyone 'backed' it yet? - just 4 days left on crowd supply https://www.crowdsupply.com/1bitsquared/glasgow )
+* [56:52](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=3412) Does CP have ability to toy with clock to get current lower on the new speed? How is current compared to Portenta ?
+* [59:28](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=3568) Any part of the RP2040 port that would be useful for me to poke at working on that needs to be done still? Now that I have a couple picos finally.
+* [1:02:49](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=3769) Will UART work over old skool pins (instead of or in addition to) through USB ?
+* [1:04:25](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=3865) what does audio mean on the RP2040
+* [1:05:44](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=3944) I2S out ( see wikipedia and readthedocs )
+* [1:07:04](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4024) PDM in (pulse modulation)
+* [1:07:56](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4076) Using Audacity to understand digital audio
+* [1:09:39](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4179) ( CP / wiznet / ethernet )
+* [1:11:08](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4268) using the REPL to explore the audio frequency rates …
+* [1:12:20](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4340) I2S out / CD standard rates
+* [1:13:09](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4389) Audio Core / RawSamples
+* [1:13:43](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4423) Audioio ( audio output )
+* [1:15:00](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4500) Audiomixer / MixerVoice
 * 1;16:05 audiomp3 - support for MP3-compressed audio files
-* 1:16:46 audiopwmio - Audio output via digital PWM ( want to do for the RP2040 )
-* 1:18:07 Can you take advantage of the parallel read/write across memory banks to improve throughput on the Pico?
+* [1:16:46](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4606) audiopwmio - Audio output via digital PWM ( want to do for the RP2040 )
+* [1:18:07](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4687) Can you take advantage of the parallel read/write across memory banks to improve throughput on the Pico?
 ( audio is not that fast… )
-* 1:19:39 - “working code”
-* 1:20:00 audio pwm out discussion / resolution 
-* 1:25:36 DMA feature - PIO pacing timers
+* [1:19:39](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4779) - “working code”
+* [1:20:00](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4800) audio pwm out discussion / resolution
+* [1:25:36](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=5136) DMA feature - PIO pacing timers
 * https://www.youtube.com/watch?v=aVLRUyPBBJk
-* 1:28:30 Clock division on RP2040 divisor_finder.py (sp?)
+* [1:28:30](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=5310) Clock division on RP2040 divisor_finder.py (sp?)
 * Tannewt rp2040_audiopwmio branch
-* 1:34:10 Pacing timer story ( 4 timers in hardware )
-* 1:37:40 8-bits and 4-bits divisor
-* 1:39:22 RP2040 requires external crystal - for more accurate frequencies…
-* 1:40:18  Plan for I2S
-* 1:41:45 Pico example and pico extras
-* 1:43:20 PIO assembly code for IO - ping pong buffers
-* 1:47:30 DMA buffer size/alignment limitations / channel chaining
-* 1:50:02 Deep dive into the DMA Registers ( around page 99 in the data sheet)
-* 1:55:40 pause and resume
-* 2:01:15 - Questions:
+* [1:34:10](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=5650) Pacing timer story ( 4 timers in hardware )
+* [1:37:40](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=5860) 8-bits and 4-bits divisor
+* [1:39:22](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=5962) RP2040 requires external crystal - for more accurate frequencies…
+* [1:40:18](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=6018)  Plan for I2S
+* [1:41:45](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=6105) Pico example and pico extras
+* [1:43:20](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=6200) PIO assembly code for IO - ping pong buffers
+* [1:47:30](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=6450) DMA buffer size/alignment limitations / channel chaining
+* [1:50:02](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=6602) Deep dive into the DMA Registers ( around page 99 in the data sheet)
+* [1:55:40](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=6940) pause and resume
+* [2:01:15](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=7275) - Questions:
 * DMA and Audio on the RP2040
-* 2:02:11 Completely unrelated question. Is there a way to use the USB connection as a USB/CDC serial device with micropython I would assume since the REPL is over the USB this wouldn't work
-* 2:04:08 What are the downsides of the rp2040? Compared to samd51 etc. 
+* [2:02:11](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=7331) Completely unrelated question. Is there a way to use the USB connection as a USB/CDC serial device with micropython I would assume since the REPL is over the USB this wouldn't work
+* [2:04:08](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=7448) What are the downsides of the rp2040? Compared to samd51 etc.
 
-* 2:09:46 could you inject ramp PIO instructions for the transitions?
-* 2:08:55 Can you be a web server in CP ?
-* 2:10:33 GPIO 15 story
-* 2:14:56 What is best target for CP to do ethernet ?
+* [2:09:46](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=7786) could you inject ramp PIO instructions for the transitions?
+* [2:08:55](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=7735) Can you be a web server in CP ?
+* [2:10:33](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=7833) GPIO 15 story
+* [2:14:56](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=8096) What is best target for CP to do ethernet ?
 * Disk partition
-* 2:16:03 Wrap-up
+* [2:16:03](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=8163) Wrap-up

--- a/2021/2021-01-29.md
+++ b/2021/2021-01-29.md
@@ -16,70 +16,70 @@ Youtube stream: https://www.youtube.com/watch?v=WS64J3BTBj0
 
 Plan
 * Questions
-* [12:22](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=742) Any plans for a ESP32 wired Ethernet feather wing?
-* [13:45](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=825) Does the Wiznet library support TLS?
-* [15:05](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=905) State of CircuitPython RP2040
-* [20:07](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1207) How'd you come to choose Arch?
-* [21:25](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1285) how to smooth library porting to and from micropython?
-* [22:49](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1369) A quick question  how feasible is to replace/upgrade to flash chip on pico?
-* [23:56](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1436) Have you ever talked about OTA (over the air updates) on a circuit python based deployment?
-* [24:53](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1493) What makes the pico better then other boards?
-* [25:31](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1531)  RP2040 as a dev board - issues
-* [27:25](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1645) Will PWM capture be supported? That would be interesting for reading ultrasonic sensors
-* [28:40](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1720) Is circuit python going to support the dual core s of the pico?
-* [29:47](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1787) will there be a Starting with Circuit Python on the PICO book?
-* [32:25](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=1945) could you tell us something about Circuitpython vs Micropython?
-* [36:05](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2165) What is your guess how far the PIO's can be pushed quadrature encoder wise for CP ? (for closed loop motor control)
-* [37:43](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2263) arduino on the pico when?
-* [38:34](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2314) do you see the rp2040/pico and circuit python overtaking arduino due to python being so much easier to code for beginners or otherwise?
-* [41:11](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2471) I often get old print statements (from infinite loops) still printing in the mu serial output after saving and my code restarting. Is that due to a big buffer somewhere still pushing out text somewhere?
-* [43:16](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2596) Is CP doing QUAD SPI or QPI to flash ? (or just SPI)
-* [46:24](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2784) did you implement peek and poke from c64?
-* [46:54](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2814) Can CircuitPython take advantage of Sparkfun's proposed larger flash part ?
-* [47:43](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2863) will Firmata work on this board?
-* [48:34](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=2914) Heh, just a follow up on the OTA question... what I meant was the support for changing the files (like code.py) on the mass storage and not circuit python itself. Would that still be considered OTA?
-* [50:15](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=3015) how would you control a low power state entry without WFE or WFI?
-* * [53:04](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=3184) From dcd: given earlier interest in FPGAs and comparing it to the focused power of the rp2040's PIO - have you followed the Glasgow Interface Explorer ? Is it the next step? Has anyone 'backed' it yet? - just 4 days left on crowd supply https://www.crowdsupply.com/1bitsquared/glasgow )
-* [56:52](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=3412) Does CP have ability to toy with clock to get current lower on the new speed? How is current compared to Portenta ?
-* [59:28](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=3568) Any part of the RP2040 port that would be useful for me to poke at working on that needs to be done still? Now that I have a couple picos finally.
-* [1:02:49](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=3769) Will UART work over old skool pins (instead of or in addition to) through USB ?
-* [1:04:25](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=3865) what does audio mean on the RP2040
-* [1:05:44](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=3944) I2S out ( see wikipedia and readthedocs )
-* [1:07:04](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4024) PDM in (pulse modulation)
-* [1:07:56](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4076) Using Audacity to understand digital audio
-* [1:09:39](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4179) ( CP / wiznet / ethernet )
-* [1:11:08](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4268) using the REPL to explore the audio frequency rates …
-* [1:12:20](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4340) I2S out / CD standard rates
-* [1:13:09](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4389) Audio Core / RawSamples
-* [1:13:43](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4423) Audioio ( audio output )
-* [1:15:00](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4500) Audiomixer / MixerVoice
+* [12:22](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=742) Any plans for a ESP32 wired Ethernet feather wing?
+* [13:45](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=825) Does the Wiznet library support TLS?
+* [15:05](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=905) State of CircuitPython RP2040
+* [20:07](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1207) How'd you come to choose Arch?
+* [21:25](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1285) how to smooth library porting to and from micropython?
+* [22:49](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1369) A quick question  how feasible is to replace/upgrade to flash chip on pico?
+* [23:56](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1436) Have you ever talked about OTA (over the air updates) on a circuit python based deployment?
+* [24:53](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1493) What makes the pico better then other boards?
+* [25:31](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1531)  RP2040 as a dev board - issues
+* [27:25](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1645) Will PWM capture be supported? That would be interesting for reading ultrasonic sensors
+* [28:40](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1720) Is circuit python going to support the dual core s of the pico?
+* [29:47](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1787) will there be a Starting with Circuit Python on the PICO book?
+* [32:25](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1945) could you tell us something about Circuitpython vs Micropython?
+* [36:05](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2165) What is your guess how far the PIO's can be pushed quadrature encoder wise for CP ? (for closed loop motor control)
+* [37:43](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2263) arduino on the pico when?
+* [38:34](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2314) do you see the rp2040/pico and circuit python overtaking arduino due to python being so much easier to code for beginners or otherwise?
+* [41:11](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2471) I often get old print statements (from infinite loops) still printing in the mu serial output after saving and my code restarting. Is that due to a big buffer somewhere still pushing out text somewhere?
+* [43:16](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2596) Is CP doing QUAD SPI or QPI to flash ? (or just SPI)
+* [46:24](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2784) did you implement peek and poke from c64?
+* [46:54](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2814) Can CircuitPython take advantage of Sparkfun's proposed larger flash part ?
+* [47:43](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2863) will Firmata work on this board?
+* [48:34](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2914) Heh, just a follow up on the OTA question... what I meant was the support for changing the files (like code.py) on the mass storage and not circuit python itself. Would that still be considered OTA?
+* [50:15](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=3015) how would you control a low power state entry without WFE or WFI?
+* * [53:04](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=3184) From dcd: given earlier interest in FPGAs and comparing it to the focused power of the rp2040's PIO - have you followed the Glasgow Interface Explorer ? Is it the next step? Has anyone 'backed' it yet? - just 4 days left on crowd supply https://www.crowdsupply.com/1bitsquared/glasgow )
+* [56:52](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=3412) Does CP have ability to toy with clock to get current lower on the new speed? How is current compared to Portenta ?
+* [59:28](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=3568) Any part of the RP2040 port that would be useful for me to poke at working on that needs to be done still? Now that I have a couple picos finally.
+* [1:02:49](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=3769) Will UART work over old skool pins (instead of or in addition to) through USB ?
+* [1:04:25](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=3865) what does audio mean on the RP2040
+* [1:05:44](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=3944) I2S out ( see wikipedia and readthedocs )
+* [1:07:04](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4024) PDM in (pulse modulation)
+* [1:07:56](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4076) Using Audacity to understand digital audio
+* [1:09:39](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4179) ( CP / wiznet / ethernet )
+* [1:11:08](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4268) using the REPL to explore the audio frequency rates …
+* [1:12:20](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4340) I2S out / CD standard rates
+* [1:13:09](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4389) Audio Core / RawSamples
+* [1:13:43](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4423) Audioio ( audio output )
+* [1:15:00](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4500) Audiomixer / MixerVoice
 * 1;16:05 audiomp3 - support for MP3-compressed audio files
-* [1:16:46](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4606) audiopwmio - Audio output via digital PWM ( want to do for the RP2040 )
-* [1:18:07](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4687) Can you take advantage of the parallel read/write across memory banks to improve throughput on the Pico?
+* [1:16:46](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4606) audiopwmio - Audio output via digital PWM ( want to do for the RP2040 )
+* [1:18:07](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4687) Can you take advantage of the parallel read/write across memory banks to improve throughput on the Pico?
 ( audio is not that fast… )
-* [1:19:39](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4779) - “working code”
-* [1:20:00](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=4800) audio pwm out discussion / resolution
-* [1:25:36](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=5136) DMA feature - PIO pacing timers
+* [1:19:39](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4779) - “working code”
+* [1:20:00](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4800) audio pwm out discussion / resolution
+* [1:25:36](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=5136) DMA feature - PIO pacing timers
 * https://www.youtube.com/watch?v=aVLRUyPBBJk
-* [1:28:30](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=5310) Clock division on RP2040 divisor_finder.py (sp?)
+* [1:28:30](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=5310) Clock division on RP2040 divisor_finder.py (sp?)
 * Tannewt rp2040_audiopwmio branch
-* [1:34:10](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=5650) Pacing timer story ( 4 timers in hardware )
-* [1:37:40](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=5860) 8-bits and 4-bits divisor
-* [1:39:22](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=5962) RP2040 requires external crystal - for more accurate frequencies…
-* [1:40:18](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=6018)  Plan for I2S
-* [1:41:45](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=6105) Pico example and pico extras
-* [1:43:20](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=6200) PIO assembly code for IO - ping pong buffers
-* [1:47:30](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=6450) DMA buffer size/alignment limitations / channel chaining
-* [1:50:02](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=6602) Deep dive into the DMA Registers ( around page 99 in the data sheet)
-* [1:55:40](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=6940) pause and resume
-* [2:01:15](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=7275) - Questions:
+* [1:34:10](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=5650) Pacing timer story ( 4 timers in hardware )
+* [1:37:40](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=5860) 8-bits and 4-bits divisor
+* [1:39:22](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=5962) RP2040 requires external crystal - for more accurate frequencies…
+* [1:40:18](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=6018)  Plan for I2S
+* [1:41:45](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=6105) Pico example and pico extras
+* [1:43:20](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=6200) PIO assembly code for IO - ping pong buffers
+* [1:47:30](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=6450) DMA buffer size/alignment limitations / channel chaining
+* [1:50:02](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=6602) Deep dive into the DMA Registers ( around page 99 in the data sheet)
+* [1:55:40](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=6940) pause and resume
+* [2:01:15](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=7275) - Questions:
 * DMA and Audio on the RP2040
-* [2:02:11](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=7331) Completely unrelated question. Is there a way to use the USB connection as a USB/CDC serial device with micropython I would assume since the REPL is over the USB this wouldn't work
-* [2:04:08](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=7448) What are the downsides of the rp2040? Compared to samd51 etc.
+* [2:02:11](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=7331) Completely unrelated question. Is there a way to use the USB connection as a USB/CDC serial device with micropython I would assume since the REPL is over the USB this wouldn't work
+* [2:04:08](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=7448) What are the downsides of the rp2040? Compared to samd51 etc.
 
-* [2:09:46](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=7786) could you inject ramp PIO instructions for the transitions?
-* [2:08:55](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=7735) Can you be a web server in CP ?
-* [2:10:33](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=7833) GPIO 15 story
-* [2:14:56](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=8096) What is best target for CP to do ethernet ?
+* [2:09:46](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=7786) could you inject ramp PIO instructions for the transitions?
+* [2:08:55](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=7735) Can you be a web server in CP ?
+* [2:10:33](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=7833) GPIO 15 story
+* [2:14:56](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=8096) What is best target for CP to do ethernet ?
 * Disk partition
-* [2:16:03](https://www.youtube.com/watch?v=VIDEO_2021_01_29?t=8163) Wrap-up
+* [2:16:03](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=8163) Wrap-up

--- a/2021/2021-01-29.md
+++ b/2021/2021-01-29.md
@@ -7,7 +7,7 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 Youtube stream: https://www.youtube.com/watch?v=WS64J3BTBj0
 
 
-07:26 Housekeeping
+[07:26](https://www.youtube.com/watch?v=WS64J3BTBj0&t=446) Housekeeping
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome. Next week is on Friday as well.
@@ -16,70 +16,70 @@ Youtube stream: https://www.youtube.com/watch?v=WS64J3BTBj0
 
 Plan
 * Questions
-* [12:22](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=742) Any plans for a ESP32 wired Ethernet feather wing?
-* [13:45](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=825) Does the Wiznet library support TLS?
-* [15:05](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=905) State of CircuitPython RP2040
-* [20:07](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1207) How'd you come to choose Arch?
-* [21:25](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1285) how to smooth library porting to and from micropython?
-* [22:49](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1369) A quick question  how feasible is to replace/upgrade to flash chip on pico?
-* [23:56](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1436) Have you ever talked about OTA (over the air updates) on a circuit python based deployment?
-* [24:53](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1493) What makes the pico better then other boards?
-* [25:31](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1531)  RP2040 as a dev board - issues
-* [27:25](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1645) Will PWM capture be supported? That would be interesting for reading ultrasonic sensors
-* [28:40](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1720) Is circuit python going to support the dual core s of the pico?
-* [29:47](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1787) will there be a Starting with Circuit Python on the PICO book?
-* [32:25](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=1945) could you tell us something about Circuitpython vs Micropython?
-* [36:05](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2165) What is your guess how far the PIO's can be pushed quadrature encoder wise for CP ? (for closed loop motor control)
-* [37:43](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2263) arduino on the pico when?
-* [38:34](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2314) do you see the rp2040/pico and circuit python overtaking arduino due to python being so much easier to code for beginners or otherwise?
-* [41:11](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2471) I often get old print statements (from infinite loops) still printing in the mu serial output after saving and my code restarting. Is that due to a big buffer somewhere still pushing out text somewhere?
-* [43:16](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2596) Is CP doing QUAD SPI or QPI to flash ? (or just SPI)
-* [46:24](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2784) did you implement peek and poke from c64?
-* [46:54](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2814) Can CircuitPython take advantage of Sparkfun's proposed larger flash part ?
-* [47:43](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2863) will Firmata work on this board?
-* [48:34](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=2914) Heh, just a follow up on the OTA question... what I meant was the support for changing the files (like code.py) on the mass storage and not circuit python itself. Would that still be considered OTA?
-* [50:15](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=3015) how would you control a low power state entry without WFE or WFI?
-* * [53:04](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=3184) From dcd: given earlier interest in FPGAs and comparing it to the focused power of the rp2040's PIO - have you followed the Glasgow Interface Explorer ? Is it the next step? Has anyone 'backed' it yet? - just 4 days left on crowd supply https://www.crowdsupply.com/1bitsquared/glasgow )
-* [56:52](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=3412) Does CP have ability to toy with clock to get current lower on the new speed? How is current compared to Portenta ?
-* [59:28](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=3568) Any part of the RP2040 port that would be useful for me to poke at working on that needs to be done still? Now that I have a couple picos finally.
-* [1:02:49](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=3769) Will UART work over old skool pins (instead of or in addition to) through USB ?
-* [1:04:25](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=3865) what does audio mean on the RP2040
-* [1:05:44](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=3944) I2S out ( see wikipedia and readthedocs )
-* [1:07:04](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4024) PDM in (pulse modulation)
-* [1:07:56](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4076) Using Audacity to understand digital audio
-* [1:09:39](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4179) ( CP / wiznet / ethernet )
-* [1:11:08](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4268) using the REPL to explore the audio frequency rates …
-* [1:12:20](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4340) I2S out / CD standard rates
-* [1:13:09](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4389) Audio Core / RawSamples
-* [1:13:43](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4423) Audioio ( audio output )
-* [1:15:00](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4500) Audiomixer / MixerVoice
-* 1;16:05 audiomp3 - support for MP3-compressed audio files
-* [1:16:46](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4606) audiopwmio - Audio output via digital PWM ( want to do for the RP2040 )
-* [1:18:07](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4687) Can you take advantage of the parallel read/write across memory banks to improve throughput on the Pico?
+* [12:22](https://www.youtube.com/watch?v=WS64J3BTBj0&t=742) Any plans for a ESP32 wired Ethernet feather wing?
+* [13:45](https://www.youtube.com/watch?v=WS64J3BTBj0&t=825) Does the Wiznet library support TLS?
+* [15:05](https://www.youtube.com/watch?v=WS64J3BTBj0&t=905) State of CircuitPython RP2040
+* [20:07](https://www.youtube.com/watch?v=WS64J3BTBj0&t=1207) How'd you come to choose Arch?
+* [21:25](https://www.youtube.com/watch?v=WS64J3BTBj0&t=1285) how to smooth library porting to and from micropython?
+* [22:49](https://www.youtube.com/watch?v=WS64J3BTBj0&t=1369) A quick question  how feasible is to replace/upgrade to flash chip on pico?
+* [23:56](https://www.youtube.com/watch?v=WS64J3BTBj0&t=1436) Have you ever talked about OTA (over the air updates) on a circuit python based deployment?
+* [24:53](https://www.youtube.com/watch?v=WS64J3BTBj0&t=1493) What makes the pico better then other boards?
+* [25:31](https://www.youtube.com/watch?v=WS64J3BTBj0&t=1531)  RP2040 as a dev board - issues
+* [27:25](https://www.youtube.com/watch?v=WS64J3BTBj0&t=1645) Will PWM capture be supported? That would be interesting for reading ultrasonic sensors
+* [28:40](https://www.youtube.com/watch?v=WS64J3BTBj0&t=1720) Is circuit python going to support the dual core s of the pico?
+* [29:47](https://www.youtube.com/watch?v=WS64J3BTBj0&t=1787) will there be a Starting with Circuit Python on the PICO book?
+* [32:25](https://www.youtube.com/watch?v=WS64J3BTBj0&t=1945) could you tell us something about Circuitpython vs Micropython?
+* [36:05](https://www.youtube.com/watch?v=WS64J3BTBj0&t=2165) What is your guess how far the PIO's can be pushed quadrature encoder wise for CP ? (for closed loop motor control)
+* [37:43](https://www.youtube.com/watch?v=WS64J3BTBj0&t=2263) arduino on the pico when?
+* [38:34](https://www.youtube.com/watch?v=WS64J3BTBj0&t=2314) do you see the rp2040/pico and circuit python overtaking arduino due to python being so much easier to code for beginners or otherwise?
+* [41:11](https://www.youtube.com/watch?v=WS64J3BTBj0&t=2471) I often get old print statements (from infinite loops) still printing in the mu serial output after saving and my code restarting. Is that due to a big buffer somewhere still pushing out text somewhere?
+* [43:16](https://www.youtube.com/watch?v=WS64J3BTBj0&t=2596) Is CP doing QUAD SPI or QPI to flash ? (or just SPI)
+* [46:24](https://www.youtube.com/watch?v=WS64J3BTBj0&t=2784) did you implement peek and poke from c64?
+* [46:54](https://www.youtube.com/watch?v=WS64J3BTBj0&t=2814) Can CircuitPython take advantage of Sparkfun's proposed larger flash part ?
+* [47:43](https://www.youtube.com/watch?v=WS64J3BTBj0&t=2863) will Firmata work on this board?
+* [48:34](https://www.youtube.com/watch?v=WS64J3BTBj0&t=2914) Heh, just a follow up on the OTA question... what I meant was the support for changing the files (like code.py) on the mass storage and not circuit python itself. Would that still be considered OTA?
+* [50:15](https://www.youtube.com/watch?v=WS64J3BTBj0&t=3015) how would you control a low power state entry without WFE or WFI?
+* [53:04](https://www.youtube.com/watch?v=WS64J3BTBj0&t=3184) From dcd: given earlier interest in FPGAs and comparing it to the focused power of the rp2040's PIO - have you followed the Glasgow Interface Explorer ? Is it the next step? Has anyone 'backed' it yet? - just 4 days left on crowd supply https://www.crowdsupply.com/1bitsquared/glasgow )
+* [56:52](https://www.youtube.com/watch?v=WS64J3BTBj0&t=3412) Does CP have ability to toy with clock to get current lower on the new speed? How is current compared to Portenta ?
+* [59:28](https://www.youtube.com/watch?v=WS64J3BTBj0&t=3568) Any part of the RP2040 port that would be useful for me to poke at working on that needs to be done still? Now that I have a couple picos finally.
+* [1:02:49](https://www.youtube.com/watch?v=WS64J3BTBj0&t=3769) Will UART work over old skool pins (instead of or in addition to) through USB ?
+* [1:04:25](https://www.youtube.com/watch?v=WS64J3BTBj0&t=3865) what does audio mean on the RP2040
+* [1:05:44](https://www.youtube.com/watch?v=WS64J3BTBj0&t=3944) I2S out ( see wikipedia and readthedocs )
+* [1:07:04](https://www.youtube.com/watch?v=WS64J3BTBj0&t=4024) PDM in (pulse modulation)
+* [1:07:56](https://www.youtube.com/watch?v=WS64J3BTBj0&t=4076) Using Audacity to understand digital audio
+* [1:09:39](https://www.youtube.com/watch?v=WS64J3BTBj0&t=4179) ( CP / wiznet / ethernet )
+* [1:11:08](https://www.youtube.com/watch?v=WS64J3BTBj0&t=4268) using the REPL to explore the audio frequency rates …
+* [1:12:20](https://www.youtube.com/watch?v=WS64J3BTBj0&t=4340) I2S out / CD standard rates
+* [1:13:09](https://www.youtube.com/watch?v=WS64J3BTBj0&t=4389) Audio Core / RawSamples
+* [1:13:43](https://www.youtube.com/watch?v=WS64J3BTBj0&t=4423) Audioio ( audio output )
+* [1:15:00](https://www.youtube.com/watch?v=WS64J3BTBj0&t=4500) Audiomixer / MixerVoice
+* [1:16:05](https://www.youtube.com/watch?v=WS64J3BTBj0&t=4565) audiomp3 - support for MP3-compressed audio files
+* [1:16:46](https://www.youtube.com/watch?v=WS64J3BTBj0&t=4606) audiopwmio - Audio output via digital PWM ( want to do for the RP2040 )
+* [1:18:07](https://www.youtube.com/watch?v=WS64J3BTBj0&t=4687) Can you take advantage of the parallel read/write across memory banks to improve throughput on the Pico?
 ( audio is not that fast… )
-* [1:19:39](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4779) - “working code”
-* [1:20:00](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=4800) audio pwm out discussion / resolution
-* [1:25:36](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=5136) DMA feature - PIO pacing timers
+* [1:19:39](https://www.youtube.com/watch?v=WS64J3BTBj0&t=4779) - “working code”
+* [1:20:00](https://www.youtube.com/watch?v=WS64J3BTBj0&t=4800) audio pwm out discussion / resolution
+* [1:25:36](https://www.youtube.com/watch?v=WS64J3BTBj0&t=5136) DMA feature - PIO pacing timers
 * https://www.youtube.com/watch?v=aVLRUyPBBJk
-* [1:28:30](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=5310) Clock division on RP2040 divisor_finder.py (sp?)
+* [1:28:30](https://www.youtube.com/watch?v=WS64J3BTBj0&t=5310) Clock division on RP2040 divisor_finder.py (sp?)
 * Tannewt rp2040_audiopwmio branch
-* [1:34:10](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=5650) Pacing timer story ( 4 timers in hardware )
-* [1:37:40](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=5860) 8-bits and 4-bits divisor
-* [1:39:22](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=5962) RP2040 requires external crystal - for more accurate frequencies…
-* [1:40:18](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=6018)  Plan for I2S
-* [1:41:45](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=6105) Pico example and pico extras
-* [1:43:20](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=6200) PIO assembly code for IO - ping pong buffers
-* [1:47:30](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=6450) DMA buffer size/alignment limitations / channel chaining
-* [1:50:02](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=6602) Deep dive into the DMA Registers ( around page 99 in the data sheet)
-* [1:55:40](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=6940) pause and resume
-* [2:01:15](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=7275) - Questions:
+* [1:34:10](https://www.youtube.com/watch?v=WS64J3BTBj0&t=5650) Pacing timer story ( 4 timers in hardware )
+* [1:37:40](https://www.youtube.com/watch?v=WS64J3BTBj0&t=5860) 8-bits and 4-bits divisor
+* [1:39:22](https://www.youtube.com/watch?v=WS64J3BTBj0&t=5962) RP2040 requires external crystal - for more accurate frequencies…
+* [1:40:18](https://www.youtube.com/watch?v=WS64J3BTBj0&t=6018)  Plan for I2S
+* [1:41:45](https://www.youtube.com/watch?v=WS64J3BTBj0&t=6105) Pico example and pico extras
+* [1:43:20](https://www.youtube.com/watch?v=WS64J3BTBj0&t=6200) PIO assembly code for IO - ping pong buffers
+* [1:47:30](https://www.youtube.com/watch?v=WS64J3BTBj0&t=6450) DMA buffer size/alignment limitations / channel chaining
+* [1:50:02](https://www.youtube.com/watch?v=WS64J3BTBj0&t=6602) Deep dive into the DMA Registers ( around page 99 in the data sheet)
+* [1:55:40](https://www.youtube.com/watch?v=WS64J3BTBj0&t=6940) pause and resume
+* [2:01:15](https://www.youtube.com/watch?v=WS64J3BTBj0&t=7275) - Questions:
 * DMA and Audio on the RP2040
-* [2:02:11](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=7331) Completely unrelated question. Is there a way to use the USB connection as a USB/CDC serial device with micropython I would assume since the REPL is over the USB this wouldn't work
-* [2:04:08](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=7448) What are the downsides of the rp2040? Compared to samd51 etc.
+* [2:02:11](https://www.youtube.com/watch?v=WS64J3BTBj0&t=7331) Completely unrelated question. Is there a way to use the USB connection as a USB/CDC serial device with micropython I would assume since the REPL is over the USB this wouldn't work
+* [2:04:08](https://www.youtube.com/watch?v=WS64J3BTBj0&t=7448) What are the downsides of the rp2040? Compared to samd51 etc.
 
-* [2:09:46](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=7786) could you inject ramp PIO instructions for the transitions?
-* [2:08:55](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=7735) Can you be a web server in CP ?
-* [2:10:33](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=7833) GPIO 15 story
-* [2:14:56](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=8096) What is best target for CP to do ethernet ?
+* [2:09:46](https://www.youtube.com/watch?v=WS64J3BTBj0&t=7786) could you inject ramp PIO instructions for the transitions?
+* [2:08:55](https://www.youtube.com/watch?v=WS64J3BTBj0&t=7735) Can you be a web server in CP ?
+* [2:10:33](https://www.youtube.com/watch?v=WS64J3BTBj0&t=7833) GPIO 15 story
+* [2:14:56](https://www.youtube.com/watch?v=WS64J3BTBj0&t=8096) What is best target for CP to do ethernet ?
 * Disk partition
-* [2:16:03](https://www.youtube.com/watch?v=VIDEO_2021_01_29&t=8163) Wrap-up
+* [2:16:03](https://www.youtube.com/watch?v=WS64J3BTBj0&t=8163) Wrap-up

--- a/2021/2021-02-05.md
+++ b/2021/2021-02-05.md
@@ -4,7 +4,7 @@
 Hi all, this doc is try and track topics and timecodes for my deep dive stream. These notes will end up in the YouTube video’s description. Any help keeping them groomed as I stream is welcome.
 
 
-07:47 Housekeeping
+[07:47](https://www.youtube.com/watch?v=KjhqMafLHiY&t=467) Housekeeping
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and a lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome. Next week is on Friday.
@@ -14,48 +14,47 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 Plan
 * Questions
 * Audio on RP2040
-* [13:32](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=812) - tiny uft channel created
-* [15:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=900) Scott’s FPGA fantasy:  ( no credit to dcd :-) )
+* [13:32](https://www.youtube.com/watch?v=KjhqMafLHiY&t=812) - tiny uft channel created
+* [15:00](https://www.youtube.com/watch?v=KjhqMafLHiY&t=900) Scott’s FPGA fantasy:  ( no credit to dcd :-) )
 William D Jones Is working on adding Lattice MachXO2 support to the OS FGPA Tools https://twitter.com/cr1901/status/1356042679608606721
-* [15:40](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=940) ​Is UART planned in CircuitPython for the Pico?
-* [18:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=1080) Ryzen discussion ( 5 seconds to build rp2040 build on ASUS ROG Crosshair VIII Hero, while rpi build took minutes )
-* [22:24](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=1344) I tried looking at sleep on the nrf, can you explain the esp32s2 code and where the calls would differ? Also, where do the nrf specific libraries live?
-* [23:49](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=1429) Sleep. Continued
-* [27:28](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=1648) NRF datasheet 5.2.1.1
-* [32:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=1920) NFR power on github
-* [35:27](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=2127) Circuit Python in space satellite - see adafruit blog - https://blog.adafruit.com/2021/02/02/inside-the-v-r3x-space-mission-circuitpython-is-now-in-space-circuitpython-space-maholli404/
-* [38:40](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=2320) Adafruit AR app for RP2040 and iOS
-* [47:24](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=2844) Audio on the Adafruit Feather!
-* [51:20](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=3080) review code.py for audio
-* [52:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=3150) foamyguy streaming tomorrow morning 10am central time
-* [53:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=3180) back to code.py…
-* [53:50](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=3230) Logic analyzer ( Logic 2 )
-* [55:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=3330) PWM output - verified that the code doesn’t work :-)
-* [57:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=3450) Stema Speaker for audio
-* [1:10:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=4230) RP2040 Datasheet for PWM
-* [1:15:08](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=4508) audio_dma.c code
-* [1:17:33](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=4653) Ladyada / mystery guest
-* [1:20:01](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=4801) Arm vs RISCV choice ( Why do you think they went with ARM and not RISCV? )
-* [1:22:26](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=4946) @arturo182 has the same RP2040 Zero sized so you both have one and wait for the chip?
-* [1:23:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=5010) Adding easy for people to add new boards to CP ( RP 2040 might bring the board count to 200 )
-* [1:26:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=5190) Audio algorithm discussion PWM / sine wave
-* [1:28:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=5280) Timers on RP 2040
-* [1:31:50](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=5510) Not enough pins on the “gameboy” thing
-* [1:35:17](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=5717) - Issue #4 - buffering data from the adc…
-* [1:42:02](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=6122) WM 8960  for I2S ( UDA chip discontinued )
-* [1:44:42](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=6282) - goodbye LadyAdy
-* [1:45:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=6300) resync / questions ….
-* [1:48:45](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=6525) X-Ray scans ( also decapped RP 2040 ) https://twitter.com/johndmcmaster/status/1355093011923750912
-* [1:52:40](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=6760) RP 2040 interpolator and divider peripherals
-* [1:54:22](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=6862) Interpolator in the Datasheet 2.3..1 SIO ( under Processor subsystem )
-* [2:00:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=7200) UART from PrimeCell UART (PL011)
-* [2:01:20](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=7280) back to Interpolator
-* [2:03:05](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=7385) back to conversion code in audio_dma.c
-* [2:04:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=7440) RP2040  desired ‘improvements’
-* [2:05:55](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=7555) pioasm complete? Missing features.
-* [2:06:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=7590) github  rp2040_audiopwmio
-* [2:07:29](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=7649) plans for second rp2040 second core
-* [2:10:59](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=7859) wrap up ( mistakes credit to dcd :-) )
-* [2:13:53](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=8033) pet the cat
-* [2:14:36](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=8076) signs off
-*
+* [15:40](https://www.youtube.com/watch?v=KjhqMafLHiY&t=940) ​Is UART planned in CircuitPython for the Pico?
+* [18:00](https://www.youtube.com/watch?v=KjhqMafLHiY&t=1080) Ryzen discussion ( 5 seconds to build rp2040 build on ASUS ROG Crosshair VIII Hero, while rpi build took minutes )
+* [22:24](https://www.youtube.com/watch?v=KjhqMafLHiY&t=1344) I tried looking at sleep on the nrf, can you explain the esp32s2 code and where the calls would differ? Also, where do the nrf specific libraries live?
+* [23:49](https://www.youtube.com/watch?v=KjhqMafLHiY&t=1429) Sleep. Continued
+* [27:28](https://www.youtube.com/watch?v=KjhqMafLHiY&t=1648) NRF datasheet 5.2.1.1
+* [32:00](https://www.youtube.com/watch?v=KjhqMafLHiY&t=1920) NFR power on github
+* [35:27](https://www.youtube.com/watch?v=KjhqMafLHiY&t=2127) Circuit Python in space satellite - see adafruit blog - https://blog.adafruit.com/2021/02/02/inside-the-v-r3x-space-mission-circuitpython-is-now-in-space-circuitpython-space-maholli404/
+* [38:40](https://www.youtube.com/watch?v=KjhqMafLHiY&t=2320) Adafruit AR app for RP2040 and iOS
+* [47:24](https://www.youtube.com/watch?v=KjhqMafLHiY&t=2844) Audio on the Adafruit Feather!
+* [51:20](https://www.youtube.com/watch?v=KjhqMafLHiY&t=3080) review code.py for audio
+* [52:30](https://www.youtube.com/watch?v=KjhqMafLHiY&t=3150) foamyguy streaming tomorrow morning 10am central time
+* [53:00](https://www.youtube.com/watch?v=KjhqMafLHiY&t=3180) back to code.py…
+* [53:50](https://www.youtube.com/watch?v=KjhqMafLHiY&t=3230) Logic analyzer ( Logic 2 )
+* [55:30](https://www.youtube.com/watch?v=KjhqMafLHiY&t=3330) PWM output - verified that the code doesn’t work :-)
+* [57:30](https://www.youtube.com/watch?v=KjhqMafLHiY&t=3450) Stema Speaker for audio
+* [1:10:30](https://www.youtube.com/watch?v=KjhqMafLHiY&t=4230) RP2040 Datasheet for PWM
+* [1:15:08](https://www.youtube.com/watch?v=KjhqMafLHiY&t=4508) audio_dma.c code
+* [1:17:33](https://www.youtube.com/watch?v=KjhqMafLHiY&t=4653) Ladyada / mystery guest
+* [1:20:01](https://www.youtube.com/watch?v=KjhqMafLHiY&t=4801) Arm vs RISCV choice ( Why do you think they went with ARM and not RISCV? )
+* [1:22:26](https://www.youtube.com/watch?v=KjhqMafLHiY&t=4946) @arturo182 has the same RP2040 Zero sized so you both have one and wait for the chip?
+* [1:23:30](https://www.youtube.com/watch?v=KjhqMafLHiY&t=5010) Adding easy for people to add new boards to CP ( RP 2040 might bring the board count to 200 )
+* [1:26:30](https://www.youtube.com/watch?v=KjhqMafLHiY&t=5190) Audio algorithm discussion PWM / sine wave
+* [1:28:00](https://www.youtube.com/watch?v=KjhqMafLHiY&t=5280) Timers on RP 2040
+* [1:31:50](https://www.youtube.com/watch?v=KjhqMafLHiY&t=5510) Not enough pins on the “gameboy” thing
+* [1:35:17](https://www.youtube.com/watch?v=KjhqMafLHiY&t=5717) - Issue #4 - buffering data from the adc…
+* [1:42:02](https://www.youtube.com/watch?v=KjhqMafLHiY&t=6122) WM 8960  for I2S ( UDA chip discontinued )
+* [1:44:42](https://www.youtube.com/watch?v=KjhqMafLHiY&t=6282) - goodbye LadyAdy
+* [1:45:00](https://www.youtube.com/watch?v=KjhqMafLHiY&t=6300) resync / questions ….
+* [1:48:45](https://www.youtube.com/watch?v=KjhqMafLHiY&t=6525) X-Ray scans ( also decapped RP 2040 ) https://twitter.com/johndmcmaster/status/1355093011923750912
+* [1:52:40](https://www.youtube.com/watch?v=KjhqMafLHiY&t=6760) RP 2040 interpolator and divider peripherals
+* [1:54:22](https://www.youtube.com/watch?v=KjhqMafLHiY&t=6862) Interpolator in the Datasheet 2.3..1 SIO ( under Processor subsystem )
+* [2:00:00](https://www.youtube.com/watch?v=KjhqMafLHiY&t=7200) UART from PrimeCell UART (PL011)
+* [2:01:20](https://www.youtube.com/watch?v=KjhqMafLHiY&t=7280) back to Interpolator
+* [2:03:05](https://www.youtube.com/watch?v=KjhqMafLHiY&t=7385) back to conversion code in audio_dma.c
+* [2:04:00](https://www.youtube.com/watch?v=KjhqMafLHiY&t=7440) RP2040  desired ‘improvements’
+* [2:05:55](https://www.youtube.com/watch?v=KjhqMafLHiY&t=7555) pioasm complete? Missing features.
+* [2:06:30](https://www.youtube.com/watch?v=KjhqMafLHiY&t=7590) github  rp2040_audiopwmio
+* [2:07:29](https://www.youtube.com/watch?v=KjhqMafLHiY&t=7649) plans for second rp2040 second core
+* [2:10:59](https://www.youtube.com/watch?v=KjhqMafLHiY&t=7859) wrap up ( mistakes credit to dcd :-) )
+* [2:13:53](https://www.youtube.com/watch?v=KjhqMafLHiY&t=8033) pet the cat
+* [2:14:36](https://www.youtube.com/watch?v=KjhqMafLHiY&t=8076) signs off

--- a/2021/2021-02-05.md
+++ b/2021/2021-02-05.md
@@ -14,48 +14,48 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 Plan
 * Questions
 * Audio on RP2040
-* 13:32 - tiny uft channel created
-* 15:00 Scott’s FPGA fantasy:  ( no credit to dcd :-) )
+* [13:32](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=812) - tiny uft channel created
+* [15:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=900) Scott’s FPGA fantasy:  ( no credit to dcd :-) )
 William D Jones Is working on adding Lattice MachXO2 support to the OS FGPA Tools https://twitter.com/cr1901/status/1356042679608606721
-* 15:40 ​Is UART planned in CircuitPython for the Pico?
-* 18:00 Ryzen discussion ( 5 seconds to build rp2040 build on ASUS ROG Crosshair VIII Hero, while rpi build took minutes )
-* 22:24 I tried looking at sleep on the nrf, can you explain the esp32s2 code and where the calls would differ? Also, where do the nrf specific libraries live?
-* 23:49 Sleep. Continued 
-* 27:28 NRF datasheet 5.2.1.1 
-* 32:00 NFR power on github
-* 35:27 Circuit Python in space satellite - see adafruit blog - https://blog.adafruit.com/2021/02/02/inside-the-v-r3x-space-mission-circuitpython-is-now-in-space-circuitpython-space-maholli404/
-* 38:40 Adafruit AR app for RP2040 and iOS
-* 47:24 Audio on the Adafruit Feather!  
-* 51:20 review code.py for audio
-* 52:30 foamyguy streaming tomorrow morning 10am central time
-* 53:00 back to code.py…
-* 53:50 Logic analyzer ( Logic 2 )
-* 55:30 PWM output - verified that the code doesn’t work :-)
-* 57:30 Stema Speaker for audio
-* 1:10:30 RP2040 Datasheet for PWM
-* 1:15:08 audio_dma.c code
-* 1:17:33 Ladyada / mystery guest
-* 1:20:01 Arm vs RISCV choice ( Why do you think they went with ARM and not RISCV? )
-* 1:22:26 @arturo182 has the same RP2040 Zero sized so you both have one and wait for the chip?
-* 1:23:30 Adding easy for people to add new boards to CP ( RP 2040 might bring the board count to 200 )
-* 1:26:30 Audio algorithm discussion PWM / sine wave
-* 1:28:00 Timers on RP 2040
-* 1:31:50 Not enough pins on the “gameboy” thing 
-* 1:35:17 - Issue #4 - buffering data from the adc…
-* 1:42:02 WM 8960  for I2S ( UDA chip discontinued )
-* 1:44:42 - goodbye LadyAdy
-* 1:45:00 resync / questions ….
-* 1:48:45 X-Ray scans ( also decapped RP 2040 ) https://twitter.com/johndmcmaster/status/1355093011923750912
-* 1:52:40 RP 2040 interpolator and divider peripherals
-* 1:54:22 Interpolator in the Datasheet 2.3..1 SIO ( under Processor subsystem )
-* 2:00:00 UART from PrimeCell UART (PL011)
-* 2:01:20 back to Interpolator 
-* 2:03:05 back to conversion code in audio_dma.c
-* 2:04:00 RP2040  desired ‘improvements’
-* 2:05:55 pioasm complete? Missing features.
-* 2:06:30 github  rp2040_audiopwmio
-* 2:07:29 plans for second rp2040 second core
-* 2:10:59 wrap up ( mistakes credit to dcd :-) )
-* 2:13:53 pet the cat
-* 2:14:36 signs off
+* [15:40](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=940) ​Is UART planned in CircuitPython for the Pico?
+* [18:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=1080) Ryzen discussion ( 5 seconds to build rp2040 build on ASUS ROG Crosshair VIII Hero, while rpi build took minutes )
+* [22:24](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=1344) I tried looking at sleep on the nrf, can you explain the esp32s2 code and where the calls would differ? Also, where do the nrf specific libraries live?
+* [23:49](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=1429) Sleep. Continued
+* [27:28](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=1648) NRF datasheet 5.2.1.1
+* [32:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=1920) NFR power on github
+* [35:27](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=2127) Circuit Python in space satellite - see adafruit blog - https://blog.adafruit.com/2021/02/02/inside-the-v-r3x-space-mission-circuitpython-is-now-in-space-circuitpython-space-maholli404/
+* [38:40](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=2320) Adafruit AR app for RP2040 and iOS
+* [47:24](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=2844) Audio on the Adafruit Feather!
+* [51:20](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=3080) review code.py for audio
+* [52:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=3150) foamyguy streaming tomorrow morning 10am central time
+* [53:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=3180) back to code.py…
+* [53:50](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=3230) Logic analyzer ( Logic 2 )
+* [55:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=3330) PWM output - verified that the code doesn’t work :-)
+* [57:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=3450) Stema Speaker for audio
+* [1:10:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=4230) RP2040 Datasheet for PWM
+* [1:15:08](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=4508) audio_dma.c code
+* [1:17:33](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=4653) Ladyada / mystery guest
+* [1:20:01](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=4801) Arm vs RISCV choice ( Why do you think they went with ARM and not RISCV? )
+* [1:22:26](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=4946) @arturo182 has the same RP2040 Zero sized so you both have one and wait for the chip?
+* [1:23:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=5010) Adding easy for people to add new boards to CP ( RP 2040 might bring the board count to 200 )
+* [1:26:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=5190) Audio algorithm discussion PWM / sine wave
+* [1:28:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=5280) Timers on RP 2040
+* [1:31:50](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=5510) Not enough pins on the “gameboy” thing
+* [1:35:17](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=5717) - Issue #4 - buffering data from the adc…
+* [1:42:02](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=6122) WM 8960  for I2S ( UDA chip discontinued )
+* [1:44:42](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=6282) - goodbye LadyAdy
+* [1:45:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=6300) resync / questions ….
+* [1:48:45](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=6525) X-Ray scans ( also decapped RP 2040 ) https://twitter.com/johndmcmaster/status/1355093011923750912
+* [1:52:40](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=6760) RP 2040 interpolator and divider peripherals
+* [1:54:22](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=6862) Interpolator in the Datasheet 2.3..1 SIO ( under Processor subsystem )
+* [2:00:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=7200) UART from PrimeCell UART (PL011)
+* [2:01:20](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=7280) back to Interpolator
+* [2:03:05](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=7385) back to conversion code in audio_dma.c
+* [2:04:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=7440) RP2040  desired ‘improvements’
+* [2:05:55](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=7555) pioasm complete? Missing features.
+* [2:06:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=7590) github  rp2040_audiopwmio
+* [2:07:29](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=7649) plans for second rp2040 second core
+* [2:10:59](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=7859) wrap up ( mistakes credit to dcd :-) )
+* [2:13:53](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=8033) pet the cat
+* [2:14:36](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=8076) signs off
 *

--- a/2021/2021-02-05.md
+++ b/2021/2021-02-05.md
@@ -14,48 +14,48 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 Plan
 * Questions
 * Audio on RP2040
-* [13:32](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=812) - tiny uft channel created
-* [15:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=900) Scott’s FPGA fantasy:  ( no credit to dcd :-) )
+* [13:32](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=812) - tiny uft channel created
+* [15:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=900) Scott’s FPGA fantasy:  ( no credit to dcd :-) )
 William D Jones Is working on adding Lattice MachXO2 support to the OS FGPA Tools https://twitter.com/cr1901/status/1356042679608606721
-* [15:40](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=940) ​Is UART planned in CircuitPython for the Pico?
-* [18:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=1080) Ryzen discussion ( 5 seconds to build rp2040 build on ASUS ROG Crosshair VIII Hero, while rpi build took minutes )
-* [22:24](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=1344) I tried looking at sleep on the nrf, can you explain the esp32s2 code and where the calls would differ? Also, where do the nrf specific libraries live?
-* [23:49](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=1429) Sleep. Continued
-* [27:28](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=1648) NRF datasheet 5.2.1.1
-* [32:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=1920) NFR power on github
-* [35:27](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=2127) Circuit Python in space satellite - see adafruit blog - https://blog.adafruit.com/2021/02/02/inside-the-v-r3x-space-mission-circuitpython-is-now-in-space-circuitpython-space-maholli404/
-* [38:40](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=2320) Adafruit AR app for RP2040 and iOS
-* [47:24](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=2844) Audio on the Adafruit Feather!
-* [51:20](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=3080) review code.py for audio
-* [52:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=3150) foamyguy streaming tomorrow morning 10am central time
-* [53:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=3180) back to code.py…
-* [53:50](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=3230) Logic analyzer ( Logic 2 )
-* [55:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=3330) PWM output - verified that the code doesn’t work :-)
-* [57:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=3450) Stema Speaker for audio
-* [1:10:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=4230) RP2040 Datasheet for PWM
-* [1:15:08](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=4508) audio_dma.c code
-* [1:17:33](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=4653) Ladyada / mystery guest
-* [1:20:01](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=4801) Arm vs RISCV choice ( Why do you think they went with ARM and not RISCV? )
-* [1:22:26](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=4946) @arturo182 has the same RP2040 Zero sized so you both have one and wait for the chip?
-* [1:23:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=5010) Adding easy for people to add new boards to CP ( RP 2040 might bring the board count to 200 )
-* [1:26:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=5190) Audio algorithm discussion PWM / sine wave
-* [1:28:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=5280) Timers on RP 2040
-* [1:31:50](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=5510) Not enough pins on the “gameboy” thing
-* [1:35:17](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=5717) - Issue #4 - buffering data from the adc…
-* [1:42:02](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=6122) WM 8960  for I2S ( UDA chip discontinued )
-* [1:44:42](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=6282) - goodbye LadyAdy
-* [1:45:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=6300) resync / questions ….
-* [1:48:45](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=6525) X-Ray scans ( also decapped RP 2040 ) https://twitter.com/johndmcmaster/status/1355093011923750912
-* [1:52:40](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=6760) RP 2040 interpolator and divider peripherals
-* [1:54:22](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=6862) Interpolator in the Datasheet 2.3..1 SIO ( under Processor subsystem )
-* [2:00:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=7200) UART from PrimeCell UART (PL011)
-* [2:01:20](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=7280) back to Interpolator
-* [2:03:05](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=7385) back to conversion code in audio_dma.c
-* [2:04:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=7440) RP2040  desired ‘improvements’
-* [2:05:55](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=7555) pioasm complete? Missing features.
-* [2:06:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=7590) github  rp2040_audiopwmio
-* [2:07:29](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=7649) plans for second rp2040 second core
-* [2:10:59](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=7859) wrap up ( mistakes credit to dcd :-) )
-* [2:13:53](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=8033) pet the cat
-* [2:14:36](https://www.youtube.com/watch?v=VIDEO_2021_02_05?t=8076) signs off
+* [15:40](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=940) ​Is UART planned in CircuitPython for the Pico?
+* [18:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=1080) Ryzen discussion ( 5 seconds to build rp2040 build on ASUS ROG Crosshair VIII Hero, while rpi build took minutes )
+* [22:24](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=1344) I tried looking at sleep on the nrf, can you explain the esp32s2 code and where the calls would differ? Also, where do the nrf specific libraries live?
+* [23:49](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=1429) Sleep. Continued
+* [27:28](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=1648) NRF datasheet 5.2.1.1
+* [32:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=1920) NFR power on github
+* [35:27](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=2127) Circuit Python in space satellite - see adafruit blog - https://blog.adafruit.com/2021/02/02/inside-the-v-r3x-space-mission-circuitpython-is-now-in-space-circuitpython-space-maholli404/
+* [38:40](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=2320) Adafruit AR app for RP2040 and iOS
+* [47:24](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=2844) Audio on the Adafruit Feather!
+* [51:20](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=3080) review code.py for audio
+* [52:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=3150) foamyguy streaming tomorrow morning 10am central time
+* [53:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=3180) back to code.py…
+* [53:50](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=3230) Logic analyzer ( Logic 2 )
+* [55:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=3330) PWM output - verified that the code doesn’t work :-)
+* [57:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=3450) Stema Speaker for audio
+* [1:10:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=4230) RP2040 Datasheet for PWM
+* [1:15:08](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=4508) audio_dma.c code
+* [1:17:33](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=4653) Ladyada / mystery guest
+* [1:20:01](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=4801) Arm vs RISCV choice ( Why do you think they went with ARM and not RISCV? )
+* [1:22:26](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=4946) @arturo182 has the same RP2040 Zero sized so you both have one and wait for the chip?
+* [1:23:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=5010) Adding easy for people to add new boards to CP ( RP 2040 might bring the board count to 200 )
+* [1:26:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=5190) Audio algorithm discussion PWM / sine wave
+* [1:28:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=5280) Timers on RP 2040
+* [1:31:50](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=5510) Not enough pins on the “gameboy” thing
+* [1:35:17](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=5717) - Issue #4 - buffering data from the adc…
+* [1:42:02](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=6122) WM 8960  for I2S ( UDA chip discontinued )
+* [1:44:42](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=6282) - goodbye LadyAdy
+* [1:45:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=6300) resync / questions ….
+* [1:48:45](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=6525) X-Ray scans ( also decapped RP 2040 ) https://twitter.com/johndmcmaster/status/1355093011923750912
+* [1:52:40](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=6760) RP 2040 interpolator and divider peripherals
+* [1:54:22](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=6862) Interpolator in the Datasheet 2.3..1 SIO ( under Processor subsystem )
+* [2:00:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=7200) UART from PrimeCell UART (PL011)
+* [2:01:20](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=7280) back to Interpolator
+* [2:03:05](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=7385) back to conversion code in audio_dma.c
+* [2:04:00](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=7440) RP2040  desired ‘improvements’
+* [2:05:55](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=7555) pioasm complete? Missing features.
+* [2:06:30](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=7590) github  rp2040_audiopwmio
+* [2:07:29](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=7649) plans for second rp2040 second core
+* [2:10:59](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=7859) wrap up ( mistakes credit to dcd :-) )
+* [2:13:53](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=8033) pet the cat
+* [2:14:36](https://www.youtube.com/watch?v=VIDEO_2021_02_05&t=8076) signs off
 *

--- a/2021/2021-02-12.md
+++ b/2021/2021-02-12.md
@@ -14,53 +14,53 @@ Housekeeping
 
 Plan
 * Questions
-* [10:05](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=605) ​Pi pico have wifi?  ( see adafruit airlift )
-* [10:48](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=648) when is qt-py and feather 2040 going to be released?
-* [12:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=720) what's the advantage/disadvantage of using a pico over an arduino
-* [13:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=820) ​Pico Vs esp32 is more interesting battle
-* [13:52](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=832) Scott - Have you seen the LVGL graphics library? They have micropython support.
-* [16:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1010) is it fair to say that unlike raspberry pi, you always have a graceful shutdown with unexpected power loss in CP ?
-* [17:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1060) do we need chip documentation when we have circuitpython ?
-* [18:30](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1110) ​Can I implement a high speed counter in PIO? Cycle accurate at 50Mhz would be fantastic and could replace hardware or fpga currently required in our lab
-* [21:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1260) LGVL editor video https://www.youtube.com/watch?v=UrSkzbuuGaw&ab_channel=LVGL
-* [22:25](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1345) LGVL summary …
-* [23:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1380) What will be the audio frequency resolution and accuracy for example generate a 167.9 Hz tone in Pico?
-* [14:15](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=855) Where does thorny store libs in micropython?
-* [14:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=890) i talked to a guy who was buying a pico in line at a microcenter. he mentioned he was making a 3d printed robot called pypot or poppy... anybody heard of that?
-* [25:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1540) - demo of adafruit proximity sensor on trackball
-* [30:17](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1817) ESP32-C3 risc-v
-* [32:29](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1949) CP potential of ESP32-C3
-* [34:13](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=2053) If we get BLE workflow, then would the old ESP32 interesting again for CP?
-* [34:52](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=2092) Would it be easier to use a different RISC-V dev board for porting CP?
-* [37:27](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=2247) ble would open so many doors... accessibility to folks with just a phone etc
-* [38:35](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=2315) Once the S3 is out, no point trying to support the previous version.
-* [39:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=2380) Could the AirLift co-pro become the main proc???
-* [40:36](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=2436) RP2040 audio demo
-* [47:45](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=2865) still need to figure out what those people doing Matrix (Hub75) over I2S are doing and why it make sense to them. Do they make a "sound" picture and run in loop?
-* [48:25](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=2905) continued audio I2S deep dive/introduction
-* [50:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=3000) but maybe you don't want to 'hold' the speaker in a single position for a long time?
+* [10:05](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=605) ​Pi pico have wifi?  ( see adafruit airlift )
+* [10:48](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=648) when is qt-py and feather 2040 going to be released?
+* [12:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=720) what's the advantage/disadvantage of using a pico over an arduino
+* [13:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=820) ​Pico Vs esp32 is more interesting battle
+* [13:52](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=832) Scott - Have you seen the LVGL graphics library? They have micropython support.
+* [16:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1010) is it fair to say that unlike raspberry pi, you always have a graceful shutdown with unexpected power loss in CP ?
+* [17:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1060) do we need chip documentation when we have circuitpython ?
+* [18:30](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1110) ​Can I implement a high speed counter in PIO? Cycle accurate at 50Mhz would be fantastic and could replace hardware or fpga currently required in our lab
+* [21:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1260) LGVL editor video https://www.youtube.com/watch?v=UrSkzbuuGaw&ab_channel=LVGL
+* [22:25](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1345) LGVL summary …
+* [23:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1380) What will be the audio frequency resolution and accuracy for example generate a 167.9 Hz tone in Pico?
+* [14:15](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=855) Where does thorny store libs in micropython?
+* [14:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=890) i talked to a guy who was buying a pico in line at a microcenter. he mentioned he was making a 3d printed robot called pypot or poppy... anybody heard of that?
+* [25:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1540) - demo of adafruit proximity sensor on trackball
+* [30:17](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1817) ESP32-C3 risc-v
+* [32:29](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1949) CP potential of ESP32-C3
+* [34:13](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=2053) If we get BLE workflow, then would the old ESP32 interesting again for CP?
+* [34:52](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=2092) Would it be easier to use a different RISC-V dev board for porting CP?
+* [37:27](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=2247) ble would open so many doors... accessibility to folks with just a phone etc
+* [38:35](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=2315) Once the S3 is out, no point trying to support the previous version.
+* [39:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=2380) Could the AirLift co-pro become the main proc???
+* [40:36](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=2436) RP2040 audio demo
+* [47:45](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=2865) still need to figure out what those people doing Matrix (Hub75) over I2S are doing and why it make sense to them. Do they make a "sound" picture and run in loop?
+* [48:25](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=2905) continued audio I2S deep dive/introduction
+* [50:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=3000) but maybe you don't want to 'hold' the speaker in a single position for a long time?
 … You will get a slight pop if you suddenly go to repeating values, but it's nowhere near as bad as stopping BCLK!
-* [50:47](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=3047) back to code.py and pioasm code
-* [1:08:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=4130) ladyada pings…. Not yet
-* [1:10:30](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=4230) resume - run logic program
-* [1:12:04](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=4324) ladyada on screen
-* [1:14:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=4440) QT PY 2040
-* [1:36:28](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=5788) back to questions…
-* [1:38:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=5880) New to all of this. Is pico a good place to start? Do you have a kit that includes all things to work through the pico book?
-* [1:39:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=5980) - invest in adafruit - “buy stuff” :-)
-* [1:40:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=6050) smart things to use 2 I2Cs
-* [1:41:30](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=6090) there is a micropython on pico book
-* [1:42:09](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=6129) Pico “too new?”
-* [1:42:45](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=6165) do you have any idea why the i2c might be really slow on Blinka devices (ft232 or mcp221)...?
-* [1:49:34](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=6574) QT-Py 2040 Midy synth
-* [1:49:48](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=6588) UF2 boot loader for QT-Py M0
-* [1:51:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=6710) back to audio
-* [1:54:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=6840) fix the compile errors :-)2:
-* [2:04:05](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=7445) No such things as default arguments in C - ( fix the missing argument )
+* [50:47](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=3047) back to code.py and pioasm code
+* [1:08:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=4130) ladyada pings…. Not yet
+* [1:10:30](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=4230) resume - run logic program
+* [1:12:04](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=4324) ladyada on screen
+* [1:14:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=4440) QT PY 2040
+* [1:36:28](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=5788) back to questions…
+* [1:38:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=5880) New to all of this. Is pico a good place to start? Do you have a kit that includes all things to work through the pico book?
+* [1:39:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=5980) - invest in adafruit - “buy stuff” :-)
+* [1:40:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=6050) smart things to use 2 I2Cs
+* [1:41:30](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=6090) there is a micropython on pico book
+* [1:42:09](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=6129) Pico “too new?”
+* [1:42:45](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=6165) do you have any idea why the i2c might be really slow on Blinka devices (ft232 or mcp221)...?
+* [1:49:34](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=6574) QT-Py 2040 Midy synth
+* [1:49:48](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=6588) UF2 boot loader for QT-Py M0
+* [1:51:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=6710) back to audio
+* [1:54:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=6840) fix the compile errors :-)2:
+* [2:04:05](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=7445) No such things as default arguments in C - ( fix the missing argument )
 * 2:-09:00 editing code.py - adding audio
-* [2:12:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=7960) hung- eject - reset
-* [2:28:18](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=8898) wrap up
-* [2:30:37](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=9037) pet the cat
+* [2:12:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=7960) hung- eject - reset
+* [2:28:18](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=8898) wrap up
+* [2:30:37](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=9037) pet the cat
 *
 * Play bleeps with PWM audio
 * I2S debugging

--- a/2021/2021-02-12.md
+++ b/2021/2021-02-12.md
@@ -14,54 +14,54 @@ Housekeeping
 
 Plan
 * Questions
-* 10:05 ​Pi pico have wifi?  ( see adafruit airlift )
-* 10:48 when is qt-py and feather 2040 going to be released?
-* 12:00 what's the advantage/disadvantage of using a pico over an arduino 
-* 13:40 ​Pico Vs esp32 is more interesting battle
-* 13:52 Scott - Have you seen the LVGL graphics library? They have micropython support.
-* 16:50 is it fair to say that unlike raspberry pi, you always have a graceful shutdown with unexpected power loss in CP ?
-* 17:40 do we need chip documentation when we have circuitpython ?
-* 18:30 ​Can I implement a high speed counter in PIO? Cycle accurate at 50Mhz would be fantastic and could replace hardware or fpga currently required in our lab
-* 21:00 LGVL editor video https://www.youtube.com/watch?v=UrSkzbuuGaw&ab_channel=LVGL
-* 22:25 LGVL summary …
-* 23:00 What will be the audio frequency resolution and accuracy for example generate a 167.9 Hz tone in Pico?
-* 14:15 Where does thorny store libs in micropython?
-* 14:50 i talked to a guy who was buying a pico in line at a microcenter. he mentioned he was making a 3d printed robot called pypot or poppy... anybody heard of that?
-* 25:40 - demo of adafruit proximity sensor on trackball
-* 30:17 ESP32-C3 risc-v
-* 32:29 CP potential of ESP32-C3 
-* 34:13 If we get BLE workflow, then would the old ESP32 interesting again for CP?
-* 34:52 Would it be easier to use a different RISC-V dev board for porting CP?
-* 37:27 ble would open so many doors... accessibility to folks with just a phone etc
-* 38:35 Once the S3 is out, no point trying to support the previous version.
-* 39:40 Could the AirLift co-pro become the main proc???
-* 40:36 RP2040 audio demo
-* 47:45 still need to figure out what those people doing Matrix (Hub75) over I2S are doing and why it make sense to them. Do they make a "sound" picture and run in loop?
-* 48:25 continued audio I2S deep dive/introduction
-* 50:00 but maybe you don't want to 'hold' the speaker in a single position for a long time?
+* [10:05](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=605) ​Pi pico have wifi?  ( see adafruit airlift )
+* [10:48](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=648) when is qt-py and feather 2040 going to be released?
+* [12:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=720) what's the advantage/disadvantage of using a pico over an arduino
+* [13:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=820) ​Pico Vs esp32 is more interesting battle
+* [13:52](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=832) Scott - Have you seen the LVGL graphics library? They have micropython support.
+* [16:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1010) is it fair to say that unlike raspberry pi, you always have a graceful shutdown with unexpected power loss in CP ?
+* [17:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1060) do we need chip documentation when we have circuitpython ?
+* [18:30](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1110) ​Can I implement a high speed counter in PIO? Cycle accurate at 50Mhz would be fantastic and could replace hardware or fpga currently required in our lab
+* [21:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1260) LGVL editor video https://www.youtube.com/watch?v=UrSkzbuuGaw&ab_channel=LVGL
+* [22:25](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1345) LGVL summary …
+* [23:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1380) What will be the audio frequency resolution and accuracy for example generate a 167.9 Hz tone in Pico?
+* [14:15](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=855) Where does thorny store libs in micropython?
+* [14:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=890) i talked to a guy who was buying a pico in line at a microcenter. he mentioned he was making a 3d printed robot called pypot or poppy... anybody heard of that?
+* [25:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1540) - demo of adafruit proximity sensor on trackball
+* [30:17](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1817) ESP32-C3 risc-v
+* [32:29](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=1949) CP potential of ESP32-C3
+* [34:13](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=2053) If we get BLE workflow, then would the old ESP32 interesting again for CP?
+* [34:52](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=2092) Would it be easier to use a different RISC-V dev board for porting CP?
+* [37:27](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=2247) ble would open so many doors... accessibility to folks with just a phone etc
+* [38:35](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=2315) Once the S3 is out, no point trying to support the previous version.
+* [39:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=2380) Could the AirLift co-pro become the main proc???
+* [40:36](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=2436) RP2040 audio demo
+* [47:45](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=2865) still need to figure out what those people doing Matrix (Hub75) over I2S are doing and why it make sense to them. Do they make a "sound" picture and run in loop?
+* [48:25](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=2905) continued audio I2S deep dive/introduction
+* [50:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=3000) but maybe you don't want to 'hold' the speaker in a single position for a long time?
 … You will get a slight pop if you suddenly go to repeating values, but it's nowhere near as bad as stopping BCLK!
-* 50:47 back to code.py and pioasm code
-* 1:08:50 ladyada pings…. Not yet
-* 1:10:30 resume - run logic program 
-* 1:12:04 ladyada on screen
-* 1:14:00 QT PY 2040 
-* 1:36:28 back to questions…
-* 1:38:00 New to all of this. Is pico a good place to start? Do you have a kit that includes all things to work through the pico book?
-* 1:39:40 - invest in adafruit - “buy stuff” :-)
-* 1:40:50 smart things to use 2 I2Cs
-* 1:41:30 there is a micropython on pico book
-* 1:42:09 Pico “too new?” 
-* 1:42:45 do you have any idea why the i2c might be really slow on Blinka devices (ft232 or mcp221)...?
-* 1:49:34 QT-Py 2040 Midy synth
-* 1:49:48 UF2 boot loader for QT-Py M0
-* 1:51:50 back to audio 
-* 1:54:00 fix the compile errors :-)2:
-* 2:04:05 No such things as default arguments in C - ( fix the missing argument )
+* [50:47](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=3047) back to code.py and pioasm code
+* [1:08:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=4130) ladyada pings…. Not yet
+* [1:10:30](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=4230) resume - run logic program
+* [1:12:04](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=4324) ladyada on screen
+* [1:14:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=4440) QT PY 2040
+* [1:36:28](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=5788) back to questions…
+* [1:38:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=5880) New to all of this. Is pico a good place to start? Do you have a kit that includes all things to work through the pico book?
+* [1:39:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=5980) - invest in adafruit - “buy stuff” :-)
+* [1:40:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=6050) smart things to use 2 I2Cs
+* [1:41:30](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=6090) there is a micropython on pico book
+* [1:42:09](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=6129) Pico “too new?”
+* [1:42:45](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=6165) do you have any idea why the i2c might be really slow on Blinka devices (ft232 or mcp221)...?
+* [1:49:34](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=6574) QT-Py 2040 Midy synth
+* [1:49:48](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=6588) UF2 boot loader for QT-Py M0
+* [1:51:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=6710) back to audio
+* [1:54:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=6840) fix the compile errors :-)2:
+* [2:04:05](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=7445) No such things as default arguments in C - ( fix the missing argument )
 * 2:-09:00 editing code.py - adding audio
-* 2:12:40 hung- eject - reset
-* 2:28:18 wrap up
-* 2:30:37 pet the cat
-* 
+* [2:12:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=7960) hung- eject - reset
+* [2:28:18](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=8898) wrap up
+* [2:30:37](https://www.youtube.com/watch?v=VIDEO_2021_02_12?t=9037) pet the cat
+*
 * Play bleeps with PWM audio
 * I2S debugging
 * Maybe ladyada again to show something off.

--- a/2021/2021-02-12.md
+++ b/2021/2021-02-12.md
@@ -4,7 +4,7 @@
 Hi all, this doc is try and track topics and timecodes for my deep dive stream. These notes will end up in the YouTube video’s description. Any help keeping them groomed as I stream is welcome.
 
 
-10:19
+[10:19](https://www.youtube.com/watch?v=5UKr0fT51ro&t=619)
 Housekeeping
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
@@ -14,53 +14,53 @@ Housekeeping
 
 Plan
 * Questions
-* [10:05](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=605) ​Pi pico have wifi?  ( see adafruit airlift )
-* [10:48](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=648) when is qt-py and feather 2040 going to be released?
-* [12:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=720) what's the advantage/disadvantage of using a pico over an arduino
-* [13:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=820) ​Pico Vs esp32 is more interesting battle
-* [13:52](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=832) Scott - Have you seen the LVGL graphics library? They have micropython support.
-* [16:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1010) is it fair to say that unlike raspberry pi, you always have a graceful shutdown with unexpected power loss in CP ?
-* [17:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1060) do we need chip documentation when we have circuitpython ?
-* [18:30](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1110) ​Can I implement a high speed counter in PIO? Cycle accurate at 50Mhz would be fantastic and could replace hardware or fpga currently required in our lab
-* [21:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1260) LGVL editor video https://www.youtube.com/watch?v=UrSkzbuuGaw&ab_channel=LVGL
-* [22:25](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1345) LGVL summary …
-* [23:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1380) What will be the audio frequency resolution and accuracy for example generate a 167.9 Hz tone in Pico?
-* [14:15](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=855) Where does thorny store libs in micropython?
-* [14:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=890) i talked to a guy who was buying a pico in line at a microcenter. he mentioned he was making a 3d printed robot called pypot or poppy... anybody heard of that?
-* [25:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1540) - demo of adafruit proximity sensor on trackball
-* [30:17](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1817) ESP32-C3 risc-v
-* [32:29](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=1949) CP potential of ESP32-C3
-* [34:13](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=2053) If we get BLE workflow, then would the old ESP32 interesting again for CP?
-* [34:52](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=2092) Would it be easier to use a different RISC-V dev board for porting CP?
-* [37:27](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=2247) ble would open so many doors... accessibility to folks with just a phone etc
-* [38:35](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=2315) Once the S3 is out, no point trying to support the previous version.
-* [39:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=2380) Could the AirLift co-pro become the main proc???
-* [40:36](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=2436) RP2040 audio demo
-* [47:45](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=2865) still need to figure out what those people doing Matrix (Hub75) over I2S are doing and why it make sense to them. Do they make a "sound" picture and run in loop?
-* [48:25](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=2905) continued audio I2S deep dive/introduction
-* [50:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=3000) but maybe you don't want to 'hold' the speaker in a single position for a long time?
+* [10:05](https://www.youtube.com/watch?v=5UKr0fT51ro&t=605) ​Pi pico have wifi?  ( see adafruit airlift )
+* [10:48](https://www.youtube.com/watch?v=5UKr0fT51ro&t=648) when is qt-py and feather 2040 going to be released?
+* [12:00](https://www.youtube.com/watch?v=5UKr0fT51ro&t=720) what's the advantage/disadvantage of using a pico over an arduino
+* [13:40](https://www.youtube.com/watch?v=5UKr0fT51ro&t=820) ​Pico Vs esp32 is more interesting battle
+* [13:52](https://www.youtube.com/watch?v=5UKr0fT51ro&t=832) Scott - Have you seen the LVGL graphics library? They have micropython support.
+* [16:50](https://www.youtube.com/watch?v=5UKr0fT51ro&t=1010) is it fair to say that unlike raspberry pi, you always have a graceful shutdown with unexpected power loss in CP ?
+* [17:40](https://www.youtube.com/watch?v=5UKr0fT51ro&t=1060) do we need chip documentation when we have circuitpython ?
+* [18:30](https://www.youtube.com/watch?v=5UKr0fT51ro&t=1110) ​Can I implement a high speed counter in PIO? Cycle accurate at 50Mhz would be fantastic and could replace hardware or fpga currently required in our lab
+* [21:00](https://www.youtube.com/watch?v=5UKr0fT51ro&t=1260) LGVL editor video https://www.youtube.com/watch?v=UrSkzbuuGaw&ab_channel=LVGL
+* [22:25](https://www.youtube.com/watch?v=5UKr0fT51ro&t=1345) LGVL summary …
+* [23:00](https://www.youtube.com/watch?v=5UKr0fT51ro&t=1380) What will be the audio frequency resolution and accuracy for example generate a 167.9 Hz tone in Pico?
+* [14:15](https://www.youtube.com/watch?v=5UKr0fT51ro&t=855) Where does thorny store libs in micropython?
+* [14:50](https://www.youtube.com/watch?v=5UKr0fT51ro&t=890) i talked to a guy who was buying a pico in line at a microcenter. he mentioned he was making a 3d printed robot called pypot or poppy... anybody heard of that?
+* [25:40](https://www.youtube.com/watch?v=5UKr0fT51ro&t=1540) - demo of adafruit proximity sensor on trackball
+* [30:17](https://www.youtube.com/watch?v=5UKr0fT51ro&t=1817) ESP32-C3 risc-v
+* [32:29](https://www.youtube.com/watch?v=5UKr0fT51ro&t=1949) CP potential of ESP32-C3
+* [34:13](https://www.youtube.com/watch?v=5UKr0fT51ro&t=2053) If we get BLE workflow, then would the old ESP32 interesting again for CP?
+* [34:52](https://www.youtube.com/watch?v=5UKr0fT51ro&t=2092) Would it be easier to use a different RISC-V dev board for porting CP?
+* [37:27](https://www.youtube.com/watch?v=5UKr0fT51ro&t=2247) ble would open so many doors... accessibility to folks with just a phone etc
+* [38:35](https://www.youtube.com/watch?v=5UKr0fT51ro&t=2315) Once the S3 is out, no point trying to support the previous version.
+* [39:40](https://www.youtube.com/watch?v=5UKr0fT51ro&t=2380) Could the AirLift co-pro become the main proc???
+* [40:36](https://www.youtube.com/watch?v=5UKr0fT51ro&t=2436) RP2040 audio demo
+* [47:45](https://www.youtube.com/watch?v=5UKr0fT51ro&t=2865) still need to figure out what those people doing Matrix (Hub75) over I2S are doing and why it make sense to them. Do they make a "sound" picture and run in loop?
+* [48:25](https://www.youtube.com/watch?v=5UKr0fT51ro&t=2905) continued audio I2S deep dive/introduction
+* [50:00](https://www.youtube.com/watch?v=5UKr0fT51ro&t=3000) but maybe you don't want to 'hold' the speaker in a single position for a long time?
 … You will get a slight pop if you suddenly go to repeating values, but it's nowhere near as bad as stopping BCLK!
-* [50:47](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=3047) back to code.py and pioasm code
-* [1:08:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=4130) ladyada pings…. Not yet
-* [1:10:30](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=4230) resume - run logic program
-* [1:12:04](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=4324) ladyada on screen
-* [1:14:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=4440) QT PY 2040
-* [1:36:28](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=5788) back to questions…
-* [1:38:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=5880) New to all of this. Is pico a good place to start? Do you have a kit that includes all things to work through the pico book?
-* [1:39:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=5980) - invest in adafruit - “buy stuff” :-)
-* [1:40:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=6050) smart things to use 2 I2Cs
-* [1:41:30](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=6090) there is a micropython on pico book
-* [1:42:09](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=6129) Pico “too new?”
-* [1:42:45](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=6165) do you have any idea why the i2c might be really slow on Blinka devices (ft232 or mcp221)...?
-* [1:49:34](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=6574) QT-Py 2040 Midy synth
-* [1:49:48](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=6588) UF2 boot loader for QT-Py M0
-* [1:51:50](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=6710) back to audio
-* [1:54:00](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=6840) fix the compile errors :-)2:
-* [2:04:05](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=7445) No such things as default arguments in C - ( fix the missing argument )
+* [50:47](https://www.youtube.com/watch?v=5UKr0fT51ro&t=3047) back to code.py and pioasm code
+* [1:08:50](https://www.youtube.com/watch?v=5UKr0fT51ro&t=4130) ladyada pings…. Not yet
+* [1:10:30](https://www.youtube.com/watch?v=5UKr0fT51ro&t=4230) resume - run logic program
+* [1:12:04](https://www.youtube.com/watch?v=5UKr0fT51ro&t=4324) ladyada on screen
+* [1:14:00](https://www.youtube.com/watch?v=5UKr0fT51ro&t=4440) QT PY 2040
+* [1:36:28](https://www.youtube.com/watch?v=5UKr0fT51ro&t=5788) back to questions…
+* [1:38:00](https://www.youtube.com/watch?v=5UKr0fT51ro&t=5880) New to all of this. Is pico a good place to start? Do you have a kit that includes all things to work through the pico book?
+* [1:39:40](https://www.youtube.com/watch?v=5UKr0fT51ro&t=5980) - invest in adafruit - “buy stuff” :-)
+* [1:40:50](https://www.youtube.com/watch?v=5UKr0fT51ro&t=6050) smart things to use 2 I2Cs
+* [1:41:30](https://www.youtube.com/watch?v=5UKr0fT51ro&t=6090) there is a micropython on pico book
+* [1:42:09](https://www.youtube.com/watch?v=5UKr0fT51ro&t=6129) Pico “too new?”
+* [1:42:45](https://www.youtube.com/watch?v=5UKr0fT51ro&t=6165) do you have any idea why the i2c might be really slow on Blinka devices (ft232 or mcp221)...?
+* [1:49:34](https://www.youtube.com/watch?v=5UKr0fT51ro&t=6574) QT-Py 2040 Midy synth
+* [1:49:48](https://www.youtube.com/watch?v=5UKr0fT51ro&t=6588) UF2 boot loader for QT-Py M0
+* [1:51:50](https://www.youtube.com/watch?v=5UKr0fT51ro&t=6710) back to audio
+* [1:54:00](https://www.youtube.com/watch?v=5UKr0fT51ro&t=6840) fix the compile errors :-)2:
+* [2:04:05](https://www.youtube.com/watch?v=5UKr0fT51ro&t=7445) No such things as default arguments in C - ( fix the missing argument )
 * 2:-09:00 editing code.py - adding audio
-* [2:12:40](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=7960) hung- eject - reset
-* [2:28:18](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=8898) wrap up
-* [2:30:37](https://www.youtube.com/watch?v=VIDEO_2021_02_12&t=9037) pet the cat
+* [2:12:40](https://www.youtube.com/watch?v=5UKr0fT51ro&t=7960) hung- eject - reset
+* [2:28:18](https://www.youtube.com/watch?v=5UKr0fT51ro&t=8898) wrap up
+* [2:30:37](https://www.youtube.com/watch?v=5UKr0fT51ro&t=9037) pet the cat
 *
 * Play bleeps with PWM audio
 * I2S debugging

--- a/2021/2021-02-18.md
+++ b/2021/2021-02-18.md
@@ -12,24 +12,24 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* 06:56 Jeff
-* 17:25 Extra UART CDC
-* 23:43 Would MP3 decoding run on the other core?
-* 26:46 by the way I'm not sure I grasped what chips can have the secondary CDC, it looks like the M0, but also the ESP32S2 don't have enough USB endpoints ?
-* 27:34 pico 8 strand neopixel demo
-* 34:43 This is probably not cost effective, but can you replace the shift register with a machXO tiny fpga, and instead of optmizing the code on the side of cpy, just do it on the fpga?
-* 35:09 Hello. what is RP2040?
-* 38:02 So is Limor going to do a board with that shift registor and 8 connector for neopixel strip?
-* 43:03 Can you talk a bit about implementing a high speed counter running in the PIO?
-* 41:11 Need a RP2040 signal analyser to work on PIO and see what I am doing…
-* 49:30 os.urandom
-* 50:40 
-* 1:02:02 
-* 1:22:53 bitops only for RP2040?
-* 1:23:24 Question: would you rather contributors merge their own work (once approved) or if say I do a review of Jeff's code and say yup this is fine, choose to merge it? Or wait for one of the maintainers to do it
-* 1:32:47 bye jeff
-* 1:43:18 Has anyone asked, why did pi develop their own chip?
+* [06:56](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=416) Jeff
+* [17:25](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=1045) Extra UART CDC
+* [23:43](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=1423) Would MP3 decoding run on the other core?
+* [26:46](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=1606) by the way I'm not sure I grasped what chips can have the secondary CDC, it looks like the M0, but also the ESP32S2 don't have enough USB endpoints ?
+* [27:34](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=1654) pico 8 strand neopixel demo
+* [34:43](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=2083) This is probably not cost effective, but can you replace the shift register with a machXO tiny fpga, and instead of optmizing the code on the side of cpy, just do it on the fpga?
+* [35:09](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=2109) Hello. what is RP2040?
+* [38:02](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=2282) So is Limor going to do a board with that shift registor and 8 connector for neopixel strip?
+* [43:03](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=2583) Can you talk a bit about implementing a high speed counter running in the PIO?
+* [41:11](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=2471) Need a RP2040 signal analyser to work on PIO and see what I am doing…
+* [49:30](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=2970) os.urandom
+* [50:40](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=3040)
+* [1:02:02](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=3722)
+* [1:22:53](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=4973) bitops only for RP2040?
+* [1:23:24](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=5004) Question: would you rather contributors merge their own work (once approved) or if say I do a review of Jeff's code and say yup this is fine, choose to merge it? Or wait for one of the maintainers to do it
+* [1:32:47](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=5567) bye jeff
+* [1:43:18](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=6198) Has anyone asked, why did pi develop their own chip?
 * Questions
-* 1:02:06 Re-review jepler’s PR:  https://github.com/adafruit/circuitpython/pull/4219
+* [1:02:06](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=3726) Re-review jepler’s PR:  https://github.com/adafruit/circuitpython/pull/4219
 * Perhaps trying to use JLink to debug PIO problem
-* 1:59:37 wrap up
+* [1:59:37](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=7177) wrap up

--- a/2021/2021-02-18.md
+++ b/2021/2021-02-18.md
@@ -4,7 +4,7 @@
 Hi all, this doc is try and track topics and timecodes for my deep dive stream. These notes will end up in the YouTube video’s description. Any help keeping them groomed as I stream is welcome.
 
 
-04:39 Housekeeping
+[04:39](https://www.youtube.com/watch?v=a9P3U622x6M&t=279) Housekeeping
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome. Next week should be on Friday.
@@ -12,24 +12,24 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* [06:56](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=416) Jeff
-* [17:25](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=1045) Extra UART CDC
-* [23:43](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=1423) Would MP3 decoding run on the other core?
-* [26:46](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=1606) by the way I'm not sure I grasped what chips can have the secondary CDC, it looks like the M0, but also the ESP32S2 don't have enough USB endpoints ?
-* [27:34](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=1654) pico 8 strand neopixel demo
-* [34:43](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=2083) This is probably not cost effective, but can you replace the shift register with a machXO tiny fpga, and instead of optmizing the code on the side of cpy, just do it on the fpga?
-* [35:09](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=2109) Hello. what is RP2040?
-* [38:02](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=2282) So is Limor going to do a board with that shift registor and 8 connector for neopixel strip?
-* [43:03](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=2583) Can you talk a bit about implementing a high speed counter running in the PIO?
-* [41:11](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=2471) Need a RP2040 signal analyser to work on PIO and see what I am doing…
-* [49:30](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=2970) os.urandom
-* [50:40](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=3040)
-* [1:02:02](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=3722)
-* [1:22:53](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=4973) bitops only for RP2040?
-* [1:23:24](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=5004) Question: would you rather contributors merge their own work (once approved) or if say I do a review of Jeff's code and say yup this is fine, choose to merge it? Or wait for one of the maintainers to do it
-* [1:32:47](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=5567) bye jeff
-* [1:43:18](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=6198) Has anyone asked, why did pi develop their own chip?
+* [06:56](https://www.youtube.com/watch?v=a9P3U622x6M&t=416) Jeff
+* [17:25](https://www.youtube.com/watch?v=a9P3U622x6M&t=1045) Extra UART CDC
+* [23:43](https://www.youtube.com/watch?v=a9P3U622x6M&t=1423) Would MP3 decoding run on the other core?
+* [26:46](https://www.youtube.com/watch?v=a9P3U622x6M&t=1606) by the way I'm not sure I grasped what chips can have the secondary CDC, it looks like the M0, but also the ESP32S2 don't have enough USB endpoints ?
+* [27:34](https://www.youtube.com/watch?v=a9P3U622x6M&t=1654) pico 8 strand neopixel demo
+* [34:43](https://www.youtube.com/watch?v=a9P3U622x6M&t=2083) This is probably not cost effective, but can you replace the shift register with a machXO tiny fpga, and instead of optmizing the code on the side of cpy, just do it on the fpga?
+* [35:09](https://www.youtube.com/watch?v=a9P3U622x6M&t=2109) Hello. what is RP2040?
+* [38:02](https://www.youtube.com/watch?v=a9P3U622x6M&t=2282) So is Limor going to do a board with that shift registor and 8 connector for neopixel strip?
+* [43:03](https://www.youtube.com/watch?v=a9P3U622x6M&t=2583) Can you talk a bit about implementing a high speed counter running in the PIO?
+* [41:11](https://www.youtube.com/watch?v=a9P3U622x6M&t=2471) Need a RP2040 signal analyser to work on PIO and see what I am doing…
+* [49:30](https://www.youtube.com/watch?v=a9P3U622x6M&t=2970) os.urandom
+* [50:40](https://www.youtube.com/watch?v=a9P3U622x6M&t=3040)
+* [1:02:02](https://www.youtube.com/watch?v=a9P3U622x6M&t=3722)
+* [1:22:53](https://www.youtube.com/watch?v=a9P3U622x6M&t=4973) bitops only for RP2040?
+* [1:23:24](https://www.youtube.com/watch?v=a9P3U622x6M&t=5004) Question: would you rather contributors merge their own work (once approved) or if say I do a review of Jeff's code and say yup this is fine, choose to merge it? Or wait for one of the maintainers to do it
+* [1:32:47](https://www.youtube.com/watch?v=a9P3U622x6M&t=5567) bye jeff
+* [1:43:18](https://www.youtube.com/watch?v=a9P3U622x6M&t=6198) Has anyone asked, why did pi develop their own chip?
 * Questions
-* [1:02:06](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=3726) Re-review jepler’s PR:  https://github.com/adafruit/circuitpython/pull/4219
+* [1:02:06](https://www.youtube.com/watch?v=a9P3U622x6M&t=3726) Re-review jepler’s PR:  https://github.com/adafruit/circuitpython/pull/4219
 * Perhaps trying to use JLink to debug PIO problem
-* [1:59:37](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=7177) wrap up
+* [1:59:37](https://www.youtube.com/watch?v=a9P3U622x6M&t=7177) wrap up

--- a/2021/2021-02-18.md
+++ b/2021/2021-02-18.md
@@ -12,24 +12,24 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* [06:56](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=416) Jeff
-* [17:25](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=1045) Extra UART CDC
-* [23:43](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=1423) Would MP3 decoding run on the other core?
-* [26:46](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=1606) by the way I'm not sure I grasped what chips can have the secondary CDC, it looks like the M0, but also the ESP32S2 don't have enough USB endpoints ?
-* [27:34](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=1654) pico 8 strand neopixel demo
-* [34:43](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=2083) This is probably not cost effective, but can you replace the shift register with a machXO tiny fpga, and instead of optmizing the code on the side of cpy, just do it on the fpga?
-* [35:09](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=2109) Hello. what is RP2040?
-* [38:02](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=2282) So is Limor going to do a board with that shift registor and 8 connector for neopixel strip?
-* [43:03](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=2583) Can you talk a bit about implementing a high speed counter running in the PIO?
-* [41:11](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=2471) Need a RP2040 signal analyser to work on PIO and see what I am doing…
-* [49:30](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=2970) os.urandom
-* [50:40](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=3040)
-* [1:02:02](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=3722)
-* [1:22:53](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=4973) bitops only for RP2040?
-* [1:23:24](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=5004) Question: would you rather contributors merge their own work (once approved) or if say I do a review of Jeff's code and say yup this is fine, choose to merge it? Or wait for one of the maintainers to do it
-* [1:32:47](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=5567) bye jeff
-* [1:43:18](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=6198) Has anyone asked, why did pi develop their own chip?
+* [06:56](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=416) Jeff
+* [17:25](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=1045) Extra UART CDC
+* [23:43](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=1423) Would MP3 decoding run on the other core?
+* [26:46](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=1606) by the way I'm not sure I grasped what chips can have the secondary CDC, it looks like the M0, but also the ESP32S2 don't have enough USB endpoints ?
+* [27:34](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=1654) pico 8 strand neopixel demo
+* [34:43](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=2083) This is probably not cost effective, but can you replace the shift register with a machXO tiny fpga, and instead of optmizing the code on the side of cpy, just do it on the fpga?
+* [35:09](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=2109) Hello. what is RP2040?
+* [38:02](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=2282) So is Limor going to do a board with that shift registor and 8 connector for neopixel strip?
+* [43:03](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=2583) Can you talk a bit about implementing a high speed counter running in the PIO?
+* [41:11](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=2471) Need a RP2040 signal analyser to work on PIO and see what I am doing…
+* [49:30](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=2970) os.urandom
+* [50:40](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=3040)
+* [1:02:02](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=3722)
+* [1:22:53](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=4973) bitops only for RP2040?
+* [1:23:24](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=5004) Question: would you rather contributors merge their own work (once approved) or if say I do a review of Jeff's code and say yup this is fine, choose to merge it? Or wait for one of the maintainers to do it
+* [1:32:47](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=5567) bye jeff
+* [1:43:18](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=6198) Has anyone asked, why did pi develop their own chip?
 * Questions
-* [1:02:06](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=3726) Re-review jepler’s PR:  https://github.com/adafruit/circuitpython/pull/4219
+* [1:02:06](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=3726) Re-review jepler’s PR:  https://github.com/adafruit/circuitpython/pull/4219
 * Perhaps trying to use JLink to debug PIO problem
-* [1:59:37](https://www.youtube.com/watch?v=VIDEO_2021_02_18?t=7177) wrap up
+* [1:59:37](https://www.youtube.com/watch?v=VIDEO_2021_02_18&t=7177) wrap up

--- a/2021/2021-02-26.md
+++ b/2021/2021-02-26.md
@@ -4,13 +4,12 @@
 Hi all, this doc is try and track topics and timecodes for my deep dive stream. These notes will end up in the YouTube video’s description. Any help keeping them groomed as I stream is welcome.
 
 
-06:29 Housekeeping
+[06:29](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=389) Housekeeping
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Next week will be on Thursday!
 * Typically goes for two hours or more. Questions are welcome.
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After I’ll unmute and continue.
-*
 
 Plan
 * Pimoroni Boards!
@@ -20,81 +19,81 @@ Plan
 
 
 Timecodes
-* [12:17](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=737) will there be a rp2040 board with wifi on it?
-* [13:32](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=812) Would it possible theoretically to have a module that works in the background kind of like rotaryio or gamepad but is responsible for reading touch screen data and queuing it up to return to the foreground coded when requested?
-* [14:45](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=885) any RISC-V port plans for CP (ala ESP32C3 or BeagleV)
-* [17:56](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1076) Is it possible to use an ESP32 board to connect to Wifi?
-* [19:13](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1153) Is there a way of obfuscating code on the device?
-* [20:12](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1212) would it be fair to characterize the pico as a more CP friendly cortex M0 than the SAMD21 boards from adafruit, given the increased RAM and clock speed?
-* [21:18](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1278) blinka on beagleboard considering putting Blinka/CP on BeagleV as GSOC project for BeagleBoard.org
-* [21:38](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1298) video / VGA?
-* [25:54](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1554) Is it possible to use a QSPI PSRAM chip with the RP2040 like is used on the ESP32-WROVER and Teensy 4.1?
-* [28:08](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1688) rp2040 chips sent out to vendors / Pimoroni on CP Downloads
-* [30:14](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1814) CP PR   ( closed )
-* [31:19](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1879) Does Adafruit have any plans for the new dual core asymmetric multiprocessing chips like the STM32H series and the similar chips from Freescale?
-* [32:18](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1938) Is Raspberry Pi releasing just stand alone chips for everyone? Or is this limited to only partner board-makers (like Adafruit)?
-* [33:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2000) pronounce… Pimoroni
-* [33:55](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2035) tuple …
-* [34:13](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2053) Wiznet5k library still requires bus_device library, which moved to core? As in native.
-* [34:33](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2073) "Pimoroni stands for Pirate, Monkey, Robot, Ninja (Pi-Mo-Ro-Ni) and sounds like the name of an expensive Italian lager. It's pronounced Pih-mo-row-kne"
-* [35:12](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2112) Do micropython and Circuit python have the same memory requirements?
-* [36:33](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2193) EN-UK support in CP?
-* [37:05](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2225) recap CP PR’s
-* [37:34](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2254) EN-Pirate ( sommersoft )
-* [37:55](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2275) Secondary USB CDC (serial) channel - bug 231
-* [39:30](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2370) Many people had projects for the second Serial... where are those projects now?
-* [39:49](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2389) Any hope of using a second serial on SAMD21?
-* [40:21](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2421) does the 2nd USB port mean that you can use USB serial while testing Deep Sleep instead of simulating it
-* [41:56](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2516) Bit transpose (jepler)
-* [42:29](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2549) On a side note, newer versions of CPython support breakpoint() instead of having to use import pdb; pdb.set_trace()
-* [44:21](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2661) I2S support  rp2pio pinstate/direction ...
-* [45:31](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2731) ​Scott, did you fix the error messages, or do you still want me to do the PR?
-* [46:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2760) ​I bet your Python linter loves that StateMachine constructor with all those arguments
-* [48:48](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2928) Fix second shared PWM
-* [50:40](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3040) pin changes between Rev A and Rev C in rp2040 feather…
-* [52:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3120) Will you be announcing the availability of Feather2040 in the store during a deep dive again? Worked well for the MagTag!
-* [52:50](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3170) Can CP know the USB host status? i.e. connect to a phone, and it goes to sleep.
-* [54:05](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3245) Next week is Thursday
-* [57:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3420) RP2040 support for UART / merged
-* [57:44](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3464) Can I "link" the second CDC serial to a UART and do USB to Serial with a Pico?
-* [1:01:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3660) Can you demo your workflow fixing spelling mistakes?
-* [1:02:13](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3733)  but does the pico work on arduino IDE yet or will it ever work on it?
-* [1:02:45](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3765) Was there a Mu meeting and will Mu be confused with the second CDC serial?
-* [1:03:55](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3835) typo PR demo
-* [1:05:05](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3905) ( tutorial on how to edit from github )
-* [1:06:23](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3983) I am thinking about building a vt220 dumb terminal for use on my PDP11/23 emulation. … see raspberry pi terminal project site:blog.adafruit.com (pygraphics https://github.com/fbergama/pigfx )
-* [1:08:11](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4091) Aside: I just did some tests with supervisor.runtime.serial_connected and it is True if you are connected to the board's REPL serial port but it is False if the board is connected to USB and doing HID/MIDI/MSD stuff. I cannot find something that says "USB host present"
-* [1:09:13](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4153) adafruit projects learn.adafruit.com
-* [1:10:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4200) Bare metal - meaning…
-* [1:10:33](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4233) ​are there any plans for a visual studio code RP2040 CircuitPython emulator like the Playground express
-* [1:11:19](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4279) - typo fix build caught error - git ‘magic’
-* [1:13:03](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4383) not sure if this was covered yet but with the pico how is the UART work going - I can see good results in the PR - would there be an eta on that?
-* [1:13:04](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4384) Speaking of RTOS - Shawn Hymel from Digi-Key has been working on a Youtube series about developing on an MCU with FreeRTOS
+* [12:17](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=737) will there be a rp2040 board with wifi on it?
+* [13:32](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=812) Would it possible theoretically to have a module that works in the background kind of like rotaryio or gamepad but is responsible for reading touch screen data and queuing it up to return to the foreground coded when requested?
+* [14:45](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=885) any RISC-V port plans for CP (ala ESP32C3 or BeagleV)
+* [17:56](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=1076) Is it possible to use an ESP32 board to connect to Wifi?
+* [19:13](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=1153) Is there a way of obfuscating code on the device?
+* [20:12](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=1212) would it be fair to characterize the pico as a more CP friendly cortex M0 than the SAMD21 boards from adafruit, given the increased RAM and clock speed?
+* [21:18](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=1278) blinka on beagleboard considering putting Blinka/CP on BeagleV as GSOC project for BeagleBoard.org
+* [21:38](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=1298) video / VGA?
+* [25:54](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=1554) Is it possible to use a QSPI PSRAM chip with the RP2040 like is used on the ESP32-WROVER and Teensy 4.1?
+* [28:08](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=1688) rp2040 chips sent out to vendors / Pimoroni on CP Downloads
+* [30:14](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=1814) CP PR   ( closed )
+* [31:19](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=1879) Does Adafruit have any plans for the new dual core asymmetric multiprocessing chips like the STM32H series and the similar chips from Freescale?
+* [32:18](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=1938) Is Raspberry Pi releasing just stand alone chips for everyone? Or is this limited to only partner board-makers (like Adafruit)?
+* [33:20](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2000) pronounce… Pimoroni
+* [33:55](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2035) tuple …
+* [34:13](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2053) Wiznet5k library still requires bus_device library, which moved to core? As in native.
+* [34:33](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2073) "Pimoroni stands for Pirate, Monkey, Robot, Ninja (Pi-Mo-Ro-Ni) and sounds like the name of an expensive Italian lager. It's pronounced Pih-mo-row-kne"
+* [35:12](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2112) Do micropython and Circuit python have the same memory requirements?
+* [36:33](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2193) EN-UK support in CP?
+* [37:05](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2225) recap CP PR’s
+* [37:34](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2254) EN-Pirate ( sommersoft )
+* [37:55](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2275) Secondary USB CDC (serial) channel - bug 231
+* [39:30](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2370) Many people had projects for the second Serial... where are those projects now?
+* [39:49](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2389) Any hope of using a second serial on SAMD21?
+* [40:21](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2421) does the 2nd USB port mean that you can use USB serial while testing Deep Sleep instead of simulating it
+* [41:56](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2516) Bit transpose (jepler)
+* [42:29](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2549) On a side note, newer versions of CPython support breakpoint() instead of having to use import pdb; pdb.set_trace()
+* [44:21](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2661) I2S support  rp2pio pinstate/direction ...
+* [45:31](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2731) ​Scott, did you fix the error messages, or do you still want me to do the PR?
+* [46:00](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2760) ​I bet your Python linter loves that StateMachine constructor with all those arguments
+* [48:48](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=2928) Fix second shared PWM
+* [50:40](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=3040) pin changes between Rev A and Rev C in rp2040 feather…
+* [52:00](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=3120) Will you be announcing the availability of Feather2040 in the store during a deep dive again? Worked well for the MagTag!
+* [52:50](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=3170) Can CP know the USB host status? i.e. connect to a phone, and it goes to sleep.
+* [54:05](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=3245) Next week is Thursday
+* [57:00](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=3420) RP2040 support for UART / merged
+* [57:44](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=3464) Can I "link" the second CDC serial to a UART and do USB to Serial with a Pico?
+* [1:01:00](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=3660) Can you demo your workflow fixing spelling mistakes?
+* [1:02:13](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=3733)  but does the pico work on arduino IDE yet or will it ever work on it?
+* [1:02:45](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=3765) Was there a Mu meeting and will Mu be confused with the second CDC serial?
+* [1:03:55](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=3835) typo PR demo
+* [1:05:05](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=3905) ( tutorial on how to edit from github )
+* [1:06:23](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=3983) I am thinking about building a vt220 dumb terminal for use on my PDP11/23 emulation. … see raspberry pi terminal project site:blog.adafruit.com (pygraphics https://github.com/fbergama/pigfx )
+* [1:08:11](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=4091) Aside: I just did some tests with supervisor.runtime.serial_connected and it is True if you are connected to the board's REPL serial port but it is False if the board is connected to USB and doing HID/MIDI/MSD stuff. I cannot find something that says "USB host present"
+* [1:09:13](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=4153) adafruit projects learn.adafruit.com
+* [1:10:00](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=4200) Bare metal - meaning…
+* [1:10:33](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=4233) ​are there any plans for a visual studio code RP2040 CircuitPython emulator like the Playground express
+* [1:11:19](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=4279) - typo fix build caught error - git ‘magic’
+* [1:13:03](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=4383) not sure if this was covered yet but with the pico how is the UART work going - I can see good results in the PR - would there be an eta on that?
+* [1:13:04](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=4384) Speaking of RTOS - Shawn Hymel from Digi-Key has been working on a Youtube series about developing on an MCU with FreeRTOS
 https://www.youtube.com/watch?v=F321087yYy4&list=PLEBQazB0HUyQ4hAPU1cJED6t3DU0h34bz
-* [1:17:40](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4660) Do you folks do automated unit test using a hardware fixture to emulate devices?…. ( no )
-* [1:20:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4820) We can have a build system/testing session on Discord sometime.
-* [1:22:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4920) bergdahl’s merge request….
-* [1:23:40](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=5020) Ladyada joined…
-* [1:24:42](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=5082) - building the tester for the feather rp2040 pcbs
-* [1:29:45](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=5385) Programming boards using SWD and  https://github.com/adafruit/Adafruit_DAP
-* [1:33:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=5580) Feather RP2040 Tester screenshot…
-* [1:34:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=5640) UF2 is twice as big…
-* [1:40:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6020) BLE workflow is the next think
-* [1:41:19](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6079) UF2
-* [1:43:52](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6232) Fixing release for Johny - ( hope he checked the box allow maintainers to edit… )   Need to do a make translate
-* [1:45:11](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6311) - ​Q: Can you explain what doesn't get whacked in light sleep (how does "audio playback" continue?). Do I/O pins retain state, PWMs keep running, etc...?
-* [1:47:10](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6430) speaking of light sleep, since it basically enables to come out of time.sleep with a pin interrupt or something, shouldn't it be supported apart from deep sleep, in order to make it easier to have it on more ports
-* [1:48:15](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6495) move to ninja build system...
-* [1:50:05](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6605) … bs2_default_padded_checksum.S
-* [1:50:44](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6644) IMX - c structures to describe flash -... execute off flash
-* [1:50:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6600) external_flash structures for CP
-* [1:53:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6780) unify the way we store flash descriptions ( TOML )   https://toml.io/en/
-* [1:55:10](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6910) Embedded rust - ​Oh, this sounds like rust I would love to do a rust version of the RP2040 and it looks like you might be going sort of that direction as well.
-* [1:57:30](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=7050) also support for MRAM
-* [2:07:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=7620) tomlkit on github - python tool that preserves comments  https://github.com/sdispater/tomlkit
-* [2:09:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=7760) Does TOML have conditional includes? That would make cascading a lot easier.... no
-* [2:10:15](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=7815) Strict YAML ( see wikipedia )
-* [2:12:15](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=7935) - have you ever seen "the norway problem" with yaml, that's funny / if you parse a list of country codes which are bareword strings, then norway is parsed as false
-* [2:13:28](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=8008)  -- overtime ….
-* [2:14:40](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=8080) Next week thursday
-* [2:15:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=8120) - cat petting
+* [1:17:40](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=4660) Do you folks do automated unit test using a hardware fixture to emulate devices?…. ( no )
+* [1:20:20](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=4820) We can have a build system/testing session on Discord sometime.
+* [1:22:00](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=4920) bergdahl’s merge request….
+* [1:23:40](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=5020) Ladyada joined…
+* [1:24:42](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=5082) - building the tester for the feather rp2040 pcbs
+* [1:29:45](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=5385) Programming boards using SWD and  https://github.com/adafruit/Adafruit_DAP
+* [1:33:00](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=5580) Feather RP2040 Tester screenshot…
+* [1:34:00](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=5640) UF2 is twice as big…
+* [1:40:20](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=6020) BLE workflow is the next think
+* [1:41:19](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=6079) UF2
+* [1:43:52](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=6232) Fixing release for Johny - ( hope he checked the box allow maintainers to edit… )   Need to do a make translate
+* [1:45:11](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=6311) - ​Q: Can you explain what doesn't get whacked in light sleep (how does "audio playback" continue?). Do I/O pins retain state, PWMs keep running, etc...?
+* [1:47:10](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=6430) speaking of light sleep, since it basically enables to come out of time.sleep with a pin interrupt or something, shouldn't it be supported apart from deep sleep, in order to make it easier to have it on more ports
+* [1:48:15](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=6495) move to ninja build system...
+* [1:50:05](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=6605) … bs2_default_padded_checksum.S
+* [1:50:44](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=6644) IMX - c structures to describe flash -... execute off flash
+* [1:50:00](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=6600) external_flash structures for CP
+* [1:53:00](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=6780) unify the way we store flash descriptions ( TOML )   https://toml.io/en/
+* [1:55:10](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=6910) Embedded rust - ​Oh, this sounds like rust I would love to do a rust version of the RP2040 and it looks like you might be going sort of that direction as well.
+* [1:57:30](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=7050) also support for MRAM
+* [2:07:00](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=7620) tomlkit on github - python tool that preserves comments  https://github.com/sdispater/tomlkit
+* [2:09:20](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=7760) Does TOML have conditional includes? That would make cascading a lot easier.... no
+* [2:10:15](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=7815) Strict YAML ( see wikipedia )
+* [2:12:15](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=7935) - have you ever seen "the norway problem" with yaml, that's funny / if you parse a list of country codes which are bareword strings, then norway is parsed as false
+* [2:13:28](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=8008)  -- overtime ….
+* [2:14:40](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=8080) Next week thursday
+* [2:15:20](https://www.youtube.com/watch?v=Vlxf8FRtV30&t=8120) - cat petting

--- a/2021/2021-02-26.md
+++ b/2021/2021-02-26.md
@@ -20,81 +20,81 @@ Plan
 
 
 Timecodes
-* [12:17](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=737) will there be a rp2040 board with wifi on it?
-* [13:32](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=812) Would it possible theoretically to have a module that works in the background kind of like rotaryio or gamepad but is responsible for reading touch screen data and queuing it up to return to the foreground coded when requested?
-* [14:45](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=885) any RISC-V port plans for CP (ala ESP32C3 or BeagleV)
-* [17:56](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1076) Is it possible to use an ESP32 board to connect to Wifi?
-* [19:13](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1153) Is there a way of obfuscating code on the device?
-* [20:12](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1212) would it be fair to characterize the pico as a more CP friendly cortex M0 than the SAMD21 boards from adafruit, given the increased RAM and clock speed?
-* [21:18](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1278) blinka on beagleboard considering putting Blinka/CP on BeagleV as GSOC project for BeagleBoard.org
-* [21:38](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1298) video / VGA?
-* [25:54](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1554) Is it possible to use a QSPI PSRAM chip with the RP2040 like is used on the ESP32-WROVER and Teensy 4.1?
-* [28:08](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1688) rp2040 chips sent out to vendors / Pimoroni on CP Downloads
-* [30:14](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1814) CP PR   ( closed )
-* [31:19](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1879) Does Adafruit have any plans for the new dual core asymmetric multiprocessing chips like the STM32H series and the similar chips from Freescale?
-* [32:18](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1938) Is Raspberry Pi releasing just stand alone chips for everyone? Or is this limited to only partner board-makers (like Adafruit)?
-* [33:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2000) pronounce… Pimoroni
-* [33:55](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2035) tuple …
-* [34:13](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2053) Wiznet5k library still requires bus_device library, which moved to core? As in native.
-* [34:33](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2073) "Pimoroni stands for Pirate, Monkey, Robot, Ninja (Pi-Mo-Ro-Ni) and sounds like the name of an expensive Italian lager. It's pronounced Pih-mo-row-kne"
-* [35:12](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2112) Do micropython and Circuit python have the same memory requirements?
-* [36:33](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2193) EN-UK support in CP?
-* [37:05](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2225) recap CP PR’s
-* [37:34](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2254) EN-Pirate ( sommersoft )
-* [37:55](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2275) Secondary USB CDC (serial) channel - bug 231
-* [39:30](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2370) Many people had projects for the second Serial... where are those projects now?
-* [39:49](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2389) Any hope of using a second serial on SAMD21?
-* [40:21](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2421) does the 2nd USB port mean that you can use USB serial while testing Deep Sleep instead of simulating it
-* [41:56](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2516) Bit transpose (jepler)
-* [42:29](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2549) On a side note, newer versions of CPython support breakpoint() instead of having to use import pdb; pdb.set_trace()
-* [44:21](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2661) I2S support  rp2pio pinstate/direction ...
-* [45:31](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2731) ​Scott, did you fix the error messages, or do you still want me to do the PR?
-* [46:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2760) ​I bet your Python linter loves that StateMachine constructor with all those arguments
-* [48:48](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2928) Fix second shared PWM
-* [50:40](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3040) pin changes between Rev A and Rev C in rp2040 feather…
-* [52:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3120) Will you be announcing the availability of Feather2040 in the store during a deep dive again? Worked well for the MagTag!
-* [52:50](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3170) Can CP know the USB host status? i.e. connect to a phone, and it goes to sleep.
-* [54:05](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3245) Next week is Thursday
-* [57:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3420) RP2040 support for UART / merged
-* [57:44](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3464) Can I "link" the second CDC serial to a UART and do USB to Serial with a Pico?
-* [1:01:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3660) Can you demo your workflow fixing spelling mistakes?
-* [1:02:13](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3733)  but does the pico work on arduino IDE yet or will it ever work on it?
-* [1:02:45](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3765) Was there a Mu meeting and will Mu be confused with the second CDC serial?
-* [1:03:55](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3835) typo PR demo
-* [1:05:05](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3905) ( tutorial on how to edit from github )
-* [1:06:23](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3983) I am thinking about building a vt220 dumb terminal for use on my PDP11/23 emulation. … see raspberry pi terminal project site:blog.adafruit.com (pygraphics https://github.com/fbergama/pigfx )
-* [1:08:11](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4091) Aside: I just did some tests with supervisor.runtime.serial_connected and it is True if you are connected to the board's REPL serial port but it is False if the board is connected to USB and doing HID/MIDI/MSD stuff. I cannot find something that says "USB host present"
-* [1:09:13](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4153) adafruit projects learn.adafruit.com
-* [1:10:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4200) Bare metal - meaning…
-* [1:10:33](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4233) ​are there any plans for a visual studio code RP2040 CircuitPython emulator like the Playground express
-* [1:11:19](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4279) - typo fix build caught error - git ‘magic’
-* [1:13:03](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4383) not sure if this was covered yet but with the pico how is the UART work going - I can see good results in the PR - would there be an eta on that?
-* [1:13:04](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4384) Speaking of RTOS - Shawn Hymel from Digi-Key has been working on a Youtube series about developing on an MCU with FreeRTOS
+* [12:17](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=737) will there be a rp2040 board with wifi on it?
+* [13:32](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=812) Would it possible theoretically to have a module that works in the background kind of like rotaryio or gamepad but is responsible for reading touch screen data and queuing it up to return to the foreground coded when requested?
+* [14:45](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=885) any RISC-V port plans for CP (ala ESP32C3 or BeagleV)
+* [17:56](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1076) Is it possible to use an ESP32 board to connect to Wifi?
+* [19:13](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1153) Is there a way of obfuscating code on the device?
+* [20:12](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1212) would it be fair to characterize the pico as a more CP friendly cortex M0 than the SAMD21 boards from adafruit, given the increased RAM and clock speed?
+* [21:18](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1278) blinka on beagleboard considering putting Blinka/CP on BeagleV as GSOC project for BeagleBoard.org
+* [21:38](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1298) video / VGA?
+* [25:54](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1554) Is it possible to use a QSPI PSRAM chip with the RP2040 like is used on the ESP32-WROVER and Teensy 4.1?
+* [28:08](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1688) rp2040 chips sent out to vendors / Pimoroni on CP Downloads
+* [30:14](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1814) CP PR   ( closed )
+* [31:19](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1879) Does Adafruit have any plans for the new dual core asymmetric multiprocessing chips like the STM32H series and the similar chips from Freescale?
+* [32:18](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=1938) Is Raspberry Pi releasing just stand alone chips for everyone? Or is this limited to only partner board-makers (like Adafruit)?
+* [33:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2000) pronounce… Pimoroni
+* [33:55](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2035) tuple …
+* [34:13](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2053) Wiznet5k library still requires bus_device library, which moved to core? As in native.
+* [34:33](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2073) "Pimoroni stands for Pirate, Monkey, Robot, Ninja (Pi-Mo-Ro-Ni) and sounds like the name of an expensive Italian lager. It's pronounced Pih-mo-row-kne"
+* [35:12](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2112) Do micropython and Circuit python have the same memory requirements?
+* [36:33](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2193) EN-UK support in CP?
+* [37:05](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2225) recap CP PR’s
+* [37:34](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2254) EN-Pirate ( sommersoft )
+* [37:55](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2275) Secondary USB CDC (serial) channel - bug 231
+* [39:30](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2370) Many people had projects for the second Serial... where are those projects now?
+* [39:49](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2389) Any hope of using a second serial on SAMD21?
+* [40:21](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2421) does the 2nd USB port mean that you can use USB serial while testing Deep Sleep instead of simulating it
+* [41:56](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2516) Bit transpose (jepler)
+* [42:29](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2549) On a side note, newer versions of CPython support breakpoint() instead of having to use import pdb; pdb.set_trace()
+* [44:21](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2661) I2S support  rp2pio pinstate/direction ...
+* [45:31](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2731) ​Scott, did you fix the error messages, or do you still want me to do the PR?
+* [46:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2760) ​I bet your Python linter loves that StateMachine constructor with all those arguments
+* [48:48](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=2928) Fix second shared PWM
+* [50:40](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3040) pin changes between Rev A and Rev C in rp2040 feather…
+* [52:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3120) Will you be announcing the availability of Feather2040 in the store during a deep dive again? Worked well for the MagTag!
+* [52:50](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3170) Can CP know the USB host status? i.e. connect to a phone, and it goes to sleep.
+* [54:05](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3245) Next week is Thursday
+* [57:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3420) RP2040 support for UART / merged
+* [57:44](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3464) Can I "link" the second CDC serial to a UART and do USB to Serial with a Pico?
+* [1:01:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3660) Can you demo your workflow fixing spelling mistakes?
+* [1:02:13](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3733)  but does the pico work on arduino IDE yet or will it ever work on it?
+* [1:02:45](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3765) Was there a Mu meeting and will Mu be confused with the second CDC serial?
+* [1:03:55](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3835) typo PR demo
+* [1:05:05](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3905) ( tutorial on how to edit from github )
+* [1:06:23](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=3983) I am thinking about building a vt220 dumb terminal for use on my PDP11/23 emulation. … see raspberry pi terminal project site:blog.adafruit.com (pygraphics https://github.com/fbergama/pigfx )
+* [1:08:11](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4091) Aside: I just did some tests with supervisor.runtime.serial_connected and it is True if you are connected to the board's REPL serial port but it is False if the board is connected to USB and doing HID/MIDI/MSD stuff. I cannot find something that says "USB host present"
+* [1:09:13](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4153) adafruit projects learn.adafruit.com
+* [1:10:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4200) Bare metal - meaning…
+* [1:10:33](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4233) ​are there any plans for a visual studio code RP2040 CircuitPython emulator like the Playground express
+* [1:11:19](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4279) - typo fix build caught error - git ‘magic’
+* [1:13:03](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4383) not sure if this was covered yet but with the pico how is the UART work going - I can see good results in the PR - would there be an eta on that?
+* [1:13:04](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4384) Speaking of RTOS - Shawn Hymel from Digi-Key has been working on a Youtube series about developing on an MCU with FreeRTOS
 https://www.youtube.com/watch?v=F321087yYy4&list=PLEBQazB0HUyQ4hAPU1cJED6t3DU0h34bz
-* [1:17:40](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4660) Do you folks do automated unit test using a hardware fixture to emulate devices?…. ( no )
-* [1:20:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4820) We can have a build system/testing session on Discord sometime.
-* [1:22:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4920) bergdahl’s merge request….
-* [1:23:40](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=5020) Ladyada joined…
-* [1:24:42](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=5082) - building the tester for the feather rp2040 pcbs
-* [1:29:45](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=5385) Programming boards using SWD and  https://github.com/adafruit/Adafruit_DAP
-* [1:33:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=5580) Feather RP2040 Tester screenshot…
-* [1:34:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=5640) UF2 is twice as big…
-* [1:40:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6020) BLE workflow is the next think
-* [1:41:19](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6079) UF2
-* [1:43:52](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6232) Fixing release for Johny - ( hope he checked the box allow maintainers to edit… )   Need to do a make translate
-* [1:45:11](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6311) - ​Q: Can you explain what doesn't get whacked in light sleep (how does "audio playback" continue?). Do I/O pins retain state, PWMs keep running, etc...?
-* [1:47:10](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6430) speaking of light sleep, since it basically enables to come out of time.sleep with a pin interrupt or something, shouldn't it be supported apart from deep sleep, in order to make it easier to have it on more ports
-* [1:48:15](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6495) move to ninja build system...
-* [1:50:05](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6605) … bs2_default_padded_checksum.S
-* [1:50:44](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6644) IMX - c structures to describe flash -... execute off flash
-* [1:50:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6600) external_flash structures for CP
-* [1:53:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6780) unify the way we store flash descriptions ( TOML )   https://toml.io/en/
-* [1:55:10](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6910) Embedded rust - ​Oh, this sounds like rust I would love to do a rust version of the RP2040 and it looks like you might be going sort of that direction as well.
-* [1:57:30](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=7050) also support for MRAM
-* [2:07:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=7620) tomlkit on github - python tool that preserves comments  https://github.com/sdispater/tomlkit
-* [2:09:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=7760) Does TOML have conditional includes? That would make cascading a lot easier.... no
-* [2:10:15](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=7815) Strict YAML ( see wikipedia )
-* [2:12:15](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=7935) - have you ever seen "the norway problem" with yaml, that's funny / if you parse a list of country codes which are bareword strings, then norway is parsed as false
-* [2:13:28](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=8008)  -- overtime ….
-* [2:14:40](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=8080) Next week thursday
-* [2:15:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=8120) - cat petting
+* [1:17:40](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4660) Do you folks do automated unit test using a hardware fixture to emulate devices?…. ( no )
+* [1:20:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4820) We can have a build system/testing session on Discord sometime.
+* [1:22:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=4920) bergdahl’s merge request….
+* [1:23:40](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=5020) Ladyada joined…
+* [1:24:42](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=5082) - building the tester for the feather rp2040 pcbs
+* [1:29:45](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=5385) Programming boards using SWD and  https://github.com/adafruit/Adafruit_DAP
+* [1:33:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=5580) Feather RP2040 Tester screenshot…
+* [1:34:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=5640) UF2 is twice as big…
+* [1:40:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6020) BLE workflow is the next think
+* [1:41:19](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6079) UF2
+* [1:43:52](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6232) Fixing release for Johny - ( hope he checked the box allow maintainers to edit… )   Need to do a make translate
+* [1:45:11](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6311) - ​Q: Can you explain what doesn't get whacked in light sleep (how does "audio playback" continue?). Do I/O pins retain state, PWMs keep running, etc...?
+* [1:47:10](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6430) speaking of light sleep, since it basically enables to come out of time.sleep with a pin interrupt or something, shouldn't it be supported apart from deep sleep, in order to make it easier to have it on more ports
+* [1:48:15](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6495) move to ninja build system...
+* [1:50:05](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6605) … bs2_default_padded_checksum.S
+* [1:50:44](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6644) IMX - c structures to describe flash -... execute off flash
+* [1:50:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6600) external_flash structures for CP
+* [1:53:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6780) unify the way we store flash descriptions ( TOML )   https://toml.io/en/
+* [1:55:10](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=6910) Embedded rust - ​Oh, this sounds like rust I would love to do a rust version of the RP2040 and it looks like you might be going sort of that direction as well.
+* [1:57:30](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=7050) also support for MRAM
+* [2:07:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=7620) tomlkit on github - python tool that preserves comments  https://github.com/sdispater/tomlkit
+* [2:09:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=7760) Does TOML have conditional includes? That would make cascading a lot easier.... no
+* [2:10:15](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=7815) Strict YAML ( see wikipedia )
+* [2:12:15](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=7935) - have you ever seen "the norway problem" with yaml, that's funny / if you parse a list of country codes which are bareword strings, then norway is parsed as false
+* [2:13:28](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=8008)  -- overtime ….
+* [2:14:40](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=8080) Next week thursday
+* [2:15:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26&t=8120) - cat petting

--- a/2021/2021-02-26.md
+++ b/2021/2021-02-26.md
@@ -10,7 +10,7 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Next week will be on Thursday!
 * Typically goes for two hours or more. Questions are welcome.
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After I’ll unmute and continue.
-* 
+*
 
 Plan
 * Pimoroni Boards!
@@ -20,81 +20,81 @@ Plan
 
 
 Timecodes
-* 12:17 will there be a rp2040 board with wifi on it?
-* 13:32 Would it possible theoretically to have a module that works in the background kind of like rotaryio or gamepad but is responsible for reading touch screen data and queuing it up to return to the foreground coded when requested?
-* 14:45 any RISC-V port plans for CP (ala ESP32C3 or BeagleV)
-* 17:56 Is it possible to use an ESP32 board to connect to Wifi?
-* 19:13 Is there a way of obfuscating code on the device?
-* 20:12 would it be fair to characterize the pico as a more CP friendly cortex M0 than the SAMD21 boards from adafruit, given the increased RAM and clock speed?
-* 21:18 blinka on beagleboard considering putting Blinka/CP on BeagleV as GSOC project for BeagleBoard.org
-* 21:38 video / VGA?
-* 25:54 Is it possible to use a QSPI PSRAM chip with the RP2040 like is used on the ESP32-WROVER and Teensy 4.1?
-* 28:08 rp2040 chips sent out to vendors / Pimoroni on CP Downloads
-* 30:14 CP PR   ( closed )
-* 31:19 Does Adafruit have any plans for the new dual core asymmetric multiprocessing chips like the STM32H series and the similar chips from Freescale?
-* 32:18 Is Raspberry Pi releasing just stand alone chips for everyone? Or is this limited to only partner board-makers (like Adafruit)?
-* 33:20 pronounce… Pimoroni
-* 33:55 tuple …
-* 34:13 Wiznet5k library still requires bus_device library, which moved to core? As in native.
-* 34:33 "Pimoroni stands for Pirate, Monkey, Robot, Ninja (Pi-Mo-Ro-Ni) and sounds like the name of an expensive Italian lager. It's pronounced Pih-mo-row-kne"
-* 35:12 Do micropython and Circuit python have the same memory requirements?
-* 36:33 EN-UK support in CP?
-* 37:05 recap CP PR’s
-* 37:34 EN-Pirate ( sommersoft )
-* 37:55 Secondary USB CDC (serial) channel - bug 231
-* 39:30 Many people had projects for the second Serial... where are those projects now?
-* 39:49 Any hope of using a second serial on SAMD21?
-* 40:21 does the 2nd USB port mean that you can use USB serial while testing Deep Sleep instead of simulating it
-* 41:56 Bit transpose (jepler)
-* 42:29 On a side note, newer versions of CPython support breakpoint() instead of having to use import pdb; pdb.set_trace()
-* 44:21 I2S support  rp2pio pinstate/direction ...
-* 45:31 ​Scott, did you fix the error messages, or do you still want me to do the PR?
-* 46:00 ​I bet your Python linter loves that StateMachine constructor with all those arguments
-* 48:48 Fix second shared PWM
-* 50:40 pin changes between Rev A and Rev C in rp2040 feather… 
-* 52:00 Will you be announcing the availability of Feather2040 in the store during a deep dive again? Worked well for the MagTag!
-* 52:50 Can CP know the USB host status? i.e. connect to a phone, and it goes to sleep.
-* 54:05 Next week is Thursday 
-* 57:00 RP2040 support for UART / merged
-* 57:44 Can I "link" the second CDC serial to a UART and do USB to Serial with a Pico?
-* 1:01:00 Can you demo your workflow fixing spelling mistakes?
-* 1:02:13  but does the pico work on arduino IDE yet or will it ever work on it?
-* 1:02:45 Was there a Mu meeting and will Mu be confused with the second CDC serial?
-* 1:03:55 typo PR demo
-* 1:05:05 ( tutorial on how to edit from github )
-* 1:06:23 I am thinking about building a vt220 dumb terminal for use on my PDP11/23 emulation. … see raspberry pi terminal project site:blog.adafruit.com (pygraphics https://github.com/fbergama/pigfx )
-* 1:08:11 Aside: I just did some tests with supervisor.runtime.serial_connected and it is True if you are connected to the board's REPL serial port but it is False if the board is connected to USB and doing HID/MIDI/MSD stuff. I cannot find something that says "USB host present"
-* 1:09:13 adafruit projects learn.adafruit.com
-* 1:10:00 Bare metal - meaning…
-* 1:10:33 ​are there any plans for a visual studio code RP2040 CircuitPython emulator like the Playground express
-* 1:11:19 - typo fix build caught error - git ‘magic’
-* 1:13:03 not sure if this was covered yet but with the pico how is the UART work going - I can see good results in the PR - would there be an eta on that?
-* 1:13:04 Speaking of RTOS - Shawn Hymel from Digi-Key has been working on a Youtube series about developing on an MCU with FreeRTOS
+* [12:17](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=737) will there be a rp2040 board with wifi on it?
+* [13:32](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=812) Would it possible theoretically to have a module that works in the background kind of like rotaryio or gamepad but is responsible for reading touch screen data and queuing it up to return to the foreground coded when requested?
+* [14:45](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=885) any RISC-V port plans for CP (ala ESP32C3 or BeagleV)
+* [17:56](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1076) Is it possible to use an ESP32 board to connect to Wifi?
+* [19:13](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1153) Is there a way of obfuscating code on the device?
+* [20:12](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1212) would it be fair to characterize the pico as a more CP friendly cortex M0 than the SAMD21 boards from adafruit, given the increased RAM and clock speed?
+* [21:18](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1278) blinka on beagleboard considering putting Blinka/CP on BeagleV as GSOC project for BeagleBoard.org
+* [21:38](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1298) video / VGA?
+* [25:54](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1554) Is it possible to use a QSPI PSRAM chip with the RP2040 like is used on the ESP32-WROVER and Teensy 4.1?
+* [28:08](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1688) rp2040 chips sent out to vendors / Pimoroni on CP Downloads
+* [30:14](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1814) CP PR   ( closed )
+* [31:19](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1879) Does Adafruit have any plans for the new dual core asymmetric multiprocessing chips like the STM32H series and the similar chips from Freescale?
+* [32:18](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=1938) Is Raspberry Pi releasing just stand alone chips for everyone? Or is this limited to only partner board-makers (like Adafruit)?
+* [33:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2000) pronounce… Pimoroni
+* [33:55](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2035) tuple …
+* [34:13](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2053) Wiznet5k library still requires bus_device library, which moved to core? As in native.
+* [34:33](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2073) "Pimoroni stands for Pirate, Monkey, Robot, Ninja (Pi-Mo-Ro-Ni) and sounds like the name of an expensive Italian lager. It's pronounced Pih-mo-row-kne"
+* [35:12](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2112) Do micropython and Circuit python have the same memory requirements?
+* [36:33](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2193) EN-UK support in CP?
+* [37:05](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2225) recap CP PR’s
+* [37:34](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2254) EN-Pirate ( sommersoft )
+* [37:55](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2275) Secondary USB CDC (serial) channel - bug 231
+* [39:30](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2370) Many people had projects for the second Serial... where are those projects now?
+* [39:49](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2389) Any hope of using a second serial on SAMD21?
+* [40:21](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2421) does the 2nd USB port mean that you can use USB serial while testing Deep Sleep instead of simulating it
+* [41:56](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2516) Bit transpose (jepler)
+* [42:29](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2549) On a side note, newer versions of CPython support breakpoint() instead of having to use import pdb; pdb.set_trace()
+* [44:21](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2661) I2S support  rp2pio pinstate/direction ...
+* [45:31](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2731) ​Scott, did you fix the error messages, or do you still want me to do the PR?
+* [46:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2760) ​I bet your Python linter loves that StateMachine constructor with all those arguments
+* [48:48](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=2928) Fix second shared PWM
+* [50:40](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3040) pin changes between Rev A and Rev C in rp2040 feather…
+* [52:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3120) Will you be announcing the availability of Feather2040 in the store during a deep dive again? Worked well for the MagTag!
+* [52:50](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3170) Can CP know the USB host status? i.e. connect to a phone, and it goes to sleep.
+* [54:05](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3245) Next week is Thursday
+* [57:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3420) RP2040 support for UART / merged
+* [57:44](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3464) Can I "link" the second CDC serial to a UART and do USB to Serial with a Pico?
+* [1:01:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3660) Can you demo your workflow fixing spelling mistakes?
+* [1:02:13](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3733)  but does the pico work on arduino IDE yet or will it ever work on it?
+* [1:02:45](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3765) Was there a Mu meeting and will Mu be confused with the second CDC serial?
+* [1:03:55](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3835) typo PR demo
+* [1:05:05](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3905) ( tutorial on how to edit from github )
+* [1:06:23](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=3983) I am thinking about building a vt220 dumb terminal for use on my PDP11/23 emulation. … see raspberry pi terminal project site:blog.adafruit.com (pygraphics https://github.com/fbergama/pigfx )
+* [1:08:11](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4091) Aside: I just did some tests with supervisor.runtime.serial_connected and it is True if you are connected to the board's REPL serial port but it is False if the board is connected to USB and doing HID/MIDI/MSD stuff. I cannot find something that says "USB host present"
+* [1:09:13](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4153) adafruit projects learn.adafruit.com
+* [1:10:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4200) Bare metal - meaning…
+* [1:10:33](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4233) ​are there any plans for a visual studio code RP2040 CircuitPython emulator like the Playground express
+* [1:11:19](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4279) - typo fix build caught error - git ‘magic’
+* [1:13:03](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4383) not sure if this was covered yet but with the pico how is the UART work going - I can see good results in the PR - would there be an eta on that?
+* [1:13:04](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4384) Speaking of RTOS - Shawn Hymel from Digi-Key has been working on a Youtube series about developing on an MCU with FreeRTOS
 https://www.youtube.com/watch?v=F321087yYy4&list=PLEBQazB0HUyQ4hAPU1cJED6t3DU0h34bz
-* 1:17:40 Do you folks do automated unit test using a hardware fixture to emulate devices?…. ( no )
-* 1:20:20 We can have a build system/testing session on Discord sometime.
-* 1:22:00 bergdahl’s merge request….
-* 1:23:40 Ladyada joined…
-* 1:24:42 - building the tester for the feather rp2040 pcbs
-* 1:29:45 Programming boards using SWD and  https://github.com/adafruit/Adafruit_DAP  
-* 1:33:00 Feather RP2040 Tester screenshot…
-* 1:34:00 UF2 is twice as big… 
-* 1:40:20 BLE workflow is the next think
-* 1:41:19 UF2 
-* 1:43:52 Fixing release for Johny - ( hope he checked the box allow maintainers to edit… )   Need to do a make translate
-* 1:45:11 - ​Q: Can you explain what doesn't get whacked in light sleep (how does "audio playback" continue?). Do I/O pins retain state, PWMs keep running, etc...?
-* 1:47:10 speaking of light sleep, since it basically enables to come out of time.sleep with a pin interrupt or something, shouldn't it be supported apart from deep sleep, in order to make it easier to have it on more ports
-* 1:48:15 move to ninja build system...
-* 1:50:05 … bs2_default_padded_checksum.S
-* 1:50:44 IMX - c structures to describe flash -... execute off flash
-* 1:50:00 external_flash structures for CP
-* 1:53:00 unify the way we store flash descriptions ( TOML )   https://toml.io/en/
-* 1:55:10 Embedded rust - ​Oh, this sounds like rust I would love to do a rust version of the RP2040 and it looks like you might be going sort of that direction as well.
-* 1:57:30 also support for MRAM
-* 2:07:00 tomlkit on github - python tool that preserves comments  https://github.com/sdispater/tomlkit
-* 2:09:20 Does TOML have conditional includes? That would make cascading a lot easier.... no 
-* 2:10:15 Strict YAML ( see wikipedia )
-* 2:12:15 - have you ever seen "the norway problem" with yaml, that's funny / if you parse a list of country codes which are bareword strings, then norway is parsed as false
-* 2:13:28  -- overtime ….
-* 2:14:40 Next week thursday
-* 2:15:20 - cat petting
+* [1:17:40](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4660) Do you folks do automated unit test using a hardware fixture to emulate devices?…. ( no )
+* [1:20:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4820) We can have a build system/testing session on Discord sometime.
+* [1:22:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=4920) bergdahl’s merge request….
+* [1:23:40](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=5020) Ladyada joined…
+* [1:24:42](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=5082) - building the tester for the feather rp2040 pcbs
+* [1:29:45](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=5385) Programming boards using SWD and  https://github.com/adafruit/Adafruit_DAP
+* [1:33:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=5580) Feather RP2040 Tester screenshot…
+* [1:34:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=5640) UF2 is twice as big…
+* [1:40:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6020) BLE workflow is the next think
+* [1:41:19](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6079) UF2
+* [1:43:52](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6232) Fixing release for Johny - ( hope he checked the box allow maintainers to edit… )   Need to do a make translate
+* [1:45:11](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6311) - ​Q: Can you explain what doesn't get whacked in light sleep (how does "audio playback" continue?). Do I/O pins retain state, PWMs keep running, etc...?
+* [1:47:10](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6430) speaking of light sleep, since it basically enables to come out of time.sleep with a pin interrupt or something, shouldn't it be supported apart from deep sleep, in order to make it easier to have it on more ports
+* [1:48:15](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6495) move to ninja build system...
+* [1:50:05](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6605) … bs2_default_padded_checksum.S
+* [1:50:44](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6644) IMX - c structures to describe flash -... execute off flash
+* [1:50:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6600) external_flash structures for CP
+* [1:53:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6780) unify the way we store flash descriptions ( TOML )   https://toml.io/en/
+* [1:55:10](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=6910) Embedded rust - ​Oh, this sounds like rust I would love to do a rust version of the RP2040 and it looks like you might be going sort of that direction as well.
+* [1:57:30](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=7050) also support for MRAM
+* [2:07:00](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=7620) tomlkit on github - python tool that preserves comments  https://github.com/sdispater/tomlkit
+* [2:09:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=7760) Does TOML have conditional includes? That would make cascading a lot easier.... no
+* [2:10:15](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=7815) Strict YAML ( see wikipedia )
+* [2:12:15](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=7935) - have you ever seen "the norway problem" with yaml, that's funny / if you parse a list of country codes which are bareword strings, then norway is parsed as false
+* [2:13:28](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=8008)  -- overtime ….
+* [2:14:40](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=8080) Next week thursday
+* [2:15:20](https://www.youtube.com/watch?v=VIDEO_2021_02_26?t=8120) - cat petting

--- a/2021/2021-03-04.md
+++ b/2021/2021-03-04.md
@@ -12,18 +12,18 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* 11:41 what sort of question/comments should go on Discord vs. YouTube chat?
-* 13:59 Mailbag!  Showed the Feather goodie bag JP sent Scott.  Used CircuitPython to program a GameBoy and the RP2040s are destined to go there!  PIO can buffer and make sure it’s timing specific.
+* [11:41](https://www.youtube.com/watch?v=VIDEO_2021_03_04?t=701) what sort of question/comments should go on Discord vs. YouTube chat?
+* [13:59](https://www.youtube.com/watch?v=VIDEO_2021_03_04?t=839) Mailbag!  Showed the Feather goodie bag JP sent Scott.  Used CircuitPython to program a GameBoy and the RP2040s are destined to go there!  PIO can buffer and make sure it’s timing specific.
 * Scott was on the Tomshardware Pi Cast.  Idea of making CircuitPython run bare-metal on a Raspberry Pi.
 * Sneak peak of Simple Electronics. Does not officially come out until tomorrow.
-* 18:49 More Mailbag!  Becca wanted a sensor to track temperature, humidity and light levels for an indoor plant sensor.  Hammond USB case (DigiKey part# 1551USB3TSK) with paper prototype.  Low profile pluggable sensors.
+* [18:49](https://www.youtube.com/watch?v=VIDEO_2021_03_04?t=1129) More Mailbag!  Becca wanted a sensor to track temperature, humidity and light levels for an indoor plant sensor.  Hammond USB case (DigiKey part# 1551USB3TSK) with paper prototype.  Low profile pluggable sensors.
 * Q) Why not use a feather with a 3D printed case?  (1) Scott doesn’t have a 3D printer and (2) he really likes the Hammond case.
 * Saw Hammond enclosures on the manufacturer’s website.
 * Showed NeoPixel board to show measurement scale, and veml 7700 temperature and humidity sensor.
 * Q) Will you be able to isolate the temperature sensor from the electronics heat?  Temperature sensor in the enclosure can read some of the case temperature.
-* 28:20 Today’s Deep Dive.  Let’s talk about flash!  Lady Ada was producing the Feather and found 4MB wasn’t working and switched to 8MB.  Saw pico-sdk GitHub and datasheet for RP2040 boot process with flowchart.  Let’s talk about the flash second stage after the checksum has passed.
+* [28:20](https://www.youtube.com/watch?v=VIDEO_2021_03_04?t=1700) Today’s Deep Dive.  Let’s talk about flash!  Lady Ada was producing the Feather and found 4MB wasn’t working and switched to 8MB.  Saw pico-sdk GitHub and datasheet for RP2040 boot process with flowchart.  Let’s talk about the flash second stage after the checksum has passed.
 * Flash second stage: problem is the code stored off-chip.  How do you figure out what flash it is and how do you talk to it?  Common problem: IMX and ESP also have the execute-in-place problem.  Pico-sdk has boot stage and 4 options for flash initialization.  Thought we were using 0x3H, but we weren’t which is why the 4MB flash failed.
-* New nvm.toml repository. mram is useful in space for satellites running CircuitPython because memory doesn’t corrupt the same way.  Saw gigadevices.  
+* New nvm.toml repository. mram is useful in space for satellites running CircuitPython because memory doesn’t corrupt the same way.  Saw gigadevices.
 * Q) Are their (sic) board where I can remove the flash and replace by sRam? Just like we add flash to QT-Py? Or SRam QT-Py?  Same question with mram.
 * Cascade TOML: can grab settings for a device using `cascadetoml cascade filter sku=\”GD25Q4C\”` for squishing settings into 1 TOML file.  We want to take the “database” and produce flash stage 2.
 * Lady Ada asked what if we came up with a stage 2 that could handle all the devices in here?
@@ -35,7 +35,7 @@ Plan
 * Testing stage2.c *drum roll*
 * Q) Will the next revision have less flash?
 * Looked at stage2 assembly in boot2.elf, then the padded and checksummed assembly.
-* 1:08:13 Lady Ada pops in to save Scott from assembly code.  Asks about the disassembler.
+* [1:08:13](https://www.youtube.com/watch?v=VIDEO_2021_03_04?t=4093) Lady Ada pops in to save Scott from assembly code.  Asks about the disassembler.
 * Lady Ada shows the tester pogo board.
 * Discussion of flash initializer assembler.
 * Q) Which flash chip will be on [the] itsy?
@@ -46,9 +46,9 @@ Plan
 * USB boot signal, chip select GPIO pin deep dive.
 * Q) Will that impact how fast the CS pin rises and falls? Does it matter?
 * Q) Scott: When will the next [RP2040] batch be in the store?
-* 1:40:52 Scott answers some of Lady Ada’s comments about soldering after she leaves.
+* [1:40:52](https://www.youtube.com/watch?v=VIDEO_2021_03_04?t=6052) Scott answers some of Lady Ada’s comments about soldering after she leaves.
 * Q) Out of curiosity, was there a benefit to the weird bootloader approach?
-* 1:45:10 Q) So where is the ROM code?
+* [1:45:10](https://www.youtube.com/watch?v=VIDEO_2021_03_04?t=6310) Q) So where is the ROM code?
 * Showed SOIC-A clip to debug the flash chip on the Feather: https://www.digikey.com/en/products/detail/pomona-electronics/5250/745102 (link courtesy of Mr. Certainly)
 * Use Saleae to capture the data line trace.  Maybe failing the checksum?  No clock signal?
 * Is the clip orientation correct?  Pulled up the GigaDevice flash chip datasheet.
@@ -56,5 +56,5 @@ Plan
 * T:6957: Unplugged it
 * T:7015: Trying a different board.  Now we can see the data line accessing flash every 20ms or so.  16kb cache.
 * T:7199: Switched clock to…
-* 2:02:07 wrap-up
+* [2:02:07](https://www.youtube.com/watch?v=VIDEO_2021_03_04?t=7327) wrap-up
 * Q) Do we have a new language UK-English?  Yes, it’s being built and you can add translations.

--- a/2021/2021-03-04.md
+++ b/2021/2021-03-04.md
@@ -4,7 +4,7 @@
 Hi all, this doc is try and track topics and timecodes for my deep dive stream. These notes will end up in the YouTube video’s description. Any help keeping them groomed as I stream is welcome.
 
 
-04:44 Housekeeping
+[04:44](https://www.youtube.com/watch?v=8lH03pQmaxM&t=284) Housekeeping
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome. Next week will be on Friday.
@@ -12,16 +12,16 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* [11:41](https://www.youtube.com/watch?v=VIDEO_2021_03_04&t=701) what sort of question/comments should go on Discord vs. YouTube chat?
-* [13:59](https://www.youtube.com/watch?v=VIDEO_2021_03_04&t=839) Mailbag!  Showed the Feather goodie bag JP sent Scott.  Used CircuitPython to program a GameBoy and the RP2040s are destined to go there!  PIO can buffer and make sure it’s timing specific.
+* [11:41](https://www.youtube.com/watch?v=8lH03pQmaxM&t=701) what sort of question/comments should go on Discord vs. YouTube chat?
+* [13:59](https://www.youtube.com/watch?v=8lH03pQmaxM&t=839) Mailbag!  Showed the Feather goodie bag JP sent Scott.  Used CircuitPython to program a GameBoy and the RP2040s are destined to go there!  PIO can buffer and make sure it’s timing specific.
 * Scott was on the Tomshardware Pi Cast.  Idea of making CircuitPython run bare-metal on a Raspberry Pi.
 * Sneak peak of Simple Electronics. Does not officially come out until tomorrow.
-* [18:49](https://www.youtube.com/watch?v=VIDEO_2021_03_04&t=1129) More Mailbag!  Becca wanted a sensor to track temperature, humidity and light levels for an indoor plant sensor.  Hammond USB case (DigiKey part# 1551USB3TSK) with paper prototype.  Low profile pluggable sensors.
+* [18:49](https://www.youtube.com/watch?v=8lH03pQmaxM&t=1129) More Mailbag!  Becca wanted a sensor to track temperature, humidity and light levels for an indoor plant sensor.  Hammond USB case (DigiKey part# 1551USB3TSK) with paper prototype.  Low profile pluggable sensors.
 * Q) Why not use a feather with a 3D printed case?  (1) Scott doesn’t have a 3D printer and (2) he really likes the Hammond case.
 * Saw Hammond enclosures on the manufacturer’s website.
 * Showed NeoPixel board to show measurement scale, and veml 7700 temperature and humidity sensor.
 * Q) Will you be able to isolate the temperature sensor from the electronics heat?  Temperature sensor in the enclosure can read some of the case temperature.
-* [28:20](https://www.youtube.com/watch?v=VIDEO_2021_03_04&t=1700) Today’s Deep Dive.  Let’s talk about flash!  Lady Ada was producing the Feather and found 4MB wasn’t working and switched to 8MB.  Saw pico-sdk GitHub and datasheet for RP2040 boot process with flowchart.  Let’s talk about the flash second stage after the checksum has passed.
+* [28:20](https://www.youtube.com/watch?v=8lH03pQmaxM&t=1700) Today’s Deep Dive.  Let’s talk about flash!  Lady Ada was producing the Feather and found 4MB wasn’t working and switched to 8MB.  Saw pico-sdk GitHub and datasheet for RP2040 boot process with flowchart.  Let’s talk about the flash second stage after the checksum has passed.
 * Flash second stage: problem is the code stored off-chip.  How do you figure out what flash it is and how do you talk to it?  Common problem: IMX and ESP also have the execute-in-place problem.  Pico-sdk has boot stage and 4 options for flash initialization.  Thought we were using 0x3H, but we weren’t which is why the 4MB flash failed.
 * New nvm.toml repository. mram is useful in space for satellites running CircuitPython because memory doesn’t corrupt the same way.  Saw gigadevices.
 * Q) Are their (sic) board where I can remove the flash and replace by sRam? Just like we add flash to QT-Py? Or SRam QT-Py?  Same question with mram.
@@ -35,7 +35,7 @@ Plan
 * Testing stage2.c *drum roll*
 * Q) Will the next revision have less flash?
 * Looked at stage2 assembly in boot2.elf, then the padded and checksummed assembly.
-* [1:08:13](https://www.youtube.com/watch?v=VIDEO_2021_03_04&t=4093) Lady Ada pops in to save Scott from assembly code.  Asks about the disassembler.
+* [1:08:13](https://www.youtube.com/watch?v=8lH03pQmaxM&t=4093) Lady Ada pops in to save Scott from assembly code.  Asks about the disassembler.
 * Lady Ada shows the tester pogo board.
 * Discussion of flash initializer assembler.
 * Q) Which flash chip will be on [the] itsy?
@@ -46,9 +46,9 @@ Plan
 * USB boot signal, chip select GPIO pin deep dive.
 * Q) Will that impact how fast the CS pin rises and falls? Does it matter?
 * Q) Scott: When will the next [RP2040] batch be in the store?
-* [1:40:52](https://www.youtube.com/watch?v=VIDEO_2021_03_04&t=6052) Scott answers some of Lady Ada’s comments about soldering after she leaves.
+* [1:40:52](https://www.youtube.com/watch?v=8lH03pQmaxM&t=6052) Scott answers some of Lady Ada’s comments about soldering after she leaves.
 * Q) Out of curiosity, was there a benefit to the weird bootloader approach?
-* [1:45:10](https://www.youtube.com/watch?v=VIDEO_2021_03_04&t=6310) Q) So where is the ROM code?
+* [1:45:10](https://www.youtube.com/watch?v=8lH03pQmaxM&t=6310) Q) So where is the ROM code?
 * Showed SOIC-A clip to debug the flash chip on the Feather: https://www.digikey.com/en/products/detail/pomona-electronics/5250/745102 (link courtesy of Mr. Certainly)
 * Use Saleae to capture the data line trace.  Maybe failing the checksum?  No clock signal?
 * Is the clip orientation correct?  Pulled up the GigaDevice flash chip datasheet.
@@ -56,5 +56,5 @@ Plan
 * T:6957: Unplugged it
 * T:7015: Trying a different board.  Now we can see the data line accessing flash every 20ms or so.  16kb cache.
 * T:7199: Switched clock to…
-* [2:02:07](https://www.youtube.com/watch?v=VIDEO_2021_03_04&t=7327) wrap-up
+* [2:02:07](https://www.youtube.com/watch?v=8lH03pQmaxM&t=7327) wrap-up
 * Q) Do we have a new language UK-English?  Yes, it’s being built and you can add translations.

--- a/2021/2021-03-04.md
+++ b/2021/2021-03-04.md
@@ -12,16 +12,16 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* [11:41](https://www.youtube.com/watch?v=VIDEO_2021_03_04?t=701) what sort of question/comments should go on Discord vs. YouTube chat?
-* [13:59](https://www.youtube.com/watch?v=VIDEO_2021_03_04?t=839) Mailbag!  Showed the Feather goodie bag JP sent Scott.  Used CircuitPython to program a GameBoy and the RP2040s are destined to go there!  PIO can buffer and make sure it’s timing specific.
+* [11:41](https://www.youtube.com/watch?v=VIDEO_2021_03_04&t=701) what sort of question/comments should go on Discord vs. YouTube chat?
+* [13:59](https://www.youtube.com/watch?v=VIDEO_2021_03_04&t=839) Mailbag!  Showed the Feather goodie bag JP sent Scott.  Used CircuitPython to program a GameBoy and the RP2040s are destined to go there!  PIO can buffer and make sure it’s timing specific.
 * Scott was on the Tomshardware Pi Cast.  Idea of making CircuitPython run bare-metal on a Raspberry Pi.
 * Sneak peak of Simple Electronics. Does not officially come out until tomorrow.
-* [18:49](https://www.youtube.com/watch?v=VIDEO_2021_03_04?t=1129) More Mailbag!  Becca wanted a sensor to track temperature, humidity and light levels for an indoor plant sensor.  Hammond USB case (DigiKey part# 1551USB3TSK) with paper prototype.  Low profile pluggable sensors.
+* [18:49](https://www.youtube.com/watch?v=VIDEO_2021_03_04&t=1129) More Mailbag!  Becca wanted a sensor to track temperature, humidity and light levels for an indoor plant sensor.  Hammond USB case (DigiKey part# 1551USB3TSK) with paper prototype.  Low profile pluggable sensors.
 * Q) Why not use a feather with a 3D printed case?  (1) Scott doesn’t have a 3D printer and (2) he really likes the Hammond case.
 * Saw Hammond enclosures on the manufacturer’s website.
 * Showed NeoPixel board to show measurement scale, and veml 7700 temperature and humidity sensor.
 * Q) Will you be able to isolate the temperature sensor from the electronics heat?  Temperature sensor in the enclosure can read some of the case temperature.
-* [28:20](https://www.youtube.com/watch?v=VIDEO_2021_03_04?t=1700) Today’s Deep Dive.  Let’s talk about flash!  Lady Ada was producing the Feather and found 4MB wasn’t working and switched to 8MB.  Saw pico-sdk GitHub and datasheet for RP2040 boot process with flowchart.  Let’s talk about the flash second stage after the checksum has passed.
+* [28:20](https://www.youtube.com/watch?v=VIDEO_2021_03_04&t=1700) Today’s Deep Dive.  Let’s talk about flash!  Lady Ada was producing the Feather and found 4MB wasn’t working and switched to 8MB.  Saw pico-sdk GitHub and datasheet for RP2040 boot process with flowchart.  Let’s talk about the flash second stage after the checksum has passed.
 * Flash second stage: problem is the code stored off-chip.  How do you figure out what flash it is and how do you talk to it?  Common problem: IMX and ESP also have the execute-in-place problem.  Pico-sdk has boot stage and 4 options for flash initialization.  Thought we were using 0x3H, but we weren’t which is why the 4MB flash failed.
 * New nvm.toml repository. mram is useful in space for satellites running CircuitPython because memory doesn’t corrupt the same way.  Saw gigadevices.
 * Q) Are their (sic) board where I can remove the flash and replace by sRam? Just like we add flash to QT-Py? Or SRam QT-Py?  Same question with mram.
@@ -35,7 +35,7 @@ Plan
 * Testing stage2.c *drum roll*
 * Q) Will the next revision have less flash?
 * Looked at stage2 assembly in boot2.elf, then the padded and checksummed assembly.
-* [1:08:13](https://www.youtube.com/watch?v=VIDEO_2021_03_04?t=4093) Lady Ada pops in to save Scott from assembly code.  Asks about the disassembler.
+* [1:08:13](https://www.youtube.com/watch?v=VIDEO_2021_03_04&t=4093) Lady Ada pops in to save Scott from assembly code.  Asks about the disassembler.
 * Lady Ada shows the tester pogo board.
 * Discussion of flash initializer assembler.
 * Q) Which flash chip will be on [the] itsy?
@@ -46,9 +46,9 @@ Plan
 * USB boot signal, chip select GPIO pin deep dive.
 * Q) Will that impact how fast the CS pin rises and falls? Does it matter?
 * Q) Scott: When will the next [RP2040] batch be in the store?
-* [1:40:52](https://www.youtube.com/watch?v=VIDEO_2021_03_04?t=6052) Scott answers some of Lady Ada’s comments about soldering after she leaves.
+* [1:40:52](https://www.youtube.com/watch?v=VIDEO_2021_03_04&t=6052) Scott answers some of Lady Ada’s comments about soldering after she leaves.
 * Q) Out of curiosity, was there a benefit to the weird bootloader approach?
-* [1:45:10](https://www.youtube.com/watch?v=VIDEO_2021_03_04?t=6310) Q) So where is the ROM code?
+* [1:45:10](https://www.youtube.com/watch?v=VIDEO_2021_03_04&t=6310) Q) So where is the ROM code?
 * Showed SOIC-A clip to debug the flash chip on the Feather: https://www.digikey.com/en/products/detail/pomona-electronics/5250/745102 (link courtesy of Mr. Certainly)
 * Use Saleae to capture the data line trace.  Maybe failing the checksum?  No clock signal?
 * Is the clip orientation correct?  Pulled up the GigaDevice flash chip datasheet.
@@ -56,5 +56,5 @@ Plan
 * T:6957: Unplugged it
 * T:7015: Trying a different board.  Now we can see the data line accessing flash every 20ms or so.  16kb cache.
 * T:7199: Switched clock to…
-* [2:02:07](https://www.youtube.com/watch?v=VIDEO_2021_03_04?t=7327) wrap-up
+* [2:02:07](https://www.youtube.com/watch?v=VIDEO_2021_03_04&t=7327) wrap-up
 * Q) Do we have a new language UK-English?  Yes, it’s being built and you can add translations.

--- a/2021/2021-03-12.md
+++ b/2021/2021-03-12.md
@@ -16,54 +16,54 @@ Video: https://www.youtube.com/watch?v=q2SjPZUsgP8
 
 
 Plan
-* [03:09](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=189) hello
-* [06:56](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=416) housekeeping
-* [11:25](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=685) How do you keep the cats away from the workstation and hot irons?
-* [12:40](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=760) how far is circuitpython's implementation of asynchronous I/O scheduler (uasyncio)?
-* [14:44](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=884) Is there a time you'd pick the STM32F405 Feather over the SAMD51 feather? They seem similarly capable, but Adafruit seems all-in on the SAMD51
-* [16:10](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=970) there was no feather airlift so ordered 1 on digikey which has not even shipped yet  Ordered another airlift yesterday from adafruit when it came back in stock so which one will show up first?
-* [18:05](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=1085) Feather RP2040 flash speed fix
-* [18:34](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=1114) OSHPark  USBmicromod/v1
-* [19:29](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=1169) Are you using debug-edge in anything? Know anyone else who is using it?
-* [24:58](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=1498) SMT assembly at OSH Park ( no )
-* [25:11](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=1511) how does OSH's flex pcb compare to the flex PCB on the neopixel/dotstar strips
-* [26:41](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=1601) Overhead / RP2040 feathers… flash socket
-* [34:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=2070) How big flash chip we can use with Metro/Feather M4 express? I tried mounting 64Mb but circuitpython didn't support it!!!
-* [35:37](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=2137) nvm.TOML improvements
-* [38:43](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=2323) Salea Logic Pro 16 work
-* [40:52](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=2452) Is there a good small library for ingesting uart stuff, and parsing into variables, in CP ? (for multi headed use cases)
-* [41:19](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=2479) back to the logic analyzer…. Examining the clock speed up during the boot process
-* [51:10](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=3070) Luke mentions RXDLY  see boot2_w25q80.S for reference
-* [55:46](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=3346) Well it delays your sampling to the point in time where you launch the next clock transition
+* [03:09](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=189) hello
+* [06:56](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=416) housekeeping
+* [11:25](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=685) How do you keep the cats away from the workstation and hot irons?
+* [12:40](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=760) how far is circuitpython's implementation of asynchronous I/O scheduler (uasyncio)?
+* [14:44](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=884) Is there a time you'd pick the STM32F405 Feather over the SAMD51 feather? They seem similarly capable, but Adafruit seems all-in on the SAMD51
+* [16:10](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=970) there was no feather airlift so ordered 1 on digikey which has not even shipped yet  Ordered another airlift yesterday from adafruit when it came back in stock so which one will show up first?
+* [18:05](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=1085) Feather RP2040 flash speed fix
+* [18:34](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=1114) OSHPark  USBmicromod/v1
+* [19:29](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=1169) Are you using debug-edge in anything? Know anyone else who is using it?
+* [24:58](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=1498) SMT assembly at OSH Park ( no )
+* [25:11](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=1511) how does OSH's flex pcb compare to the flex PCB on the neopixel/dotstar strips
+* [26:41](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=1601) Overhead / RP2040 feathers… flash socket
+* [34:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=2070) How big flash chip we can use with Metro/Feather M4 express? I tried mounting 64Mb but circuitpython didn't support it!!!
+* [35:37](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=2137) nvm.TOML improvements
+* [38:43](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=2323) Salea Logic Pro 16 work
+* [40:52](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=2452) Is there a good small library for ingesting uart stuff, and parsing into variables, in CP ? (for multi headed use cases)
+* [41:19](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=2479) back to the logic analyzer…. Examining the clock speed up during the boot process
+* [51:10](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=3070) Luke mentions RXDLY  see boot2_w25q80.S for reference
+* [55:46](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=3346) Well it delays your sampling to the point in time where you launch the next clock transition
 which should still give you plenty of hold time
 because your data hold will be equal to round trip delay
 ​so RX_SAMPLE_DLY = 1 should be fine for BAUDR = 2
 ha, I bet the second read is the hardfault vector fetch
-* [58:35](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=3515) - works one time when new software is installed, but not on power up
-* [1:00:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=3630) is there a good source to understand how PIO was implemented? Its not part of the M0 "platform", right? So I'm assuming it’s something uniquely developed for the RP2040
-* [1:01:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=3690) updating firmware again….
-* [1:06:09](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=3969) Lady Ada drops in1
-* [1:07:14](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=4034) ItsyBitsy RP2040 prototype ( launching with 4MB flash? )
+* [58:35](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=3515) - works one time when new software is installed, but not on power up
+* [1:00:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=3630) is there a good source to understand how PIO was implemented? Its not part of the M0 "platform", right? So I'm assuming it’s something uniquely developed for the RP2040
+* [1:01:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=3690) updating firmware again….
+* [1:06:09](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=3969) Lady Ada drops in1
+* [1:07:14](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=4034) ItsyBitsy RP2040 prototype ( launching with 4MB flash? )
 Discussion of Flash speed
-* [1:17:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=4650) - Luke added “there is more timing to play with -- for boot2_w25q80 we also disable input schmitt to get good setup timing. Have run the winbond devices at their max 133 MHz SCK reliably” ​(with RP2040 running a bit off-label :-)  )
-* [1:21:11](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=4871) ‘quad enable bit non-volatile’ frustration / warning….
-* [1:38:40](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=5920) - catch desk of ladyada on Sunday!
-* [1:39:15](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=5955) bye LadyAda
-* [1:39:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=5970) Does this relate to the QT-Py flash?
-* [1:40:02](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6002) so is there a volatile QSPI enable also?
-* [1:41:25](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6085) Can Micro Python libraries work on Circuit Python?
-* [1:42:06](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6126) Schmidt Trigger idea from Luke …
-* [1:44:02](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6242) how do you get those cool colors and such in your terminal prompt??
-* [1:44:20](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6260) Scott’s quick build machine -j32
-* [1:48:45](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6525) commit code before moving back to C…
-* [1:52:40](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6760) Did you get the Pomona clip working from last week?
-* [1:53:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6810) What are you not allowed to tell us ?
-* [1:55:15](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6915) ​is that 2 x 5 SWD header difficult to solder on?
-* [1:56:55](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=7015) how many times is a decent test for reliability in this sort of case?
-* [1:59:25](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=7165) rebase code
-* [2:00:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=7230) responding to spam calls ..
-* [2:01:00](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=7260) pull request
-* [2:02:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=7350) why are you using Mac? and why not Linux?
-* [2:03:29](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=7409) so what do you use to capture the camera feeds?
-* [2:05:14](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=7514) wrap up
-* [2:06:28](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=7588) sign off 4:07pm...
+* [1:17:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=4650) - Luke added “there is more timing to play with -- for boot2_w25q80 we also disable input schmitt to get good setup timing. Have run the winbond devices at their max 133 MHz SCK reliably” ​(with RP2040 running a bit off-label :-)  )
+* [1:21:11](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=4871) ‘quad enable bit non-volatile’ frustration / warning….
+* [1:38:40](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=5920) - catch desk of ladyada on Sunday!
+* [1:39:15](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=5955) bye LadyAda
+* [1:39:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=5970) Does this relate to the QT-Py flash?
+* [1:40:02](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6002) so is there a volatile QSPI enable also?
+* [1:41:25](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6085) Can Micro Python libraries work on Circuit Python?
+* [1:42:06](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6126) Schmidt Trigger idea from Luke …
+* [1:44:02](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6242) how do you get those cool colors and such in your terminal prompt??
+* [1:44:20](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6260) Scott’s quick build machine -j32
+* [1:48:45](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6525) commit code before moving back to C…
+* [1:52:40](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6760) Did you get the Pomona clip working from last week?
+* [1:53:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6810) What are you not allowed to tell us ?
+* [1:55:15](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6915) ​is that 2 x 5 SWD header difficult to solder on?
+* [1:56:55](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=7015) how many times is a decent test for reliability in this sort of case?
+* [1:59:25](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=7165) rebase code
+* [2:00:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=7230) responding to spam calls ..
+* [2:01:00](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=7260) pull request
+* [2:02:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=7350) why are you using Mac? and why not Linux?
+* [2:03:29](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=7409) so what do you use to capture the camera feeds?
+* [2:05:14](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=7514) wrap up
+* [2:06:28](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=7588) sign off 4:07pm...

--- a/2021/2021-03-12.md
+++ b/2021/2021-03-12.md
@@ -16,54 +16,54 @@ Video: https://www.youtube.com/watch?v=q2SjPZUsgP8
 
 
 Plan
-* [03:09](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=189) hello
-* [06:56](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=416) housekeeping
-* [11:25](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=685) How do you keep the cats away from the workstation and hot irons?
-* [12:40](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=760) how far is circuitpython's implementation of asynchronous I/O scheduler (uasyncio)?
-* [14:44](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=884) Is there a time you'd pick the STM32F405 Feather over the SAMD51 feather? They seem similarly capable, but Adafruit seems all-in on the SAMD51
-* [16:10](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=970) there was no feather airlift so ordered 1 on digikey which has not even shipped yet  Ordered another airlift yesterday from adafruit when it came back in stock so which one will show up first?
-* [18:05](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=1085) Feather RP2040 flash speed fix
-* [18:34](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=1114) OSHPark  USBmicromod/v1
-* [19:29](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=1169) Are you using debug-edge in anything? Know anyone else who is using it?
-* [24:58](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=1498) SMT assembly at OSH Park ( no )
-* [25:11](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=1511) how does OSH's flex pcb compare to the flex PCB on the neopixel/dotstar strips
-* [26:41](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=1601) Overhead / RP2040 feathers… flash socket
-* [34:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=2070) How big flash chip we can use with Metro/Feather M4 express? I tried mounting 64Mb but circuitpython didn't support it!!!
-* [35:37](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=2137) nvm.TOML improvements
-* [38:43](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=2323) Salea Logic Pro 16 work
-* [40:52](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=2452) Is there a good small library for ingesting uart stuff, and parsing into variables, in CP ? (for multi headed use cases)
-* [41:19](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=2479) back to the logic analyzer…. Examining the clock speed up during the boot process
-* [51:10](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=3070) Luke mentions RXDLY  see boot2_w25q80.S for reference
-* [55:46](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=3346) Well it delays your sampling to the point in time where you launch the next clock transition
+* [03:09](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=189) hello
+* [06:56](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=416) housekeeping
+* [11:25](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=685) How do you keep the cats away from the workstation and hot irons?
+* [12:40](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=760) how far is circuitpython's implementation of asynchronous I/O scheduler (uasyncio)?
+* [14:44](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=884) Is there a time you'd pick the STM32F405 Feather over the SAMD51 feather? They seem similarly capable, but Adafruit seems all-in on the SAMD51
+* [16:10](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=970) there was no feather airlift so ordered 1 on digikey which has not even shipped yet  Ordered another airlift yesterday from adafruit when it came back in stock so which one will show up first?
+* [18:05](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=1085) Feather RP2040 flash speed fix
+* [18:34](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=1114) OSHPark  USBmicromod/v1
+* [19:29](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=1169) Are you using debug-edge in anything? Know anyone else who is using it?
+* [24:58](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=1498) SMT assembly at OSH Park ( no )
+* [25:11](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=1511) how does OSH's flex pcb compare to the flex PCB on the neopixel/dotstar strips
+* [26:41](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=1601) Overhead / RP2040 feathers… flash socket
+* [34:30](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=2070) How big flash chip we can use with Metro/Feather M4 express? I tried mounting 64Mb but circuitpython didn't support it!!!
+* [35:37](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=2137) nvm.TOML improvements
+* [38:43](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=2323) Salea Logic Pro 16 work
+* [40:52](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=2452) Is there a good small library for ingesting uart stuff, and parsing into variables, in CP ? (for multi headed use cases)
+* [41:19](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=2479) back to the logic analyzer…. Examining the clock speed up during the boot process
+* [51:10](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=3070) Luke mentions RXDLY  see boot2_w25q80.S for reference
+* [55:46](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=3346) Well it delays your sampling to the point in time where you launch the next clock transition
 which should still give you plenty of hold time
 because your data hold will be equal to round trip delay
 ​so RX_SAMPLE_DLY = 1 should be fine for BAUDR = 2
 ha, I bet the second read is the hardfault vector fetch
-* [58:35](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=3515) - works one time when new software is installed, but not on power up
-* [1:00:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=3630) is there a good source to understand how PIO was implemented? Its not part of the M0 "platform", right? So I'm assuming it’s something uniquely developed for the RP2040
-* [1:01:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=3690) updating firmware again….
-* [1:06:09](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=3969) Lady Ada drops in1
-* [1:07:14](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=4034) ItsyBitsy RP2040 prototype ( launching with 4MB flash? )
+* [58:35](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=3515) - works one time when new software is installed, but not on power up
+* [1:00:30](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=3630) is there a good source to understand how PIO was implemented? Its not part of the M0 "platform", right? So I'm assuming it’s something uniquely developed for the RP2040
+* [1:01:30](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=3690) updating firmware again….
+* [1:06:09](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=3969) Lady Ada drops in1
+* [1:07:14](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=4034) ItsyBitsy RP2040 prototype ( launching with 4MB flash? )
 Discussion of Flash speed
-* [1:17:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=4650) - Luke added “there is more timing to play with -- for boot2_w25q80 we also disable input schmitt to get good setup timing. Have run the winbond devices at their max 133 MHz SCK reliably” ​(with RP2040 running a bit off-label :-)  )
-* [1:21:11](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=4871) ‘quad enable bit non-volatile’ frustration / warning….
-* [1:38:40](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=5920) - catch desk of ladyada on Sunday!
-* [1:39:15](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=5955) bye LadyAda
-* [1:39:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=5970) Does this relate to the QT-Py flash?
-* [1:40:02](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6002) so is there a volatile QSPI enable also?
-* [1:41:25](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6085) Can Micro Python libraries work on Circuit Python?
-* [1:42:06](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6126) Schmidt Trigger idea from Luke …
-* [1:44:02](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6242) how do you get those cool colors and such in your terminal prompt??
-* [1:44:20](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6260) Scott’s quick build machine -j32
-* [1:48:45](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6525) commit code before moving back to C…
-* [1:52:40](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6760) Did you get the Pomona clip working from last week?
-* [1:53:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6810) What are you not allowed to tell us ?
-* [1:55:15](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=6915) ​is that 2 x 5 SWD header difficult to solder on?
-* [1:56:55](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=7015) how many times is a decent test for reliability in this sort of case?
-* [1:59:25](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=7165) rebase code
-* [2:00:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=7230) responding to spam calls ..
-* [2:01:00](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=7260) pull request
-* [2:02:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=7350) why are you using Mac? and why not Linux?
-* [2:03:29](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=7409) so what do you use to capture the camera feeds?
-* [2:05:14](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=7514) wrap up
-* [2:06:28](https://www.youtube.com/watch?v=VIDEO_2021_03_12&t=7588) sign off 4:07pm...
+* [1:17:30](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=4650) - Luke added “there is more timing to play with -- for boot2_w25q80 we also disable input schmitt to get good setup timing. Have run the winbond devices at their max 133 MHz SCK reliably” ​(with RP2040 running a bit off-label :-)  )
+* [1:21:11](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=4871) ‘quad enable bit non-volatile’ frustration / warning….
+* [1:38:40](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=5920) - catch desk of ladyada on Sunday!
+* [1:39:15](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=5955) bye LadyAda
+* [1:39:30](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=5970) Does this relate to the QT-Py flash?
+* [1:40:02](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=6002) so is there a volatile QSPI enable also?
+* [1:41:25](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=6085) Can Micro Python libraries work on Circuit Python?
+* [1:42:06](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=6126) Schmidt Trigger idea from Luke …
+* [1:44:02](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=6242) how do you get those cool colors and such in your terminal prompt??
+* [1:44:20](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=6260) Scott’s quick build machine -j32
+* [1:48:45](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=6525) commit code before moving back to C…
+* [1:52:40](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=6760) Did you get the Pomona clip working from last week?
+* [1:53:30](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=6810) What are you not allowed to tell us ?
+* [1:55:15](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=6915) ​is that 2 x 5 SWD header difficult to solder on?
+* [1:56:55](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=7015) how many times is a decent test for reliability in this sort of case?
+* [1:59:25](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=7165) rebase code
+* [2:00:30](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=7230) responding to spam calls ..
+* [2:01:00](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=7260) pull request
+* [2:02:30](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=7350) why are you using Mac? and why not Linux?
+* [2:03:29](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=7409) so what do you use to capture the camera feeds?
+* [2:05:14](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=7514) wrap up
+* [2:06:28](https://www.youtube.com/watch?v=q2SjPZUsgP8&t=7588) sign off 4:07pm...

--- a/2021/2021-03-12.md
+++ b/2021/2021-03-12.md
@@ -16,54 +16,54 @@ Video: https://www.youtube.com/watch?v=q2SjPZUsgP8
 
 
 Plan
-* 03:09 hello 
-* 06:56 housekeeping
-* 11:25 How do you keep the cats away from the workstation and hot irons?
-* 12:40 how far is circuitpython's implementation of asynchronous I/O scheduler (uasyncio)?
-* 14:44 Is there a time you'd pick the STM32F405 Feather over the SAMD51 feather? They seem similarly capable, but Adafruit seems all-in on the SAMD51
-* 16:10 there was no feather airlift so ordered 1 on digikey which has not even shipped yet  Ordered another airlift yesterday from adafruit when it came back in stock so which one will show up first?
-* 18:05 Feather RP2040 flash speed fix
-* 18:34 OSHPark  USBmicromod/v1
-* 19:29 Are you using debug-edge in anything? Know anyone else who is using it?
-* 24:58 SMT assembly at OSH Park ( no )
-* 25:11 how does OSH's flex pcb compare to the flex PCB on the neopixel/dotstar strips
-* 26:41 Overhead / RP2040 feathers… flash socket
-* 34:30 How big flash chip we can use with Metro/Feather M4 express? I tried mounting 64Mb but circuitpython didn't support it!!!
-* 35:37 nvm.TOML improvements
-* 38:43 Salea Logic Pro 16 work
-* 40:52 Is there a good small library for ingesting uart stuff, and parsing into variables, in CP ? (for multi headed use cases)
-* 41:19 back to the logic analyzer…. Examining the clock speed up during the boot process
-* 51:10 Luke mentions RXDLY  see boot2_w25q80.S for reference
-* 55:46 Well it delays your sampling to the point in time where you launch the next clock transition
+* [03:09](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=189) hello
+* [06:56](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=416) housekeeping
+* [11:25](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=685) How do you keep the cats away from the workstation and hot irons?
+* [12:40](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=760) how far is circuitpython's implementation of asynchronous I/O scheduler (uasyncio)?
+* [14:44](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=884) Is there a time you'd pick the STM32F405 Feather over the SAMD51 feather? They seem similarly capable, but Adafruit seems all-in on the SAMD51
+* [16:10](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=970) there was no feather airlift so ordered 1 on digikey which has not even shipped yet  Ordered another airlift yesterday from adafruit when it came back in stock so which one will show up first?
+* [18:05](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=1085) Feather RP2040 flash speed fix
+* [18:34](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=1114) OSHPark  USBmicromod/v1
+* [19:29](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=1169) Are you using debug-edge in anything? Know anyone else who is using it?
+* [24:58](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=1498) SMT assembly at OSH Park ( no )
+* [25:11](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=1511) how does OSH's flex pcb compare to the flex PCB on the neopixel/dotstar strips
+* [26:41](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=1601) Overhead / RP2040 feathers… flash socket
+* [34:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=2070) How big flash chip we can use with Metro/Feather M4 express? I tried mounting 64Mb but circuitpython didn't support it!!!
+* [35:37](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=2137) nvm.TOML improvements
+* [38:43](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=2323) Salea Logic Pro 16 work
+* [40:52](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=2452) Is there a good small library for ingesting uart stuff, and parsing into variables, in CP ? (for multi headed use cases)
+* [41:19](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=2479) back to the logic analyzer…. Examining the clock speed up during the boot process
+* [51:10](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=3070) Luke mentions RXDLY  see boot2_w25q80.S for reference
+* [55:46](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=3346) Well it delays your sampling to the point in time where you launch the next clock transition
 which should still give you plenty of hold time
 because your data hold will be equal to round trip delay
 ​so RX_SAMPLE_DLY = 1 should be fine for BAUDR = 2
 ha, I bet the second read is the hardfault vector fetch
-* 58:35 - works one time when new software is installed, but not on power up
-* 1:00:30 is there a good source to understand how PIO was implemented? Its not part of the M0 "platform", right? So I'm assuming it’s something uniquely developed for the RP2040
-* 1:01:30 updating firmware again….
-* 1:06:09 Lady Ada drops in1
-* 1:07:14 ItsyBitsy RP2040 prototype ( launching with 4MB flash? )
+* [58:35](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=3515) - works one time when new software is installed, but not on power up
+* [1:00:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=3630) is there a good source to understand how PIO was implemented? Its not part of the M0 "platform", right? So I'm assuming it’s something uniquely developed for the RP2040
+* [1:01:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=3690) updating firmware again….
+* [1:06:09](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=3969) Lady Ada drops in1
+* [1:07:14](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=4034) ItsyBitsy RP2040 prototype ( launching with 4MB flash? )
 Discussion of Flash speed
-* 1:17:30 - Luke added “there is more timing to play with -- for boot2_w25q80 we also disable input schmitt to get good setup timing. Have run the winbond devices at their max 133 MHz SCK reliably” ​(with RP2040 running a bit off-label :-)  )
-* 1:21:11 ‘quad enable bit non-volatile’ frustration / warning….
-* 1:38:40 - catch desk of ladyada on Sunday!
-* 1:39:15 bye LadyAda
-* 1:39:30 Does this relate to the QT-Py flash?
-* 1:40:02 so is there a volatile QSPI enable also?
-* 1:41:25 Can Micro Python libraries work on Circuit Python?
-* 1:42:06 Schmidt Trigger idea from Luke …
-* 1:44:02 how do you get those cool colors and such in your terminal prompt??
-* 1:44:20 Scott’s quick build machine -j32 
-* 1:48:45 commit code before moving back to C…
-* 1:52:40 Did you get the Pomona clip working from last week?
-* 1:53:30 What are you not allowed to tell us ?
-* 1:55:15 ​is that 2 x 5 SWD header difficult to solder on?
-* 1:56:55 how many times is a decent test for reliability in this sort of case?
-* 1:59:25 rebase code 
-* 2:00:30 responding to spam calls .. 
-* 2:01:00 pull request
-* 2:02:30 why are you using Mac? and why not Linux?
-* 2:03:29 so what do you use to capture the camera feeds?
-* 2:05:14 wrap up
-* 2:06:28 sign off 4:07pm...
+* [1:17:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=4650) - Luke added “there is more timing to play with -- for boot2_w25q80 we also disable input schmitt to get good setup timing. Have run the winbond devices at their max 133 MHz SCK reliably” ​(with RP2040 running a bit off-label :-)  )
+* [1:21:11](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=4871) ‘quad enable bit non-volatile’ frustration / warning….
+* [1:38:40](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=5920) - catch desk of ladyada on Sunday!
+* [1:39:15](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=5955) bye LadyAda
+* [1:39:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=5970) Does this relate to the QT-Py flash?
+* [1:40:02](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6002) so is there a volatile QSPI enable also?
+* [1:41:25](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6085) Can Micro Python libraries work on Circuit Python?
+* [1:42:06](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6126) Schmidt Trigger idea from Luke …
+* [1:44:02](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6242) how do you get those cool colors and such in your terminal prompt??
+* [1:44:20](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6260) Scott’s quick build machine -j32
+* [1:48:45](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6525) commit code before moving back to C…
+* [1:52:40](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6760) Did you get the Pomona clip working from last week?
+* [1:53:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6810) What are you not allowed to tell us ?
+* [1:55:15](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=6915) ​is that 2 x 5 SWD header difficult to solder on?
+* [1:56:55](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=7015) how many times is a decent test for reliability in this sort of case?
+* [1:59:25](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=7165) rebase code
+* [2:00:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=7230) responding to spam calls ..
+* [2:01:00](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=7260) pull request
+* [2:02:30](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=7350) why are you using Mac? and why not Linux?
+* [2:03:29](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=7409) so what do you use to capture the camera feeds?
+* [2:05:14](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=7514) wrap up
+* [2:06:28](https://www.youtube.com/watch?v=VIDEO_2021_03_12?t=7588) sign off 4:07pm...

--- a/2021/2021-03-19.md
+++ b/2021/2021-03-19.md
@@ -14,36 +14,36 @@ Housekeeping
 Plan
 
 
-* 06:42 housekeeping  (2:00 PM pdt )
-* 08:50 Sandy MacDonald (from Pimoroni) first live stream on the Keybow 2040.
-* 10:35 Mailbag Compute Module board and module
-* 12:56 bluetooth work coming…
-* 14:05 Hacktober fest T-shirt
-* 15:39 14:53 New Soldering iron
-* 16:54 Detour - Logic Pro 16 / Logic 2 / Feather + SPI flash
-* 18:40 simple parallel support - wrapping up pull request for spi flash…
-* 20:34 asking about “the state of CircuitPython on Zephyr” and I realized I never heard the two in the same sentence.
-* 23:09 ​DSLogic is a solid and cheaper alternative for a logic analyser … Saleae is awesome kit. 
-* 24:39 SPI Flash is local version ‘plug-in’ for the Logic 2  0.9.0 
-* 29:06 code review - including gen_stage2.py ( toml )
-* 40:39 continued review stage2.c.jinja
-* 48:05 Dual Mode considerations…
-* 49:08 continue review with rp2040  internal_flash.c 
-* 52:19 check out the code / testing…
-* 55:40 flash data sheets…
-* 1:01:10 How consistent are these [flash] commands? Is there a standard?
+* [06:42](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=402) housekeeping  (2:00 PM pdt )
+* [08:50](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=530) Sandy MacDonald (from Pimoroni) first live stream on the Keybow 2040.
+* [10:35](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=635) Mailbag Compute Module board and module
+* [12:56](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=776) bluetooth work coming…
+* [14:05](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=845) Hacktober fest T-shirt
+* [15:39](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=939) 14:53 New Soldering iron
+* [16:54](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=1014) Detour - Logic Pro 16 / Logic 2 / Feather + SPI flash
+* [18:40](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=1120) simple parallel support - wrapping up pull request for spi flash…
+* [20:34](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=1234) asking about “the state of CircuitPython on Zephyr” and I realized I never heard the two in the same sentence.
+* [23:09](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=1389) ​DSLogic is a solid and cheaper alternative for a logic analyser … Saleae is awesome kit.
+* [24:39](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=1479) SPI Flash is local version ‘plug-in’ for the Logic 2  0.9.0
+* [29:06](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=1746) code review - including gen_stage2.py ( toml )
+* [40:39](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=2439) continued review stage2.c.jinja
+* [48:05](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=2885) Dual Mode considerations…
+* [49:08](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=2948) continue review with rp2040  internal_flash.c
+* [52:19](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=3139) check out the code / testing…
+* [55:40](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=3340) flash data sheets…
+* [1:01:10](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=3670) How consistent are these [flash] commands? Is there a standard?
 Luke Wren​There are *many* standards :)
-* 1:08:00 Learn guide / Building CircuitPython 
-* 1:08:30 Limor was talking about erasing the flash taking a long time in manufacturing (might have been on Desk of LA). This Flash has a "chip erase" command that is quicker than doing it block by block.
-* 1:10:00 Isn't the most recent CircuitPython build info here: https://github.com/adafruit/circuitpython/blob/main/BUILDING.md
-* 1:13:40 Dev Requirements for python
-* 1:15:30 continue verifying that adding the Jinja, hyufman, typer, polib and TOML dependencies is ok
-* 1:16:39 requirements-dev.txt  / BUILDING.md
-* 1:18:05 Is there a separate build process/etc for just the Blinka libraries? Does this impact them?
-* 1:21:25 verify the CI dependencies ( build.yml )
-* 1:29:00 Is there a TOML parser for CircuitPython or is it "just python"
-* 1:29:54 open the pull request - CI does the testing :-)
-* 1:30:30 ​Are there other languages like circut python? Like circut C++ or circut JS?
-* 1:33:59 Wrap up - Next week on Thursday
+* [1:08:00](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=4080) Learn guide / Building CircuitPython
+* [1:08:30](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=4110) Limor was talking about erasing the flash taking a long time in manufacturing (might have been on Desk of LA). This Flash has a "chip erase" command that is quicker than doing it block by block.
+* [1:10:00](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=4200) Isn't the most recent CircuitPython build info here: https://github.com/adafruit/circuitpython/blob/main/BUILDING.md
+* [1:13:40](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=4420) Dev Requirements for python
+* [1:15:30](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=4530) continue verifying that adding the Jinja, hyufman, typer, polib and TOML dependencies is ok
+* [1:16:39](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=4599) requirements-dev.txt  / BUILDING.md
+* [1:18:05](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=4685) Is there a separate build process/etc for just the Blinka libraries? Does this impact them?
+* [1:21:25](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=4885) verify the CI dependencies ( build.yml )
+* [1:29:00](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=5340) Is there a TOML parser for CircuitPython or is it "just python"
+* [1:29:54](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=5394) open the pull request - CI does the testing :-)
+* [1:30:30](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=5430) ​Are there other languages like circut python? Like circut C++ or circut JS?
+* [1:33:59](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=5639) Wrap up - Next week on Thursday
 1:35:36 3:30PM PDT
 *

--- a/2021/2021-03-19.md
+++ b/2021/2021-03-19.md
@@ -14,36 +14,36 @@ Housekeeping
 Plan
 
 
-* [06:42](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=402) housekeeping  (2:00 PM pdt )
-* [08:50](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=530) Sandy MacDonald (from Pimoroni) first live stream on the Keybow 2040.
-* [10:35](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=635) Mailbag Compute Module board and module
-* [12:56](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=776) bluetooth work coming…
-* [14:05](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=845) Hacktober fest T-shirt
-* [15:39](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=939) 14:53 New Soldering iron
-* [16:54](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=1014) Detour - Logic Pro 16 / Logic 2 / Feather + SPI flash
-* [18:40](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=1120) simple parallel support - wrapping up pull request for spi flash…
-* [20:34](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=1234) asking about “the state of CircuitPython on Zephyr” and I realized I never heard the two in the same sentence.
-* [23:09](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=1389) ​DSLogic is a solid and cheaper alternative for a logic analyser … Saleae is awesome kit.
-* [24:39](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=1479) SPI Flash is local version ‘plug-in’ for the Logic 2  0.9.0
-* [29:06](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=1746) code review - including gen_stage2.py ( toml )
-* [40:39](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=2439) continued review stage2.c.jinja
-* [48:05](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=2885) Dual Mode considerations…
-* [49:08](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=2948) continue review with rp2040  internal_flash.c
-* [52:19](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=3139) check out the code / testing…
-* [55:40](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=3340) flash data sheets…
-* [1:01:10](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=3670) How consistent are these [flash] commands? Is there a standard?
+* [06:42](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=402) housekeeping  (2:00 PM pdt )
+* [08:50](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=530) Sandy MacDonald (from Pimoroni) first live stream on the Keybow 2040.
+* [10:35](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=635) Mailbag Compute Module board and module
+* [12:56](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=776) bluetooth work coming…
+* [14:05](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=845) Hacktober fest T-shirt
+* [15:39](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=939) 14:53 New Soldering iron
+* [16:54](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=1014) Detour - Logic Pro 16 / Logic 2 / Feather + SPI flash
+* [18:40](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=1120) simple parallel support - wrapping up pull request for spi flash…
+* [20:34](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=1234) asking about “the state of CircuitPython on Zephyr” and I realized I never heard the two in the same sentence.
+* [23:09](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=1389) ​DSLogic is a solid and cheaper alternative for a logic analyser … Saleae is awesome kit.
+* [24:39](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=1479) SPI Flash is local version ‘plug-in’ for the Logic 2  0.9.0
+* [29:06](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=1746) code review - including gen_stage2.py ( toml )
+* [40:39](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=2439) continued review stage2.c.jinja
+* [48:05](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=2885) Dual Mode considerations…
+* [49:08](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=2948) continue review with rp2040  internal_flash.c
+* [52:19](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=3139) check out the code / testing…
+* [55:40](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=3340) flash data sheets…
+* [1:01:10](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=3670) How consistent are these [flash] commands? Is there a standard?
 Luke Wren​There are *many* standards :)
-* [1:08:00](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=4080) Learn guide / Building CircuitPython
-* [1:08:30](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=4110) Limor was talking about erasing the flash taking a long time in manufacturing (might have been on Desk of LA). This Flash has a "chip erase" command that is quicker than doing it block by block.
-* [1:10:00](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=4200) Isn't the most recent CircuitPython build info here: https://github.com/adafruit/circuitpython/blob/main/BUILDING.md
-* [1:13:40](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=4420) Dev Requirements for python
-* [1:15:30](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=4530) continue verifying that adding the Jinja, hyufman, typer, polib and TOML dependencies is ok
-* [1:16:39](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=4599) requirements-dev.txt  / BUILDING.md
-* [1:18:05](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=4685) Is there a separate build process/etc for just the Blinka libraries? Does this impact them?
-* [1:21:25](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=4885) verify the CI dependencies ( build.yml )
-* [1:29:00](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=5340) Is there a TOML parser for CircuitPython or is it "just python"
-* [1:29:54](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=5394) open the pull request - CI does the testing :-)
-* [1:30:30](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=5430) ​Are there other languages like circut python? Like circut C++ or circut JS?
-* [1:33:59](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=5639) Wrap up - Next week on Thursday
+* [1:08:00](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=4080) Learn guide / Building CircuitPython
+* [1:08:30](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=4110) Limor was talking about erasing the flash taking a long time in manufacturing (might have been on Desk of LA). This Flash has a "chip erase" command that is quicker than doing it block by block.
+* [1:10:00](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=4200) Isn't the most recent CircuitPython build info here: https://github.com/adafruit/circuitpython/blob/main/BUILDING.md
+* [1:13:40](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=4420) Dev Requirements for python
+* [1:15:30](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=4530) continue verifying that adding the Jinja, hyufman, typer, polib and TOML dependencies is ok
+* [1:16:39](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=4599) requirements-dev.txt  / BUILDING.md
+* [1:18:05](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=4685) Is there a separate build process/etc for just the Blinka libraries? Does this impact them?
+* [1:21:25](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=4885) verify the CI dependencies ( build.yml )
+* [1:29:00](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=5340) Is there a TOML parser for CircuitPython or is it "just python"
+* [1:29:54](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=5394) open the pull request - CI does the testing :-)
+* [1:30:30](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=5430) ​Are there other languages like circut python? Like circut C++ or circut JS?
+* [1:33:59](https://www.youtube.com/watch?v=TjfxnFr7Owg&t=5639) Wrap up - Next week on Thursday
 1:35:36 3:30PM PDT
 *

--- a/2021/2021-03-19.md
+++ b/2021/2021-03-19.md
@@ -14,36 +14,36 @@ Housekeeping
 Plan
 
 
-* [06:42](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=402) housekeeping  (2:00 PM pdt )
-* [08:50](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=530) Sandy MacDonald (from Pimoroni) first live stream on the Keybow 2040.
-* [10:35](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=635) Mailbag Compute Module board and module
-* [12:56](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=776) bluetooth work coming…
-* [14:05](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=845) Hacktober fest T-shirt
-* [15:39](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=939) 14:53 New Soldering iron
-* [16:54](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=1014) Detour - Logic Pro 16 / Logic 2 / Feather + SPI flash
-* [18:40](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=1120) simple parallel support - wrapping up pull request for spi flash…
-* [20:34](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=1234) asking about “the state of CircuitPython on Zephyr” and I realized I never heard the two in the same sentence.
-* [23:09](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=1389) ​DSLogic is a solid and cheaper alternative for a logic analyser … Saleae is awesome kit.
-* [24:39](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=1479) SPI Flash is local version ‘plug-in’ for the Logic 2  0.9.0
-* [29:06](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=1746) code review - including gen_stage2.py ( toml )
-* [40:39](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=2439) continued review stage2.c.jinja
-* [48:05](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=2885) Dual Mode considerations…
-* [49:08](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=2948) continue review with rp2040  internal_flash.c
-* [52:19](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=3139) check out the code / testing…
-* [55:40](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=3340) flash data sheets…
-* [1:01:10](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=3670) How consistent are these [flash] commands? Is there a standard?
+* [06:42](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=402) housekeeping  (2:00 PM pdt )
+* [08:50](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=530) Sandy MacDonald (from Pimoroni) first live stream on the Keybow 2040.
+* [10:35](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=635) Mailbag Compute Module board and module
+* [12:56](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=776) bluetooth work coming…
+* [14:05](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=845) Hacktober fest T-shirt
+* [15:39](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=939) 14:53 New Soldering iron
+* [16:54](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=1014) Detour - Logic Pro 16 / Logic 2 / Feather + SPI flash
+* [18:40](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=1120) simple parallel support - wrapping up pull request for spi flash…
+* [20:34](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=1234) asking about “the state of CircuitPython on Zephyr” and I realized I never heard the two in the same sentence.
+* [23:09](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=1389) ​DSLogic is a solid and cheaper alternative for a logic analyser … Saleae is awesome kit.
+* [24:39](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=1479) SPI Flash is local version ‘plug-in’ for the Logic 2  0.9.0
+* [29:06](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=1746) code review - including gen_stage2.py ( toml )
+* [40:39](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=2439) continued review stage2.c.jinja
+* [48:05](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=2885) Dual Mode considerations…
+* [49:08](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=2948) continue review with rp2040  internal_flash.c
+* [52:19](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=3139) check out the code / testing…
+* [55:40](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=3340) flash data sheets…
+* [1:01:10](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=3670) How consistent are these [flash] commands? Is there a standard?
 Luke Wren​There are *many* standards :)
-* [1:08:00](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=4080) Learn guide / Building CircuitPython
-* [1:08:30](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=4110) Limor was talking about erasing the flash taking a long time in manufacturing (might have been on Desk of LA). This Flash has a "chip erase" command that is quicker than doing it block by block.
-* [1:10:00](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=4200) Isn't the most recent CircuitPython build info here: https://github.com/adafruit/circuitpython/blob/main/BUILDING.md
-* [1:13:40](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=4420) Dev Requirements for python
-* [1:15:30](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=4530) continue verifying that adding the Jinja, hyufman, typer, polib and TOML dependencies is ok
-* [1:16:39](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=4599) requirements-dev.txt  / BUILDING.md
-* [1:18:05](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=4685) Is there a separate build process/etc for just the Blinka libraries? Does this impact them?
-* [1:21:25](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=4885) verify the CI dependencies ( build.yml )
-* [1:29:00](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=5340) Is there a TOML parser for CircuitPython or is it "just python"
-* [1:29:54](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=5394) open the pull request - CI does the testing :-)
-* [1:30:30](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=5430) ​Are there other languages like circut python? Like circut C++ or circut JS?
-* [1:33:59](https://www.youtube.com/watch?v=VIDEO_2021_03_19?t=5639) Wrap up - Next week on Thursday
+* [1:08:00](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=4080) Learn guide / Building CircuitPython
+* [1:08:30](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=4110) Limor was talking about erasing the flash taking a long time in manufacturing (might have been on Desk of LA). This Flash has a "chip erase" command that is quicker than doing it block by block.
+* [1:10:00](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=4200) Isn't the most recent CircuitPython build info here: https://github.com/adafruit/circuitpython/blob/main/BUILDING.md
+* [1:13:40](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=4420) Dev Requirements for python
+* [1:15:30](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=4530) continue verifying that adding the Jinja, hyufman, typer, polib and TOML dependencies is ok
+* [1:16:39](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=4599) requirements-dev.txt  / BUILDING.md
+* [1:18:05](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=4685) Is there a separate build process/etc for just the Blinka libraries? Does this impact them?
+* [1:21:25](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=4885) verify the CI dependencies ( build.yml )
+* [1:29:00](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=5340) Is there a TOML parser for CircuitPython or is it "just python"
+* [1:29:54](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=5394) open the pull request - CI does the testing :-)
+* [1:30:30](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=5430) ​Are there other languages like circut python? Like circut C++ or circut JS?
+* [1:33:59](https://www.youtube.com/watch?v=VIDEO_2021_03_19&t=5639) Wrap up - Next week on Thursday
 1:35:36 3:30PM PDT
 *

--- a/2021/2021-03-25.md
+++ b/2021/2021-03-25.md
@@ -13,17 +13,17 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* [09:42](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=582) digikey order
-* [20:41](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=1241) designing a pcb?
-* [24:19](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=1459) How to configure the UART receive interrupt in Circuitpython?
-* [26:17](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=1577) USB host is supported on the Teensy 4.1, plan to support in CP?
-* [27:28](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=1648) What is the intended purpose of the Seesaw?
-* [30:11](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=1811) What are/would be the major milestones to get a BT-only experience working on a CP device?
-* [38:35](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=2315) HCI
-* [39:24](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=2364) So would REPL be part of the initial BT/BLE workflow, or a later enhacement?
-* [41:24](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=2484) Can we do BT gateaway chinese wall with BT on the AirLift and BT on the NRF52840?
-* [43:04](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=2584) Switching platforms - iMX unboxing
-* [53:51](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=3231) Doesn't the Teensy have a proprietary part? Like the bootloader? And it is supported. Where other iMX board are "raw"? So what will be the difference for CP support?
-* [1:19:35](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=4775) check on flash PR
-* [1:29:50](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=5390) How to add a flash chip to nvm.toml
-* [2:08:51](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=7731) wrap-up
+* [09:42](https://www.youtube.com/watch?v=gG2S0H5DQaY&t=582) digikey order
+* [20:41](https://www.youtube.com/watch?v=gG2S0H5DQaY&t=1241) designing a pcb?
+* [24:19](https://www.youtube.com/watch?v=gG2S0H5DQaY&t=1459) How to configure the UART receive interrupt in Circuitpython?
+* [26:17](https://www.youtube.com/watch?v=gG2S0H5DQaY&t=1577) USB host is supported on the Teensy 4.1, plan to support in CP?
+* [27:28](https://www.youtube.com/watch?v=gG2S0H5DQaY&t=1648) What is the intended purpose of the Seesaw?
+* [30:11](https://www.youtube.com/watch?v=gG2S0H5DQaY&t=1811) What are/would be the major milestones to get a BT-only experience working on a CP device?
+* [38:35](https://www.youtube.com/watch?v=gG2S0H5DQaY&t=2315) HCI
+* [39:24](https://www.youtube.com/watch?v=gG2S0H5DQaY&t=2364) So would REPL be part of the initial BT/BLE workflow, or a later enhacement?
+* [41:24](https://www.youtube.com/watch?v=gG2S0H5DQaY&t=2484) Can we do BT gateaway chinese wall with BT on the AirLift and BT on the NRF52840?
+* [43:04](https://www.youtube.com/watch?v=gG2S0H5DQaY&t=2584) Switching platforms - iMX unboxing
+* [53:51](https://www.youtube.com/watch?v=gG2S0H5DQaY&t=3231) Doesn't the Teensy have a proprietary part? Like the bootloader? And it is supported. Where other iMX board are "raw"? So what will be the difference for CP support?
+* [1:19:35](https://www.youtube.com/watch?v=gG2S0H5DQaY&t=4775) check on flash PR
+* [1:29:50](https://www.youtube.com/watch?v=gG2S0H5DQaY&t=5390) How to add a flash chip to nvm.toml
+* [2:08:51](https://www.youtube.com/watch?v=gG2S0H5DQaY&t=7731) wrap-up

--- a/2021/2021-03-25.md
+++ b/2021/2021-03-25.md
@@ -13,17 +13,17 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* [09:42](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=582) digikey order
-* [20:41](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=1241) designing a pcb?
-* [24:19](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=1459) How to configure the UART receive interrupt in Circuitpython?
-* [26:17](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=1577) USB host is supported on the Teensy 4.1, plan to support in CP?
-* [27:28](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=1648) What is the intended purpose of the Seesaw?
-* [30:11](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=1811) What are/would be the major milestones to get a BT-only experience working on a CP device?
-* [38:35](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=2315) HCI
-* [39:24](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=2364) So would REPL be part of the initial BT/BLE workflow, or a later enhacement?
-* [41:24](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=2484) Can we do BT gateaway chinese wall with BT on the AirLift and BT on the NRF52840?
-* [43:04](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=2584) Switching platforms - iMX unboxing
-* [53:51](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=3231) Doesn't the Teensy have a proprietary part? Like the bootloader? And it is supported. Where other iMX board are "raw"? So what will be the difference for CP support?
-* [1:19:35](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=4775) check on flash PR
-* [1:29:50](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=5390) How to add a flash chip to nvm.toml
-* [2:08:51](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=7731) wrap-up
+* [09:42](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=582) digikey order
+* [20:41](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=1241) designing a pcb?
+* [24:19](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=1459) How to configure the UART receive interrupt in Circuitpython?
+* [26:17](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=1577) USB host is supported on the Teensy 4.1, plan to support in CP?
+* [27:28](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=1648) What is the intended purpose of the Seesaw?
+* [30:11](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=1811) What are/would be the major milestones to get a BT-only experience working on a CP device?
+* [38:35](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=2315) HCI
+* [39:24](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=2364) So would REPL be part of the initial BT/BLE workflow, or a later enhacement?
+* [41:24](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=2484) Can we do BT gateaway chinese wall with BT on the AirLift and BT on the NRF52840?
+* [43:04](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=2584) Switching platforms - iMX unboxing
+* [53:51](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=3231) Doesn't the Teensy have a proprietary part? Like the bootloader? And it is supported. Where other iMX board are "raw"? So what will be the difference for CP support?
+* [1:19:35](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=4775) check on flash PR
+* [1:29:50](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=5390) How to add a flash chip to nvm.toml
+* [2:08:51](https://www.youtube.com/watch?v=VIDEO_2021_03_25&t=7731) wrap-up

--- a/2021/2021-03-25.md
+++ b/2021/2021-03-25.md
@@ -4,7 +4,7 @@
 Hi all, this doc is try and track topics and timecodes for my deep dive stream. These notes will end up in the YouTube video’s description. Any help keeping them groomed as I stream is welcome.
 
 
-04:11 Housekeeping
+[04:11](https://www.youtube.com/watch?v=gG2S0H5DQaY&t=251) Housekeeping
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.

--- a/2021/2021-03-25.md
+++ b/2021/2021-03-25.md
@@ -13,17 +13,17 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Plan
-* 09:42 digikey order
-* 20:41 designing a pcb?
-* 24:19 How to configure the UART receive interrupt in Circuitpython?
-* 26:17 USB host is supported on the Teensy 4.1, plan to support in CP?
-* 27:28 What is the intended purpose of the Seesaw?
-* 30:11 What are/would be the major milestones to get a BT-only experience working on a CP device?
-* 38:35 HCI
-* 39:24 So would REPL be part of the initial BT/BLE workflow, or a later enhacement?
-* 41:24 Can we do BT gateaway chinese wall with BT on the AirLift and BT on the NRF52840?
-* 43:04 Switching platforms - iMX unboxing
-* 53:51 Doesn't the Teensy have a proprietary part? Like the bootloader? And it is supported. Where other iMX board are "raw"? So what will be the difference for CP support?
-* 1:19:35 check on flash PR
-* 1:29:50 How to add a flash chip to nvm.toml 
-* 2:08:51 wrap-up
+* [09:42](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=582) digikey order
+* [20:41](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=1241) designing a pcb?
+* [24:19](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=1459) How to configure the UART receive interrupt in Circuitpython?
+* [26:17](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=1577) USB host is supported on the Teensy 4.1, plan to support in CP?
+* [27:28](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=1648) What is the intended purpose of the Seesaw?
+* [30:11](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=1811) What are/would be the major milestones to get a BT-only experience working on a CP device?
+* [38:35](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=2315) HCI
+* [39:24](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=2364) So would REPL be part of the initial BT/BLE workflow, or a later enhacement?
+* [41:24](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=2484) Can we do BT gateaway chinese wall with BT on the AirLift and BT on the NRF52840?
+* [43:04](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=2584) Switching platforms - iMX unboxing
+* [53:51](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=3231) Doesn't the Teensy have a proprietary part? Like the bootloader? And it is supported. Where other iMX board are "raw"? So what will be the difference for CP support?
+* [1:19:35](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=4775) check on flash PR
+* [1:29:50](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=5390) How to add a flash chip to nvm.toml
+* [2:08:51](https://www.youtube.com/watch?v=VIDEO_2021_03_25?t=7731) wrap-up

--- a/2021/2021-04-02.md
+++ b/2021/2021-04-02.md
@@ -13,64 +13,64 @@ Housekeeping
 
         Unplanned - youtube only, plus discord
 Plan
-* 3:30 - hello and thanks to 009 for the gpu clue
-* 6:30 - q: just started my first BLE project that i showed on S&T. i'm confused what the BLE components i need to setup some kind of "clear/reset connections and repair from scratch" button to make my board useable across devices without having to manually disconnect before reconnecting
+* [3:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=210) - hello and thanks to 009 for the gpu clue
+* [6:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=390) - q: just started my first BLE project that i showed on S&T. i'm confused what the BLE components i need to setup some kind of "clear/reset connections and repair from scratch" button to make my board useable across devices without having to manually disconnect before reconnecting
 *repair read as re-pair right now when i plug in the battery, it auto connects to my laptop, unless i first disconnect from the laptop. i'd like to have a button that just forgets connected devices and goes into pairing mode
-* 8:45 - core modules ble erase_bonding…
-* 9:25 am working on a digital thermometer for an old bmw that would obviously show the engine's temp. I want to use an stm32. so what advice would you give me knowing that am really bad with programming
-* 14:30 BLE - Bluetooth Low Energy
-* 17:17 Circuit Playground Bluefruit - Bluetooth Low Energy
-* 19:40 what applications would you recommend BLE for?
-* 25:15 Bonding
-* 29:11 I know you can SEND data with the Micro:bit BLE, but can you program it from mobile through BLE??
-* 29:40 Serial/UART over BLE is not "super standard" as opposed to Serial on Bluetooth. There is a circuit python LIB that does the Nordic way. But you cannot change the UUID for another copy of serial.
-* 30:15 BLE workflow - discovery
-* 35:25 for devices that allow multiple devices to connect (like a mouse that toggles between machines) do you need a separate BLE chip for each device?
-* 36:30 Is this workflow tied to BLE or is it standard for regular (older) bluetooth as well?
-* 36:50 The number of pairs, bonds, or connected?
-* 39:45 ​I want to make a BLE keyboard that I can quickly switch between my phone, desktop, laptop, and RPi. So, what's the most bonds possible?
-* 41:40 what security things should be we aware of when working w/ BLE?
-* 43:15 Works well unless all the manufactures hardcode it to 1234 or 0000 to make it easier to connect
-* 43:40 there was a microcontroller that used flashing an led and your phone camera to pass pairing info
-* 44:46 nfc is another system for pairing. but once paired then you have to increase security at least that's my vague understanding
-* 45:50 Desktop / “where scott is at”...
-* 46:20 Packet buffer fixes #4535
-* 48:00 ​Don't the packets have sequence numbers?
-* 48:47 Fix central pairing #4522
-* 51:11 Proof of concept code for CP future behavior
-* 51:54 I noticed a 7.0.0 tag has appeared in the CPY repo. wonder what that will bring
-* 52:35 switching how we do microlab (ulab? sp) for CP 7.0
-* 53:35 So it is not going to be in the "kernel" but in "library"? Or it is a mockup in "userland"?
-* 54:05 Adafruit_CircuitPython_BLE_Creation / Creation IDs on github
-* 57:30 instance id?  ( NO )
-* 1:02:14 Creator IDs, how are you allocating them? So 0x1234_xxxx could be registered by one person/organisation?
-* 1:03:22 Examples ( advertisement / scan? )
-* 1:04:30 File Transfer
-* 1:06:20 The BLE SIG is in Kirkland, WA if you want to chat with them. I might have some contacts.
-* 1:06:35 There is/was that file transfer solution over the REPL for micropython. Can you reuse that?
-* 1:07:55 Do you envision the BLE file transfer protocol requiring the storage to be mounted writable from boot.py on the CircuitPython device?
-* 1:09:20 ampy <== That was the recommendation for micropython… ( “No - don’t like it”)
-* 1:09:40 This might be old information... but at one point iOS didn't support serial over bluetooth. (Ham radio control apps used this). Has that changed ?
-* 1:10:30 What is BLE range on CPB/Micro:bit (estimate)
-* 1:11:55 Does BLE keyboard use scan codes or ASCII? ( Same as USB )
-* 1:13:12 BLE file transfer library
-* 1:14:00 BLE number set
-* 1:17:00 ​I'm going to need a way for my keyboard to know whether the device it's talking to is in Dvorak or US mode.
-* 1:19:35 Flow Control
-* 1:21:15 demo 
-* 1:22:35 In "Bluefruit Connect" you have packet based protocol, over serial with function like picking a color or sending image... you could expand that.
-* 1:24:19 Is the bug that it's starting to corrupt the file system, but not finishing the job? Or that it's corrupting the filesystem at all? Asking for someone who is pedantic about the English language
-* 1:24:45 Maybe that "Bluefruit Connect" and protocol and serial was there for old way to connect serial co-pro to old stuff, before nRF52 support.
-* 1:25:21 - Demo …( using tio  on arch linux )
-* 1:28:25 - Ryzen 16-core - speedier than a raspberry pi 4
-* 1:31:05 - simulating the file system in a dictionary
-* 1:32:58 book recommendations for ble ?
-* 1:34:27 Blinka "server side" thing, to control a PiZero? Is that possible or we hit a limitation of BLE on the Blinka side? ( To have the BLE workflow for a Pi. )
-* 1:35:02 https://www.amazon.com/Make-Bluetooth-Projects-Raspberry-Smartphones/dp/1457187094 for Sander Vesik's question.
-* 1:38:07 Any news about the "convergence" with BLE on micropython? /Both MP and CP were developing separately at the same time. / Low level, so blinka can build on top... to make it CP like.
-* 1:40:20 ​I guess they're not big on hand-holding. ( referring to micropython )
-* 1:45:00 outline for OHS
-* 1:47:49 Soooo at 15 minutes is it a shallow dive ?
-* 1:48:15 plan for next weeks - don’t block Trevor 
-* 1:49:38 wrap up
+* [8:45](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=525) - core modules ble erase_bonding…
+* [9:25](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=565) am working on a digital thermometer for an old bmw that would obviously show the engine's temp. I want to use an stm32. so what advice would you give me knowing that am really bad with programming
+* [14:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=870) BLE - Bluetooth Low Energy
+* [17:17](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=1037) Circuit Playground Bluefruit - Bluetooth Low Energy
+* [19:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=1180) what applications would you recommend BLE for?
+* [25:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=1515) Bonding
+* [29:11](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=1751) I know you can SEND data with the Micro:bit BLE, but can you program it from mobile through BLE??
+* [29:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=1780) Serial/UART over BLE is not "super standard" as opposed to Serial on Bluetooth. There is a circuit python LIB that does the Nordic way. But you cannot change the UUID for another copy of serial.
+* [30:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=1815) BLE workflow - discovery
+* [35:25](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2125) for devices that allow multiple devices to connect (like a mouse that toggles between machines) do you need a separate BLE chip for each device?
+* [36:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2190) Is this workflow tied to BLE or is it standard for regular (older) bluetooth as well?
+* [36:50](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2210) The number of pairs, bonds, or connected?
+* [39:45](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2385) ​I want to make a BLE keyboard that I can quickly switch between my phone, desktop, laptop, and RPi. So, what's the most bonds possible?
+* [41:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2500) what security things should be we aware of when working w/ BLE?
+* [43:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2595) Works well unless all the manufactures hardcode it to 1234 or 0000 to make it easier to connect
+* [43:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2620) there was a microcontroller that used flashing an led and your phone camera to pass pairing info
+* [44:46](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2686) nfc is another system for pairing. but once paired then you have to increase security at least that's my vague understanding
+* [45:50](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2750) Desktop / “where scott is at”...
+* [46:20](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2780) Packet buffer fixes #4535
+* [48:00](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2880) ​Don't the packets have sequence numbers?
+* [48:47](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2927) Fix central pairing #4522
+* [51:11](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3071) Proof of concept code for CP future behavior
+* [51:54](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3114) I noticed a 7.0.0 tag has appeared in the CPY repo. wonder what that will bring
+* [52:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3155) switching how we do microlab (ulab? sp) for CP 7.0
+* [53:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3215) So it is not going to be in the "kernel" but in "library"? Or it is a mockup in "userland"?
+* [54:05](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3245) Adafruit_CircuitPython_BLE_Creation / Creation IDs on github
+* [57:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3450) instance id?  ( NO )
+* [1:02:14](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3734) Creator IDs, how are you allocating them? So 0x1234_xxxx could be registered by one person/organisation?
+* [1:03:22](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3802) Examples ( advertisement / scan? )
+* [1:04:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3870) File Transfer
+* [1:06:20](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3980) The BLE SIG is in Kirkland, WA if you want to chat with them. I might have some contacts.
+* [1:06:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3995) There is/was that file transfer solution over the REPL for micropython. Can you reuse that?
+* [1:07:55](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4075) Do you envision the BLE file transfer protocol requiring the storage to be mounted writable from boot.py on the CircuitPython device?
+* [1:09:20](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4160) ampy <== That was the recommendation for micropython… ( “No - don’t like it”)
+* [1:09:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4180) This might be old information... but at one point iOS didn't support serial over bluetooth. (Ham radio control apps used this). Has that changed ?
+* [1:10:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4230) What is BLE range on CPB/Micro:bit (estimate)
+* [1:11:55](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4315) Does BLE keyboard use scan codes or ASCII? ( Same as USB )
+* [1:13:12](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4392) BLE file transfer library
+* [1:14:00](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4440) BLE number set
+* [1:17:00](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4620) ​I'm going to need a way for my keyboard to know whether the device it's talking to is in Dvorak or US mode.
+* [1:19:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4775) Flow Control
+* [1:21:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4875) demo
+* [1:22:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4955) In "Bluefruit Connect" you have packet based protocol, over serial with function like picking a color or sending image... you could expand that.
+* [1:24:19](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5059) Is the bug that it's starting to corrupt the file system, but not finishing the job? Or that it's corrupting the filesystem at all? Asking for someone who is pedantic about the English language
+* [1:24:45](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5085) Maybe that "Bluefruit Connect" and protocol and serial was there for old way to connect serial co-pro to old stuff, before nRF52 support.
+* [1:25:21](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5121) - Demo …( using tio  on arch linux )
+* [1:28:25](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5305) - Ryzen 16-core - speedier than a raspberry pi 4
+* [1:31:05](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5465) - simulating the file system in a dictionary
+* [1:32:58](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5578) book recommendations for ble ?
+* [1:34:27](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5667) Blinka "server side" thing, to control a PiZero? Is that possible or we hit a limitation of BLE on the Blinka side? ( To have the BLE workflow for a Pi. )
+* [1:35:02](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5702) https://www.amazon.com/Make-Bluetooth-Projects-Raspberry-Smartphones/dp/1457187094 for Sander Vesik's question.
+* [1:38:07](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5887) Any news about the "convergence" with BLE on micropython? /Both MP and CP were developing separately at the same time. / Low level, so blinka can build on top... to make it CP like.
+* [1:40:20](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=6020) ​I guess they're not big on hand-holding. ( referring to micropython )
+* [1:45:00](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=6300) outline for OHS
+* [1:47:49](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=6469) Soooo at 15 minutes is it a shallow dive ?
+* [1:48:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=6495) plan for next weeks - don’t block Trevor
+* [1:49:38](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=6578) wrap up
 * --- 4:07 PM 1:53:05

--- a/2021/2021-04-02.md
+++ b/2021/2021-04-02.md
@@ -13,64 +13,64 @@ Housekeeping
 
         Unplanned - youtube only, plus discord
 Plan
-* [3:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=210) - hello and thanks to 009 for the gpu clue
-* [6:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=390) - q: just started my first BLE project that i showed on S&T. i'm confused what the BLE components i need to setup some kind of "clear/reset connections and repair from scratch" button to make my board useable across devices without having to manually disconnect before reconnecting
+* [3:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=210) - hello and thanks to 009 for the gpu clue
+* [6:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=390) - q: just started my first BLE project that i showed on S&T. i'm confused what the BLE components i need to setup some kind of "clear/reset connections and repair from scratch" button to make my board useable across devices without having to manually disconnect before reconnecting
 *repair read as re-pair right now when i plug in the battery, it auto connects to my laptop, unless i first disconnect from the laptop. i'd like to have a button that just forgets connected devices and goes into pairing mode
-* [8:45](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=525) - core modules ble erase_bonding…
-* [9:25](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=565) am working on a digital thermometer for an old bmw that would obviously show the engine's temp. I want to use an stm32. so what advice would you give me knowing that am really bad with programming
-* [14:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=870) BLE - Bluetooth Low Energy
-* [17:17](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=1037) Circuit Playground Bluefruit - Bluetooth Low Energy
-* [19:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=1180) what applications would you recommend BLE for?
-* [25:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=1515) Bonding
-* [29:11](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=1751) I know you can SEND data with the Micro:bit BLE, but can you program it from mobile through BLE??
-* [29:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=1780) Serial/UART over BLE is not "super standard" as opposed to Serial on Bluetooth. There is a circuit python LIB that does the Nordic way. But you cannot change the UUID for another copy of serial.
-* [30:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=1815) BLE workflow - discovery
-* [35:25](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2125) for devices that allow multiple devices to connect (like a mouse that toggles between machines) do you need a separate BLE chip for each device?
-* [36:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2190) Is this workflow tied to BLE or is it standard for regular (older) bluetooth as well?
-* [36:50](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2210) The number of pairs, bonds, or connected?
-* [39:45](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2385) ​I want to make a BLE keyboard that I can quickly switch between my phone, desktop, laptop, and RPi. So, what's the most bonds possible?
-* [41:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2500) what security things should be we aware of when working w/ BLE?
-* [43:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2595) Works well unless all the manufactures hardcode it to 1234 or 0000 to make it easier to connect
-* [43:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2620) there was a microcontroller that used flashing an led and your phone camera to pass pairing info
-* [44:46](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2686) nfc is another system for pairing. but once paired then you have to increase security at least that's my vague understanding
-* [45:50](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2750) Desktop / “where scott is at”...
-* [46:20](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2780) Packet buffer fixes #4535
-* [48:00](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2880) ​Don't the packets have sequence numbers?
-* [48:47](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=2927) Fix central pairing #4522
-* [51:11](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3071) Proof of concept code for CP future behavior
-* [51:54](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3114) I noticed a 7.0.0 tag has appeared in the CPY repo. wonder what that will bring
-* [52:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3155) switching how we do microlab (ulab? sp) for CP 7.0
-* [53:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3215) So it is not going to be in the "kernel" but in "library"? Or it is a mockup in "userland"?
-* [54:05](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3245) Adafruit_CircuitPython_BLE_Creation / Creation IDs on github
-* [57:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3450) instance id?  ( NO )
-* [1:02:14](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3734) Creator IDs, how are you allocating them? So 0x1234_xxxx could be registered by one person/organisation?
-* [1:03:22](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3802) Examples ( advertisement / scan? )
-* [1:04:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3870) File Transfer
-* [1:06:20](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3980) The BLE SIG is in Kirkland, WA if you want to chat with them. I might have some contacts.
-* [1:06:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=3995) There is/was that file transfer solution over the REPL for micropython. Can you reuse that?
-* [1:07:55](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4075) Do you envision the BLE file transfer protocol requiring the storage to be mounted writable from boot.py on the CircuitPython device?
-* [1:09:20](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4160) ampy <== That was the recommendation for micropython… ( “No - don’t like it”)
-* [1:09:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4180) This might be old information... but at one point iOS didn't support serial over bluetooth. (Ham radio control apps used this). Has that changed ?
-* [1:10:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4230) What is BLE range on CPB/Micro:bit (estimate)
-* [1:11:55](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4315) Does BLE keyboard use scan codes or ASCII? ( Same as USB )
-* [1:13:12](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4392) BLE file transfer library
-* [1:14:00](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4440) BLE number set
-* [1:17:00](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4620) ​I'm going to need a way for my keyboard to know whether the device it's talking to is in Dvorak or US mode.
-* [1:19:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4775) Flow Control
-* [1:21:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4875) demo
-* [1:22:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=4955) In "Bluefruit Connect" you have packet based protocol, over serial with function like picking a color or sending image... you could expand that.
-* [1:24:19](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5059) Is the bug that it's starting to corrupt the file system, but not finishing the job? Or that it's corrupting the filesystem at all? Asking for someone who is pedantic about the English language
-* [1:24:45](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5085) Maybe that "Bluefruit Connect" and protocol and serial was there for old way to connect serial co-pro to old stuff, before nRF52 support.
-* [1:25:21](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5121) - Demo …( using tio  on arch linux )
-* [1:28:25](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5305) - Ryzen 16-core - speedier than a raspberry pi 4
-* [1:31:05](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5465) - simulating the file system in a dictionary
-* [1:32:58](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5578) book recommendations for ble ?
-* [1:34:27](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5667) Blinka "server side" thing, to control a PiZero? Is that possible or we hit a limitation of BLE on the Blinka side? ( To have the BLE workflow for a Pi. )
-* [1:35:02](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5702) https://www.amazon.com/Make-Bluetooth-Projects-Raspberry-Smartphones/dp/1457187094 for Sander Vesik's question.
-* [1:38:07](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=5887) Any news about the "convergence" with BLE on micropython? /Both MP and CP were developing separately at the same time. / Low level, so blinka can build on top... to make it CP like.
-* [1:40:20](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=6020) ​I guess they're not big on hand-holding. ( referring to micropython )
-* [1:45:00](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=6300) outline for OHS
-* [1:47:49](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=6469) Soooo at 15 minutes is it a shallow dive ?
-* [1:48:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=6495) plan for next weeks - don’t block Trevor
-* [1:49:38](https://www.youtube.com/watch?v=VIDEO_2021_04_02?t=6578) wrap up
+* [8:45](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=525) - core modules ble erase_bonding…
+* [9:25](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=565) am working on a digital thermometer for an old bmw that would obviously show the engine's temp. I want to use an stm32. so what advice would you give me knowing that am really bad with programming
+* [14:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=870) BLE - Bluetooth Low Energy
+* [17:17](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=1037) Circuit Playground Bluefruit - Bluetooth Low Energy
+* [19:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=1180) what applications would you recommend BLE for?
+* [25:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=1515) Bonding
+* [29:11](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=1751) I know you can SEND data with the Micro:bit BLE, but can you program it from mobile through BLE??
+* [29:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=1780) Serial/UART over BLE is not "super standard" as opposed to Serial on Bluetooth. There is a circuit python LIB that does the Nordic way. But you cannot change the UUID for another copy of serial.
+* [30:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=1815) BLE workflow - discovery
+* [35:25](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2125) for devices that allow multiple devices to connect (like a mouse that toggles between machines) do you need a separate BLE chip for each device?
+* [36:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2190) Is this workflow tied to BLE or is it standard for regular (older) bluetooth as well?
+* [36:50](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2210) The number of pairs, bonds, or connected?
+* [39:45](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2385) ​I want to make a BLE keyboard that I can quickly switch between my phone, desktop, laptop, and RPi. So, what's the most bonds possible?
+* [41:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2500) what security things should be we aware of when working w/ BLE?
+* [43:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2595) Works well unless all the manufactures hardcode it to 1234 or 0000 to make it easier to connect
+* [43:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2620) there was a microcontroller that used flashing an led and your phone camera to pass pairing info
+* [44:46](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2686) nfc is another system for pairing. but once paired then you have to increase security at least that's my vague understanding
+* [45:50](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2750) Desktop / “where scott is at”...
+* [46:20](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2780) Packet buffer fixes #4535
+* [48:00](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2880) ​Don't the packets have sequence numbers?
+* [48:47](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2927) Fix central pairing #4522
+* [51:11](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3071) Proof of concept code for CP future behavior
+* [51:54](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3114) I noticed a 7.0.0 tag has appeared in the CPY repo. wonder what that will bring
+* [52:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3155) switching how we do microlab (ulab? sp) for CP 7.0
+* [53:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3215) So it is not going to be in the "kernel" but in "library"? Or it is a mockup in "userland"?
+* [54:05](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3245) Adafruit_CircuitPython_BLE_Creation / Creation IDs on github
+* [57:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3450) instance id?  ( NO )
+* [1:02:14](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3734) Creator IDs, how are you allocating them? So 0x1234_xxxx could be registered by one person/organisation?
+* [1:03:22](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3802) Examples ( advertisement / scan? )
+* [1:04:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3870) File Transfer
+* [1:06:20](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3980) The BLE SIG is in Kirkland, WA if you want to chat with them. I might have some contacts.
+* [1:06:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3995) There is/was that file transfer solution over the REPL for micropython. Can you reuse that?
+* [1:07:55](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4075) Do you envision the BLE file transfer protocol requiring the storage to be mounted writable from boot.py on the CircuitPython device?
+* [1:09:20](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4160) ampy <== That was the recommendation for micropython… ( “No - don’t like it”)
+* [1:09:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4180) This might be old information... but at one point iOS didn't support serial over bluetooth. (Ham radio control apps used this). Has that changed ?
+* [1:10:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4230) What is BLE range on CPB/Micro:bit (estimate)
+* [1:11:55](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4315) Does BLE keyboard use scan codes or ASCII? ( Same as USB )
+* [1:13:12](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4392) BLE file transfer library
+* [1:14:00](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4440) BLE number set
+* [1:17:00](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4620) ​I'm going to need a way for my keyboard to know whether the device it's talking to is in Dvorak or US mode.
+* [1:19:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4775) Flow Control
+* [1:21:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4875) demo
+* [1:22:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4955) In "Bluefruit Connect" you have packet based protocol, over serial with function like picking a color or sending image... you could expand that.
+* [1:24:19](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5059) Is the bug that it's starting to corrupt the file system, but not finishing the job? Or that it's corrupting the filesystem at all? Asking for someone who is pedantic about the English language
+* [1:24:45](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5085) Maybe that "Bluefruit Connect" and protocol and serial was there for old way to connect serial co-pro to old stuff, before nRF52 support.
+* [1:25:21](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5121) - Demo …( using tio  on arch linux )
+* [1:28:25](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5305) - Ryzen 16-core - speedier than a raspberry pi 4
+* [1:31:05](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5465) - simulating the file system in a dictionary
+* [1:32:58](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5578) book recommendations for ble ?
+* [1:34:27](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5667) Blinka "server side" thing, to control a PiZero? Is that possible or we hit a limitation of BLE on the Blinka side? ( To have the BLE workflow for a Pi. )
+* [1:35:02](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5702) https://www.amazon.com/Make-Bluetooth-Projects-Raspberry-Smartphones/dp/1457187094 for Sander Vesik's question.
+* [1:38:07](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5887) Any news about the "convergence" with BLE on micropython? /Both MP and CP were developing separately at the same time. / Low level, so blinka can build on top... to make it CP like.
+* [1:40:20](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=6020) ​I guess they're not big on hand-holding. ( referring to micropython )
+* [1:45:00](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=6300) outline for OHS
+* [1:47:49](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=6469) Soooo at 15 minutes is it a shallow dive ?
+* [1:48:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=6495) plan for next weeks - don’t block Trevor
+* [1:49:38](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=6578) wrap up
 * --- 4:07 PM 1:53:05

--- a/2021/2021-04-02.md
+++ b/2021/2021-04-02.md
@@ -13,64 +13,64 @@ Housekeeping
 
         Unplanned - youtube only, plus discord
 Plan
-* [3:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=210) - hello and thanks to 009 for the gpu clue
-* [6:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=390) - q: just started my first BLE project that i showed on S&T. i'm confused what the BLE components i need to setup some kind of "clear/reset connections and repair from scratch" button to make my board useable across devices without having to manually disconnect before reconnecting
+* [3:30](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=210) - hello and thanks to 009 for the gpu clue
+* [6:30](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=390) - q: just started my first BLE project that i showed on S&T. i'm confused what the BLE components i need to setup some kind of "clear/reset connections and repair from scratch" button to make my board useable across devices without having to manually disconnect before reconnecting
 *repair read as re-pair right now when i plug in the battery, it auto connects to my laptop, unless i first disconnect from the laptop. i'd like to have a button that just forgets connected devices and goes into pairing mode
-* [8:45](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=525) - core modules ble erase_bonding…
-* [9:25](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=565) am working on a digital thermometer for an old bmw that would obviously show the engine's temp. I want to use an stm32. so what advice would you give me knowing that am really bad with programming
-* [14:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=870) BLE - Bluetooth Low Energy
-* [17:17](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=1037) Circuit Playground Bluefruit - Bluetooth Low Energy
-* [19:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=1180) what applications would you recommend BLE for?
-* [25:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=1515) Bonding
-* [29:11](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=1751) I know you can SEND data with the Micro:bit BLE, but can you program it from mobile through BLE??
-* [29:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=1780) Serial/UART over BLE is not "super standard" as opposed to Serial on Bluetooth. There is a circuit python LIB that does the Nordic way. But you cannot change the UUID for another copy of serial.
-* [30:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=1815) BLE workflow - discovery
-* [35:25](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2125) for devices that allow multiple devices to connect (like a mouse that toggles between machines) do you need a separate BLE chip for each device?
-* [36:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2190) Is this workflow tied to BLE or is it standard for regular (older) bluetooth as well?
-* [36:50](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2210) The number of pairs, bonds, or connected?
-* [39:45](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2385) ​I want to make a BLE keyboard that I can quickly switch between my phone, desktop, laptop, and RPi. So, what's the most bonds possible?
-* [41:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2500) what security things should be we aware of when working w/ BLE?
-* [43:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2595) Works well unless all the manufactures hardcode it to 1234 or 0000 to make it easier to connect
-* [43:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2620) there was a microcontroller that used flashing an led and your phone camera to pass pairing info
-* [44:46](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2686) nfc is another system for pairing. but once paired then you have to increase security at least that's my vague understanding
-* [45:50](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2750) Desktop / “where scott is at”...
-* [46:20](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2780) Packet buffer fixes #4535
-* [48:00](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2880) ​Don't the packets have sequence numbers?
-* [48:47](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=2927) Fix central pairing #4522
-* [51:11](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3071) Proof of concept code for CP future behavior
-* [51:54](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3114) I noticed a 7.0.0 tag has appeared in the CPY repo. wonder what that will bring
-* [52:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3155) switching how we do microlab (ulab? sp) for CP 7.0
-* [53:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3215) So it is not going to be in the "kernel" but in "library"? Or it is a mockup in "userland"?
-* [54:05](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3245) Adafruit_CircuitPython_BLE_Creation / Creation IDs on github
-* [57:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3450) instance id?  ( NO )
-* [1:02:14](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3734) Creator IDs, how are you allocating them? So 0x1234_xxxx could be registered by one person/organisation?
-* [1:03:22](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3802) Examples ( advertisement / scan? )
-* [1:04:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3870) File Transfer
-* [1:06:20](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3980) The BLE SIG is in Kirkland, WA if you want to chat with them. I might have some contacts.
-* [1:06:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=3995) There is/was that file transfer solution over the REPL for micropython. Can you reuse that?
-* [1:07:55](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4075) Do you envision the BLE file transfer protocol requiring the storage to be mounted writable from boot.py on the CircuitPython device?
-* [1:09:20](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4160) ampy <== That was the recommendation for micropython… ( “No - don’t like it”)
-* [1:09:40](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4180) This might be old information... but at one point iOS didn't support serial over bluetooth. (Ham radio control apps used this). Has that changed ?
-* [1:10:30](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4230) What is BLE range on CPB/Micro:bit (estimate)
-* [1:11:55](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4315) Does BLE keyboard use scan codes or ASCII? ( Same as USB )
-* [1:13:12](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4392) BLE file transfer library
-* [1:14:00](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4440) BLE number set
-* [1:17:00](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4620) ​I'm going to need a way for my keyboard to know whether the device it's talking to is in Dvorak or US mode.
-* [1:19:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4775) Flow Control
-* [1:21:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4875) demo
-* [1:22:35](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=4955) In "Bluefruit Connect" you have packet based protocol, over serial with function like picking a color or sending image... you could expand that.
-* [1:24:19](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5059) Is the bug that it's starting to corrupt the file system, but not finishing the job? Or that it's corrupting the filesystem at all? Asking for someone who is pedantic about the English language
-* [1:24:45](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5085) Maybe that "Bluefruit Connect" and protocol and serial was there for old way to connect serial co-pro to old stuff, before nRF52 support.
-* [1:25:21](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5121) - Demo …( using tio  on arch linux )
-* [1:28:25](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5305) - Ryzen 16-core - speedier than a raspberry pi 4
-* [1:31:05](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5465) - simulating the file system in a dictionary
-* [1:32:58](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5578) book recommendations for ble ?
-* [1:34:27](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5667) Blinka "server side" thing, to control a PiZero? Is that possible or we hit a limitation of BLE on the Blinka side? ( To have the BLE workflow for a Pi. )
-* [1:35:02](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5702) https://www.amazon.com/Make-Bluetooth-Projects-Raspberry-Smartphones/dp/1457187094 for Sander Vesik's question.
-* [1:38:07](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=5887) Any news about the "convergence" with BLE on micropython? /Both MP and CP were developing separately at the same time. / Low level, so blinka can build on top... to make it CP like.
-* [1:40:20](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=6020) ​I guess they're not big on hand-holding. ( referring to micropython )
-* [1:45:00](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=6300) outline for OHS
-* [1:47:49](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=6469) Soooo at 15 minutes is it a shallow dive ?
-* [1:48:15](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=6495) plan for next weeks - don’t block Trevor
-* [1:49:38](https://www.youtube.com/watch?v=VIDEO_2021_04_02&t=6578) wrap up
+* [8:45](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=525) - core modules ble erase_bonding…
+* [9:25](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=565) am working on a digital thermometer for an old bmw that would obviously show the engine's temp. I want to use an stm32. so what advice would you give me knowing that am really bad with programming
+* [14:30](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=870) BLE - Bluetooth Low Energy
+* [17:17](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=1037) Circuit Playground Bluefruit - Bluetooth Low Energy
+* [19:40](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=1180) what applications would you recommend BLE for?
+* [25:15](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=1515) Bonding
+* [29:11](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=1751) I know you can SEND data with the Micro:bit BLE, but can you program it from mobile through BLE??
+* [29:40](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=1780) Serial/UART over BLE is not "super standard" as opposed to Serial on Bluetooth. There is a circuit python LIB that does the Nordic way. But you cannot change the UUID for another copy of serial.
+* [30:15](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=1815) BLE workflow - discovery
+* [35:25](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=2125) for devices that allow multiple devices to connect (like a mouse that toggles between machines) do you need a separate BLE chip for each device?
+* [36:30](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=2190) Is this workflow tied to BLE or is it standard for regular (older) bluetooth as well?
+* [36:50](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=2210) The number of pairs, bonds, or connected?
+* [39:45](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=2385) ​I want to make a BLE keyboard that I can quickly switch between my phone, desktop, laptop, and RPi. So, what's the most bonds possible?
+* [41:40](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=2500) what security things should be we aware of when working w/ BLE?
+* [43:15](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=2595) Works well unless all the manufactures hardcode it to 1234 or 0000 to make it easier to connect
+* [43:40](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=2620) there was a microcontroller that used flashing an led and your phone camera to pass pairing info
+* [44:46](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=2686) nfc is another system for pairing. but once paired then you have to increase security at least that's my vague understanding
+* [45:50](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=2750) Desktop / “where scott is at”...
+* [46:20](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=2780) Packet buffer fixes #4535
+* [48:00](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=2880) ​Don't the packets have sequence numbers?
+* [48:47](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=2927) Fix central pairing #4522
+* [51:11](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=3071) Proof of concept code for CP future behavior
+* [51:54](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=3114) I noticed a 7.0.0 tag has appeared in the CPY repo. wonder what that will bring
+* [52:35](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=3155) switching how we do microlab (ulab? sp) for CP 7.0
+* [53:35](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=3215) So it is not going to be in the "kernel" but in "library"? Or it is a mockup in "userland"?
+* [54:05](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=3245) Adafruit_CircuitPython_BLE_Creation / Creation IDs on github
+* [57:30](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=3450) instance id?  ( NO )
+* [1:02:14](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=3734) Creator IDs, how are you allocating them? So 0x1234_xxxx could be registered by one person/organisation?
+* [1:03:22](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=3802) Examples ( advertisement / scan? )
+* [1:04:30](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=3870) File Transfer
+* [1:06:20](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=3980) The BLE SIG is in Kirkland, WA if you want to chat with them. I might have some contacts.
+* [1:06:35](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=3995) There is/was that file transfer solution over the REPL for micropython. Can you reuse that?
+* [1:07:55](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=4075) Do you envision the BLE file transfer protocol requiring the storage to be mounted writable from boot.py on the CircuitPython device?
+* [1:09:20](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=4160) ampy <== That was the recommendation for micropython… ( “No - don’t like it”)
+* [1:09:40](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=4180) This might be old information... but at one point iOS didn't support serial over bluetooth. (Ham radio control apps used this). Has that changed ?
+* [1:10:30](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=4230) What is BLE range on CPB/Micro:bit (estimate)
+* [1:11:55](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=4315) Does BLE keyboard use scan codes or ASCII? ( Same as USB )
+* [1:13:12](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=4392) BLE file transfer library
+* [1:14:00](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=4440) BLE number set
+* [1:17:00](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=4620) ​I'm going to need a way for my keyboard to know whether the device it's talking to is in Dvorak or US mode.
+* [1:19:35](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=4775) Flow Control
+* [1:21:15](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=4875) demo
+* [1:22:35](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=4955) In "Bluefruit Connect" you have packet based protocol, over serial with function like picking a color or sending image... you could expand that.
+* [1:24:19](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=5059) Is the bug that it's starting to corrupt the file system, but not finishing the job? Or that it's corrupting the filesystem at all? Asking for someone who is pedantic about the English language
+* [1:24:45](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=5085) Maybe that "Bluefruit Connect" and protocol and serial was there for old way to connect serial co-pro to old stuff, before nRF52 support.
+* [1:25:21](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=5121) - Demo …( using tio  on arch linux )
+* [1:28:25](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=5305) - Ryzen 16-core - speedier than a raspberry pi 4
+* [1:31:05](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=5465) - simulating the file system in a dictionary
+* [1:32:58](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=5578) book recommendations for ble ?
+* [1:34:27](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=5667) Blinka "server side" thing, to control a PiZero? Is that possible or we hit a limitation of BLE on the Blinka side? ( To have the BLE workflow for a Pi. )
+* [1:35:02](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=5702) https://www.amazon.com/Make-Bluetooth-Projects-Raspberry-Smartphones/dp/1457187094 for Sander Vesik's question.
+* [1:38:07](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=5887) Any news about the "convergence" with BLE on micropython? /Both MP and CP were developing separately at the same time. / Low level, so blinka can build on top... to make it CP like.
+* [1:40:20](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=6020) ​I guess they're not big on hand-holding. ( referring to micropython )
+* [1:45:00](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=6300) outline for OHS
+* [1:47:49](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=6469) Soooo at 15 minutes is it a shallow dive ?
+* [1:48:15](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=6495) plan for next weeks - don’t block Trevor
+* [1:49:38](https://www.youtube.com/watch?v=QVgmQCBXTZ8&t=6578) wrap up
 * --- 4:07 PM 1:53:05

--- a/2021/2021-04-09.md
+++ b/2021/2021-04-09.md
@@ -12,15 +12,15 @@ Housekeeping
 
 
 Plan
-* [5:57](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=357) housekeeping
-* [8:54](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=534) anniversary
-* [11:55](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=715) ​I am trying to write, compile and build in C++ for the RPi Pico. Do you have an advice for a source to increase my knowledge of C++ ?
-* [14:18](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=858) hellow scoot , ever heard about low energy packets ,piconets in bluetooth,? they are uses for Wpan wireless personal area networks mostly for devices,wearables but rarely also for implantable devices
+* [5:57](https://www.youtube.com/watch?v=7djiPZU85OY&t=357) housekeeping
+* [8:54](https://www.youtube.com/watch?v=7djiPZU85OY&t=534) anniversary
+* [11:55](https://www.youtube.com/watch?v=7djiPZU85OY&t=715) ​I am trying to write, compile and build in C++ for the RPi Pico. Do you have an advice for a source to increase my knowledge of C++ ?
+* [14:18](https://www.youtube.com/watch?v=7djiPZU85OY&t=858) hellow scoot , ever heard about low energy packets ,piconets in bluetooth,? they are uses for Wpan wireless personal area networks mostly for devices,wearables but rarely also for implantable devices
 * 21;27 Open hardware summit
-* [48:00](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=2880) Could you please link in the Audio sessions you did previously?
-* [49:47](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=2987) Will CPY 7.x be merged with MPY 1.14 (or later)
-* [52:41](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=3161) what are the major milestones for that merge to take place?
-* [57:26](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=3446) ESP32-C6
-* [1:06:06](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=3966) Q: I don't remember with 100% certainty, but did you share a resource on getting up to speed, or at least familiar, with BLE, protocols, etc?
-* [1:11:52](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=4312) onto ble
+* [48:00](https://www.youtube.com/watch?v=7djiPZU85OY&t=2880) Could you please link in the Audio sessions you did previously?
+* [49:47](https://www.youtube.com/watch?v=7djiPZU85OY&t=2987) Will CPY 7.x be merged with MPY 1.14 (or later)
+* [52:41](https://www.youtube.com/watch?v=7djiPZU85OY&t=3161) what are the major milestones for that merge to take place?
+* [57:26](https://www.youtube.com/watch?v=7djiPZU85OY&t=3446) ESP32-C6
+* [1:06:06](https://www.youtube.com/watch?v=7djiPZU85OY&t=3966) Q: I don't remember with 100% certainty, but did you share a resource on getting up to speed, or at least familiar, with BLE, protocols, etc?
+* [1:11:52](https://www.youtube.com/watch?v=7djiPZU85OY&t=4312) onto ble
 * LadyAda

--- a/2021/2021-04-09.md
+++ b/2021/2021-04-09.md
@@ -12,15 +12,15 @@ Housekeeping
 
 
 Plan
-* 5:57 housekeeping 
-* 8:54 anniversary
-* 11:55 ​I am trying to write, compile and build in C++ for the RPi Pico. Do you have an advice for a source to increase my knowledge of C++ ?
-* 14:18 hellow scoot , ever heard about low energy packets ,piconets in bluetooth,? they are uses for Wpan wireless personal area networks mostly for devices,wearables but rarely also for implantable devices
+* [5:57](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=357) housekeeping
+* [8:54](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=534) anniversary
+* [11:55](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=715) ​I am trying to write, compile and build in C++ for the RPi Pico. Do you have an advice for a source to increase my knowledge of C++ ?
+* [14:18](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=858) hellow scoot , ever heard about low energy packets ,piconets in bluetooth,? they are uses for Wpan wireless personal area networks mostly for devices,wearables but rarely also for implantable devices
 * 21;27 Open hardware summit
-* 48:00 Could you please link in the Audio sessions you did previously?
-* 49:47 Will CPY 7.x be merged with MPY 1.14 (or later)
-* 52:41 what are the major milestones for that merge to take place?
-* 57:26 ESP32-C6
-* 1:06:06 Q: I don't remember with 100% certainty, but did you share a resource on getting up to speed, or at least familiar, with BLE, protocols, etc?
-* 1:11:52 onto ble
+* [48:00](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=2880) Could you please link in the Audio sessions you did previously?
+* [49:47](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=2987) Will CPY 7.x be merged with MPY 1.14 (or later)
+* [52:41](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=3161) what are the major milestones for that merge to take place?
+* [57:26](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=3446) ESP32-C6
+* [1:06:06](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=3966) Q: I don't remember with 100% certainty, but did you share a resource on getting up to speed, or at least familiar, with BLE, protocols, etc?
+* [1:11:52](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=4312) onto ble
 * LadyAda

--- a/2021/2021-04-09.md
+++ b/2021/2021-04-09.md
@@ -12,15 +12,15 @@ Housekeeping
 
 
 Plan
-* [5:57](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=357) housekeeping
-* [8:54](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=534) anniversary
-* [11:55](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=715) ​I am trying to write, compile and build in C++ for the RPi Pico. Do you have an advice for a source to increase my knowledge of C++ ?
-* [14:18](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=858) hellow scoot , ever heard about low energy packets ,piconets in bluetooth,? they are uses for Wpan wireless personal area networks mostly for devices,wearables but rarely also for implantable devices
+* [5:57](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=357) housekeeping
+* [8:54](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=534) anniversary
+* [11:55](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=715) ​I am trying to write, compile and build in C++ for the RPi Pico. Do you have an advice for a source to increase my knowledge of C++ ?
+* [14:18](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=858) hellow scoot , ever heard about low energy packets ,piconets in bluetooth,? they are uses for Wpan wireless personal area networks mostly for devices,wearables but rarely also for implantable devices
 * 21;27 Open hardware summit
-* [48:00](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=2880) Could you please link in the Audio sessions you did previously?
-* [49:47](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=2987) Will CPY 7.x be merged with MPY 1.14 (or later)
-* [52:41](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=3161) what are the major milestones for that merge to take place?
-* [57:26](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=3446) ESP32-C6
-* [1:06:06](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=3966) Q: I don't remember with 100% certainty, but did you share a resource on getting up to speed, or at least familiar, with BLE, protocols, etc?
-* [1:11:52](https://www.youtube.com/watch?v=VIDEO_2021_04_09?t=4312) onto ble
+* [48:00](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=2880) Could you please link in the Audio sessions you did previously?
+* [49:47](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=2987) Will CPY 7.x be merged with MPY 1.14 (or later)
+* [52:41](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=3161) what are the major milestones for that merge to take place?
+* [57:26](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=3446) ESP32-C6
+* [1:06:06](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=3966) Q: I don't remember with 100% certainty, but did you share a resource on getting up to speed, or at least familiar, with BLE, protocols, etc?
+* [1:11:52](https://www.youtube.com/watch?v=VIDEO_2021_04_09&t=4312) onto ble
 * LadyAda

--- a/2021/2021-04-16.md
+++ b/2021/2021-04-16.md
@@ -20,42 +20,42 @@ Plan
 
 
 Timestamps (5000 char max)
-* [23:59](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=1439) clap
-* [0:00:21](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=21) - microlab
-* [0:01:22](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=82) adafruit benefits / support
-* [4:39](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=279) housekeeping
-* [11:49](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=709) Learn Guides / “project bundle”Zip file downloads - soon to be on Circup (sp)
-* [16:27](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=987) 200 boards that support CP milestone
-* [19:07](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=1147) Filter ‘thing’ support matrix on readthedocs.io
-* [24:30](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=1470) obfuscation techniques if you want to make Python code unreadable
-* [25:30](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=1530) - filter on ‘alarm’
-* [20:00](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=1200) downloads page has filters too
-* [27:37](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=1657) github actions, 1,500 repositories / github.com/circuitpython
-* [30:30](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=1830) TinyML for *python?
-* [35:00](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=2100) CI Monitor / problem matchers
-* [37:41](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=2261) installing micropython on rp2040  feather ( broken link … )
-* [40:59](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=2459)  add a sentence (to CI) to say that if you need help from a human, come on discord etc?
-* [42:22](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=2542) BlueFruit ideas - phone/tablet focus
-* [44:28](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=2668) BLE_File_Transfer pull request
-* [47:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=2835) demo - about 5-6KBs - larger block about 11KBs
-* [56:33](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=3393) talk about how CP gets onto these devices that are BLE only? Will that a per chip mfg process
-* [58:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=3495) TinyML file transfer mention
-* [59:35](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=3575) Python Struct is ‘awesome’ / PR out there now
-* [1:02:00](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=3720) wrapped up: how's the BLE going?
-* [1:03:04](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=3784)  Remove LED line number blinks
-* [1:08:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=4095) Android on the road map ?
-* [1:10:35](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=4235) LED is a problem for low power
-* [1:17:20](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=4640) on error - run this file (mentioned)
-* [1:18:35](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=4715) new branch / connect  jlink to feather
-* [1:24:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=5055) attempt to connect via gdb ( rebuild with DEBUG=1 to connect )
-* [1:57:10](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=7030) first compile
-* [1:59:44](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=7184) last question call
-* [2:00:00](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=7200) set time between blinks configuration request
-* [2:08:05](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=7685) save mode blink
-* [2:11:30](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=7890) Safe mode ‘trick’ - fake it
-* [2:14:28](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=8068) Factor the blink-off delay out
-* [2:17:28](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=8248) ‘review’ the changes - and commit tannewt simplify_status_led
-* [2:21:10](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=8470) We can see Scott!
-* [2:22:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=8535) next week Friday
-* [2:23:02](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=8582) off stream
+* [23:59](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=1439) clap
+* [0:00:21](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=21) - microlab
+* [0:01:22](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=82) adafruit benefits / support
+* [4:39](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=279) housekeeping
+* [11:49](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=709) Learn Guides / “project bundle”Zip file downloads - soon to be on Circup (sp)
+* [16:27](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=987) 200 boards that support CP milestone
+* [19:07](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=1147) Filter ‘thing’ support matrix on readthedocs.io
+* [24:30](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=1470) obfuscation techniques if you want to make Python code unreadable
+* [25:30](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=1530) - filter on ‘alarm’
+* [20:00](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=1200) downloads page has filters too
+* [27:37](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=1657) github actions, 1,500 repositories / github.com/circuitpython
+* [30:30](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=1830) TinyML for *python?
+* [35:00](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=2100) CI Monitor / problem matchers
+* [37:41](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=2261) installing micropython on rp2040  feather ( broken link … )
+* [40:59](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=2459)  add a sentence (to CI) to say that if you need help from a human, come on discord etc?
+* [42:22](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=2542) BlueFruit ideas - phone/tablet focus
+* [44:28](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=2668) BLE_File_Transfer pull request
+* [47:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=2835) demo - about 5-6KBs - larger block about 11KBs
+* [56:33](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=3393) talk about how CP gets onto these devices that are BLE only? Will that a per chip mfg process
+* [58:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=3495) TinyML file transfer mention
+* [59:35](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=3575) Python Struct is ‘awesome’ / PR out there now
+* [1:02:00](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=3720) wrapped up: how's the BLE going?
+* [1:03:04](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=3784)  Remove LED line number blinks
+* [1:08:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=4095) Android on the road map ?
+* [1:10:35](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=4235) LED is a problem for low power
+* [1:17:20](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=4640) on error - run this file (mentioned)
+* [1:18:35](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=4715) new branch / connect  jlink to feather
+* [1:24:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=5055) attempt to connect via gdb ( rebuild with DEBUG=1 to connect )
+* [1:57:10](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=7030) first compile
+* [1:59:44](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=7184) last question call
+* [2:00:00](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=7200) set time between blinks configuration request
+* [2:08:05](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=7685) save mode blink
+* [2:11:30](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=7890) Safe mode ‘trick’ - fake it
+* [2:14:28](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=8068) Factor the blink-off delay out
+* [2:17:28](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=8248) ‘review’ the changes - and commit tannewt simplify_status_led
+* [2:21:10](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=8470) We can see Scott!
+* [2:22:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=8535) next week Friday
+* [2:23:02](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=8582) off stream
 *

--- a/2021/2021-04-16.md
+++ b/2021/2021-04-16.md
@@ -20,42 +20,42 @@ Plan
 
 
 Timestamps (5000 char max)
-* 23:59 clap
-* 0:00:21 - microlab 
-* 0:01:22 adafruit benefits / support
-* 4:39 housekeeping
-* 11:49 Learn Guides / “project bundle”Zip file downloads - soon to be on Circup (sp)
-* 16:27 200 boards that support CP milestone
-* 19:07 Filter ‘thing’ support matrix on readthedocs.io
-* 24:30 obfuscation techniques if you want to make Python code unreadable
-* 25:30 - filter on ‘alarm’
-* 20:00 downloads page has filters too
-* 27:37 github actions, 1,500 repositories / github.com/circuitpython
-* 30:30 TinyML for *python?
-* 35:00 CI Monitor / problem matchers
-* 37:41 installing micropython on rp2040  feather ( broken link … )
-* 40:59  add a sentence (to CI) to say that if you need help from a human, come on discord etc?
-* 42:22 BlueFruit ideas - phone/tablet focus
-* 44:28 BLE_File_Transfer pull request
-* 47:15 demo - about 5-6KBs - larger block about 11KBs
-* 56:33 talk about how CP gets onto these devices that are BLE only? Will that a per chip mfg process
-* 58:15 TinyML file transfer mention
-* 59:35 Python Struct is ‘awesome’ / PR out there now
-* 1:02:00 wrapped up: how's the BLE going?
-* 1:03:04  Remove LED line number blinks
-* 1:08:15 Android on the road map ?
-* 1:10:35 LED is a problem for low power
-* 1:17:20 on error - run this file (mentioned)
-* 1:18:35 new branch / connect  jlink to feather
-* 1:24:15 attempt to connect via gdb ( rebuild with DEBUG=1 to connect )
-* 1:57:10 first compile 
-* 1:59:44 last question call
-* 2:00:00 set time between blinks configuration request
-* 2:08:05 save mode blink
-* 2:11:30 Safe mode ‘trick’ - fake it
-* 2:14:28 Factor the blink-off delay out
-* 2:17:28 ‘review’ the changes - and commit tannewt simplify_status_led
-* 2:21:10 We can see Scott!
-* 2:22:15 next week Friday
-* 2:23:02 off stream
+* [23:59](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=1439) clap
+* [0:00:21](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=21) - microlab
+* [0:01:22](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=82) adafruit benefits / support
+* [4:39](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=279) housekeeping
+* [11:49](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=709) Learn Guides / “project bundle”Zip file downloads - soon to be on Circup (sp)
+* [16:27](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=987) 200 boards that support CP milestone
+* [19:07](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=1147) Filter ‘thing’ support matrix on readthedocs.io
+* [24:30](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=1470) obfuscation techniques if you want to make Python code unreadable
+* [25:30](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=1530) - filter on ‘alarm’
+* [20:00](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=1200) downloads page has filters too
+* [27:37](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=1657) github actions, 1,500 repositories / github.com/circuitpython
+* [30:30](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=1830) TinyML for *python?
+* [35:00](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=2100) CI Monitor / problem matchers
+* [37:41](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=2261) installing micropython on rp2040  feather ( broken link … )
+* [40:59](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=2459)  add a sentence (to CI) to say that if you need help from a human, come on discord etc?
+* [42:22](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=2542) BlueFruit ideas - phone/tablet focus
+* [44:28](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=2668) BLE_File_Transfer pull request
+* [47:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=2835) demo - about 5-6KBs - larger block about 11KBs
+* [56:33](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=3393) talk about how CP gets onto these devices that are BLE only? Will that a per chip mfg process
+* [58:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=3495) TinyML file transfer mention
+* [59:35](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=3575) Python Struct is ‘awesome’ / PR out there now
+* [1:02:00](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=3720) wrapped up: how's the BLE going?
+* [1:03:04](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=3784)  Remove LED line number blinks
+* [1:08:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=4095) Android on the road map ?
+* [1:10:35](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=4235) LED is a problem for low power
+* [1:17:20](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=4640) on error - run this file (mentioned)
+* [1:18:35](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=4715) new branch / connect  jlink to feather
+* [1:24:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=5055) attempt to connect via gdb ( rebuild with DEBUG=1 to connect )
+* [1:57:10](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=7030) first compile
+* [1:59:44](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=7184) last question call
+* [2:00:00](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=7200) set time between blinks configuration request
+* [2:08:05](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=7685) save mode blink
+* [2:11:30](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=7890) Safe mode ‘trick’ - fake it
+* [2:14:28](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=8068) Factor the blink-off delay out
+* [2:17:28](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=8248) ‘review’ the changes - and commit tannewt simplify_status_led
+* [2:21:10](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=8470) We can see Scott!
+* [2:22:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=8535) next week Friday
+* [2:23:02](https://www.youtube.com/watch?v=VIDEO_2021_04_16?t=8582) off stream
 *

--- a/2021/2021-04-16.md
+++ b/2021/2021-04-16.md
@@ -4,7 +4,7 @@
 Hi all, this doc is try and track topics and timecodes for my deep dive stream. These notes will end up in the YouTube video’s description. Any help keeping them groomed as I stream is welcome.
 
 
-11:23 Housekeeping
+[11:23](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=683) Housekeeping
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
@@ -58,4 +58,3 @@ Timestamps (5000 char max)
 * [2:21:10](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=8470) We can see Scott!
 * [2:22:15](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=8535) next week Friday
 * [2:23:02](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=8582) off stream
-*

--- a/2021/2021-04-16.md
+++ b/2021/2021-04-16.md
@@ -20,42 +20,42 @@ Plan
 
 
 Timestamps (5000 char max)
-* [23:59](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=1439) clap
-* [0:00:21](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=21) - microlab
-* [0:01:22](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=82) adafruit benefits / support
-* [4:39](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=279) housekeeping
-* [11:49](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=709) Learn Guides / “project bundle”Zip file downloads - soon to be on Circup (sp)
-* [16:27](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=987) 200 boards that support CP milestone
-* [19:07](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=1147) Filter ‘thing’ support matrix on readthedocs.io
-* [24:30](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=1470) obfuscation techniques if you want to make Python code unreadable
-* [25:30](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=1530) - filter on ‘alarm’
-* [20:00](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=1200) downloads page has filters too
-* [27:37](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=1657) github actions, 1,500 repositories / github.com/circuitpython
-* [30:30](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=1830) TinyML for *python?
-* [35:00](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=2100) CI Monitor / problem matchers
-* [37:41](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=2261) installing micropython on rp2040  feather ( broken link … )
-* [40:59](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=2459)  add a sentence (to CI) to say that if you need help from a human, come on discord etc?
-* [42:22](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=2542) BlueFruit ideas - phone/tablet focus
-* [44:28](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=2668) BLE_File_Transfer pull request
-* [47:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=2835) demo - about 5-6KBs - larger block about 11KBs
-* [56:33](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=3393) talk about how CP gets onto these devices that are BLE only? Will that a per chip mfg process
-* [58:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=3495) TinyML file transfer mention
-* [59:35](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=3575) Python Struct is ‘awesome’ / PR out there now
-* [1:02:00](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=3720) wrapped up: how's the BLE going?
-* [1:03:04](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=3784)  Remove LED line number blinks
-* [1:08:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=4095) Android on the road map ?
-* [1:10:35](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=4235) LED is a problem for low power
-* [1:17:20](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=4640) on error - run this file (mentioned)
-* [1:18:35](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=4715) new branch / connect  jlink to feather
-* [1:24:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=5055) attempt to connect via gdb ( rebuild with DEBUG=1 to connect )
-* [1:57:10](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=7030) first compile
-* [1:59:44](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=7184) last question call
-* [2:00:00](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=7200) set time between blinks configuration request
-* [2:08:05](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=7685) save mode blink
-* [2:11:30](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=7890) Safe mode ‘trick’ - fake it
-* [2:14:28](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=8068) Factor the blink-off delay out
-* [2:17:28](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=8248) ‘review’ the changes - and commit tannewt simplify_status_led
-* [2:21:10](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=8470) We can see Scott!
-* [2:22:15](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=8535) next week Friday
-* [2:23:02](https://www.youtube.com/watch?v=VIDEO_2021_04_16&t=8582) off stream
+* [23:59](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=1439) clap
+* [0:00:21](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=21) - microlab
+* [0:01:22](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=82) adafruit benefits / support
+* [4:39](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=279) housekeeping
+* [11:49](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=709) Learn Guides / “project bundle”Zip file downloads - soon to be on Circup (sp)
+* [16:27](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=987) 200 boards that support CP milestone
+* [19:07](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=1147) Filter ‘thing’ support matrix on readthedocs.io
+* [24:30](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=1470) obfuscation techniques if you want to make Python code unreadable
+* [25:30](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=1530) - filter on ‘alarm’
+* [20:00](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=1200) downloads page has filters too
+* [27:37](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=1657) github actions, 1,500 repositories / github.com/circuitpython
+* [30:30](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=1830) TinyML for *python?
+* [35:00](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=2100) CI Monitor / problem matchers
+* [37:41](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=2261) installing micropython on rp2040  feather ( broken link … )
+* [40:59](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=2459)  add a sentence (to CI) to say that if you need help from a human, come on discord etc?
+* [42:22](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=2542) BlueFruit ideas - phone/tablet focus
+* [44:28](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=2668) BLE_File_Transfer pull request
+* [47:15](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=2835) demo - about 5-6KBs - larger block about 11KBs
+* [56:33](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=3393) talk about how CP gets onto these devices that are BLE only? Will that a per chip mfg process
+* [58:15](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=3495) TinyML file transfer mention
+* [59:35](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=3575) Python Struct is ‘awesome’ / PR out there now
+* [1:02:00](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=3720) wrapped up: how's the BLE going?
+* [1:03:04](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=3784)  Remove LED line number blinks
+* [1:08:15](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=4095) Android on the road map ?
+* [1:10:35](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=4235) LED is a problem for low power
+* [1:17:20](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=4640) on error - run this file (mentioned)
+* [1:18:35](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=4715) new branch / connect  jlink to feather
+* [1:24:15](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=5055) attempt to connect via gdb ( rebuild with DEBUG=1 to connect )
+* [1:57:10](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=7030) first compile
+* [1:59:44](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=7184) last question call
+* [2:00:00](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=7200) set time between blinks configuration request
+* [2:08:05](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=7685) save mode blink
+* [2:11:30](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=7890) Safe mode ‘trick’ - fake it
+* [2:14:28](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=8068) Factor the blink-off delay out
+* [2:17:28](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=8248) ‘review’ the changes - and commit tannewt simplify_status_led
+* [2:21:10](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=8470) We can see Scott!
+* [2:22:15](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=8535) next week Friday
+* [2:23:02](https://www.youtube.com/watch?v=Q4sUzNMQA0U&t=8582) off stream
 *

--- a/2021/2021-04-23.md
+++ b/2021/2021-04-23.md
@@ -4,7 +4,7 @@
 Hi all, this doc is try and track topics and timecodes for my deep dive stream. These notes will end up in the YouTube video’s description. Any help keeping them groomed as I stream is welcome.
 
 
-5:15Housekeeping
+[5:15](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=315) Housekeeping
 * I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.

--- a/2021/2021-04-23.md
+++ b/2021/2021-04-23.md
@@ -9,67 +9,67 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After I’ll unmute and continue.
-* [7:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=460) Next week will be on Friday.
+* [7:40](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=460) Next week will be on Friday.
 
 
 Plan
 *
 
 Timestamps
-* [1:43](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=103) @2:01pm Housekeeping ( 5:15 - above ) adjusted below
-* [8:04](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=484) hellos
-* [9:03](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=543) CircuitPython intro…
-* [9:16](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=556) ( 9:11 ) clap
-* [10:05](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=605) Micropython updates / release notes for 6.2.0 based on Jun 2018 Micropython!
-* [11:34](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=694) Talk of CP 7.0 - mpy version revisit
-* [11:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=700) Will circup know what mpy to take based on version of the board? (yes)
-* [15:10](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=910) How will the learn guide new zip thing behave?
-* [16:25](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=985) Plan for multiple merges from MP to CP
-* [17:25](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1045) MP v1.10 merged in S3
-* [18:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1100) Merge conflict battles…
-* [19:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1160) Damien's doing faster release cycles now as well - since 1.13, so CP Is going to really want to stay updated more often going forward.
-* [20:45](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1245) Sublime Merge
-* [22:01](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1321) plans to support the Arduino Portenta?
-* [22:45](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1365) Are each of the 1.1x going to be tested, or we only care about the last one?
-* [26:15](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1575) anything particular you're looking for in the merge reviews? looked through the 1.11 PR, and built it for the RP2040.
-* [28:28](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1708) The changelog will be crazy…
-* [29:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1760)  the merge process explained
-* [32:15](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1935) Maybe we can get community to run automation on different boards …
-* [32:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1960) Arduino Portenta dual core M7/M4
-* [33:48](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2028) Does the toolchain allow for a code builder front end ?(edited)
-* [35:08](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2108) How often is this done?
-* [36:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2200) Micropython release notes
-* [37:45](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2265) Is there a difference in merging the change from MP into CP... and redoing the change from CP into the last MP? (does that make sense)
-* [39:30](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2370) v1.10
-* [40:16](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2416) CP translation considerations ( new strings?)
-* [42:30](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2550) MP (native/machine code) emitters
-* [43:22](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2602) thought CircuitPython already supported underscores in numeric literals. On 6.2.0 on QT Py, I can do a = 1_000_000; print(a) and it's a number
-* [43:57](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2637) v1.11
-* [45:50](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2750) mpy-cross & mpy-tool
-* [45:52](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2752) will testing with .py possibly give different results from testing with .mpy?
-* [48:22](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2902) v1.12
-* [51:25](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=3085) littlefs (vs. FAT )
-* [56:56](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=3416) What on chip peripherals are used for a Neo pixel ? One channel of a timer ?
-* [58:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=3500) v1.13
-* [1:06:39](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=3999) Was there a time where people were saying that using foo and bar make IT less accessible and it is not good for STEM and being open? Is that still the opinion?
-* [1:07:03](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=4023) With threading an interrupts couldn't we just write them in a c code block to use that inside circuit python?
-* [1:09:12](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=4152) v1.14
-* [1:12:00](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=4320) Could you rename the cp Ports folder do eliminate all these naming conflicts ?
-* [1:15:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=4520) v1.15
-* [1:22:07](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=4927) v1.11 merge failing checks…
-* [1:24:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=5060) git worktree
-* [1:26:23](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=5183) ​Is there a specific CPython version that you target compatibility with? (2.7, 3.9, etc)
-* [1:27:45](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=5265) fixing atmel-samd build error (openbook_m4)
-* [1:35:04](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=5704) Git commit --amend and cherry picking…
-* [1:37:00](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=5820) Are you getting the diff between MP's v1.x and v1.(x+1), and then cherry-picking that?
-* [1:38:25](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=5905) So how are you bringing in the per-release changes from MP?
-* [1:40:55](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=6055)  Scott’s  ‘other project’ / use git to store laws / HB1336 - 2021-22
-* [1:52:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=6760) Uniform Electronic Legal Access
-* [1:53:55](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=6835) RCW (current state)
-* [1:55:00](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=6900) wa-log.org
-* [1:56:50](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=7010) adoc (asciidoc) vs markdown
-* [2:04:56](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=7496) Gitlab allows adding users
-* [2:11:06](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=7866) Bills and terms of service agreements are things I wish I could track history of it better
-* [2:11:30](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=7890) completely different question from the topic. why adafruit nrf52840 still using softdevice 6.1.1 stack instead of 7.2.0(because of different memory layout)?
-* [2:14:12](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=8052) (4:10pm) wrap up
-* [2:15:30](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=8130) - headset off (4:12 pm)
+* [1:43](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=103) @2:01pm Housekeeping ( 5:15 - above ) adjusted below
+* [8:04](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=484) hellos
+* [9:03](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=543) CircuitPython intro…
+* [9:16](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=556) ( 9:11 ) clap
+* [10:05](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=605) Micropython updates / release notes for 6.2.0 based on Jun 2018 Micropython!
+* [11:34](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=694) Talk of CP 7.0 - mpy version revisit
+* [11:40](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=700) Will circup know what mpy to take based on version of the board? (yes)
+* [15:10](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=910) How will the learn guide new zip thing behave?
+* [16:25](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=985) Plan for multiple merges from MP to CP
+* [17:25](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=1045) MP v1.10 merged in S3
+* [18:20](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=1100) Merge conflict battles…
+* [19:20](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=1160) Damien's doing faster release cycles now as well - since 1.13, so CP Is going to really want to stay updated more often going forward.
+* [20:45](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=1245) Sublime Merge
+* [22:01](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=1321) plans to support the Arduino Portenta?
+* [22:45](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=1365) Are each of the 1.1x going to be tested, or we only care about the last one?
+* [26:15](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=1575) anything particular you're looking for in the merge reviews? looked through the 1.11 PR, and built it for the RP2040.
+* [28:28](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=1708) The changelog will be crazy…
+* [29:20](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=1760)  the merge process explained
+* [32:15](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=1935) Maybe we can get community to run automation on different boards …
+* [32:40](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=1960) Arduino Portenta dual core M7/M4
+* [33:48](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=2028) Does the toolchain allow for a code builder front end ?(edited)
+* [35:08](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=2108) How often is this done?
+* [36:40](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=2200) Micropython release notes
+* [37:45](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=2265) Is there a difference in merging the change from MP into CP... and redoing the change from CP into the last MP? (does that make sense)
+* [39:30](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=2370) v1.10
+* [40:16](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=2416) CP translation considerations ( new strings?)
+* [42:30](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=2550) MP (native/machine code) emitters
+* [43:22](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=2602) thought CircuitPython already supported underscores in numeric literals. On 6.2.0 on QT Py, I can do a = 1_000_000; print(a) and it's a number
+* [43:57](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=2637) v1.11
+* [45:50](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=2750) mpy-cross & mpy-tool
+* [45:52](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=2752) will testing with .py possibly give different results from testing with .mpy?
+* [48:22](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=2902) v1.12
+* [51:25](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=3085) littlefs (vs. FAT )
+* [56:56](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=3416) What on chip peripherals are used for a Neo pixel ? One channel of a timer ?
+* [58:20](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=3500) v1.13
+* [1:06:39](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=3999) Was there a time where people were saying that using foo and bar make IT less accessible and it is not good for STEM and being open? Is that still the opinion?
+* [1:07:03](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=4023) With threading an interrupts couldn't we just write them in a c code block to use that inside circuit python?
+* [1:09:12](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=4152) v1.14
+* [1:12:00](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=4320) Could you rename the cp Ports folder do eliminate all these naming conflicts ?
+* [1:15:20](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=4520) v1.15
+* [1:22:07](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=4927) v1.11 merge failing checks…
+* [1:24:20](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=5060) git worktree
+* [1:26:23](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=5183) ​Is there a specific CPython version that you target compatibility with? (2.7, 3.9, etc)
+* [1:27:45](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=5265) fixing atmel-samd build error (openbook_m4)
+* [1:35:04](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=5704) Git commit --amend and cherry picking…
+* [1:37:00](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=5820) Are you getting the diff between MP's v1.x and v1.(x+1), and then cherry-picking that?
+* [1:38:25](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=5905) So how are you bringing in the per-release changes from MP?
+* [1:40:55](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=6055)  Scott’s  ‘other project’ / use git to store laws / HB1336 - 2021-22
+* [1:52:40](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=6760) Uniform Electronic Legal Access
+* [1:53:55](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=6835) RCW (current state)
+* [1:55:00](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=6900) wa-log.org
+* [1:56:50](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=7010) adoc (asciidoc) vs markdown
+* [2:04:56](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=7496) Gitlab allows adding users
+* [2:11:06](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=7866) Bills and terms of service agreements are things I wish I could track history of it better
+* [2:11:30](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=7890) completely different question from the topic. why adafruit nrf52840 still using softdevice 6.1.1 stack instead of 7.2.0(because of different memory layout)?
+* [2:14:12](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=8052) (4:10pm) wrap up
+* [2:15:30](https://www.youtube.com/watch?v=21Qt4mRoyBo&t=8130) - headset off (4:12 pm)

--- a/2021/2021-04-23.md
+++ b/2021/2021-04-23.md
@@ -9,67 +9,67 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After I’ll unmute and continue.
-* [7:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=460) Next week will be on Friday.
+* [7:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=460) Next week will be on Friday.
 
 
 Plan
 *
 
 Timestamps
-* [1:43](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=103) @2:01pm Housekeeping ( 5:15 - above ) adjusted below
-* [8:04](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=484) hellos
-* [9:03](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=543) CircuitPython intro…
-* [9:16](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=556) ( 9:11 ) clap
-* [10:05](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=605) Micropython updates / release notes for 6.2.0 based on Jun 2018 Micropython!
-* [11:34](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=694) Talk of CP 7.0 - mpy version revisit
-* [11:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=700) Will circup know what mpy to take based on version of the board? (yes)
-* [15:10](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=910) How will the learn guide new zip thing behave?
-* [16:25](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=985) Plan for multiple merges from MP to CP
-* [17:25](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1045) MP v1.10 merged in S3
-* [18:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1100) Merge conflict battles…
-* [19:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1160) Damien's doing faster release cycles now as well - since 1.13, so CP Is going to really want to stay updated more often going forward.
-* [20:45](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1245) Sublime Merge
-* [22:01](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1321) plans to support the Arduino Portenta?
-* [22:45](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1365) Are each of the 1.1x going to be tested, or we only care about the last one?
-* [26:15](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1575) anything particular you're looking for in the merge reviews? looked through the 1.11 PR, and built it for the RP2040.
-* [28:28](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1708) The changelog will be crazy…
-* [29:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1760)  the merge process explained
-* [32:15](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1935) Maybe we can get community to run automation on different boards …
-* [32:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1960) Arduino Portenta dual core M7/M4
-* [33:48](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2028) Does the toolchain allow for a code builder front end ?(edited)
-* [35:08](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2108) How often is this done?
-* [36:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2200) Micropython release notes
-* [37:45](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2265) Is there a difference in merging the change from MP into CP... and redoing the change from CP into the last MP? (does that make sense)
-* [39:30](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2370) v1.10
-* [40:16](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2416) CP translation considerations ( new strings?)
-* [42:30](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2550) MP (native/machine code) emitters
-* [43:22](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2602) thought CircuitPython already supported underscores in numeric literals. On 6.2.0 on QT Py, I can do a = 1_000_000; print(a) and it's a number
-* [43:57](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2637) v1.11
-* [45:50](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2750) mpy-cross & mpy-tool
-* [45:52](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2752) will testing with .py possibly give different results from testing with .mpy?
-* [48:22](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2902) v1.12
-* [51:25](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=3085) littlefs (vs. FAT )
-* [56:56](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=3416) What on chip peripherals are used for a Neo pixel ? One channel of a timer ?
-* [58:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=3500) v1.13
-* [1:06:39](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=3999) Was there a time where people were saying that using foo and bar make IT less accessible and it is not good for STEM and being open? Is that still the opinion?
-* [1:07:03](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=4023) With threading an interrupts couldn't we just write them in a c code block to use that inside circuit python?
-* [1:09:12](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=4152) v1.14
-* [1:12:00](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=4320) Could you rename the cp Ports folder do eliminate all these naming conflicts ?
-* [1:15:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=4520) v1.15
-* [1:22:07](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=4927) v1.11 merge failing checks…
-* [1:24:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=5060) git worktree
-* [1:26:23](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=5183) ​Is there a specific CPython version that you target compatibility with? (2.7, 3.9, etc)
-* [1:27:45](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=5265) fixing atmel-samd build error (openbook_m4)
-* [1:35:04](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=5704) Git commit --amend and cherry picking…
-* [1:37:00](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=5820) Are you getting the diff between MP's v1.x and v1.(x+1), and then cherry-picking that?
-* [1:38:25](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=5905) So how are you bringing in the per-release changes from MP?
-* [1:40:55](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=6055)  Scott’s  ‘other project’ / use git to store laws / HB1336 - 2021-22
-* [1:52:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=6760) Uniform Electronic Legal Access
-* [1:53:55](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=6835) RCW (current state)
-* [1:55:00](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=6900) wa-log.org
-* [1:56:50](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=7010) adoc (asciidoc) vs markdown
-* [2:04:56](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=7496) Gitlab allows adding users
-* [2:11:06](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=7866) Bills and terms of service agreements are things I wish I could track history of it better
-* [2:11:30](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=7890) completely different question from the topic. why adafruit nrf52840 still using softdevice 6.1.1 stack instead of 7.2.0(because of different memory layout)?
-* [2:14:12](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=8052) (4:10pm) wrap up
-* [2:15:30](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=8130) - headset off (4:12 pm)
+* [1:43](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=103) @2:01pm Housekeeping ( 5:15 - above ) adjusted below
+* [8:04](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=484) hellos
+* [9:03](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=543) CircuitPython intro…
+* [9:16](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=556) ( 9:11 ) clap
+* [10:05](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=605) Micropython updates / release notes for 6.2.0 based on Jun 2018 Micropython!
+* [11:34](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=694) Talk of CP 7.0 - mpy version revisit
+* [11:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=700) Will circup know what mpy to take based on version of the board? (yes)
+* [15:10](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=910) How will the learn guide new zip thing behave?
+* [16:25](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=985) Plan for multiple merges from MP to CP
+* [17:25](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1045) MP v1.10 merged in S3
+* [18:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1100) Merge conflict battles…
+* [19:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1160) Damien's doing faster release cycles now as well - since 1.13, so CP Is going to really want to stay updated more often going forward.
+* [20:45](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1245) Sublime Merge
+* [22:01](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1321) plans to support the Arduino Portenta?
+* [22:45](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1365) Are each of the 1.1x going to be tested, or we only care about the last one?
+* [26:15](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1575) anything particular you're looking for in the merge reviews? looked through the 1.11 PR, and built it for the RP2040.
+* [28:28](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1708) The changelog will be crazy…
+* [29:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1760)  the merge process explained
+* [32:15](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1935) Maybe we can get community to run automation on different boards …
+* [32:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=1960) Arduino Portenta dual core M7/M4
+* [33:48](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2028) Does the toolchain allow for a code builder front end ?(edited)
+* [35:08](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2108) How often is this done?
+* [36:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2200) Micropython release notes
+* [37:45](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2265) Is there a difference in merging the change from MP into CP... and redoing the change from CP into the last MP? (does that make sense)
+* [39:30](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2370) v1.10
+* [40:16](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2416) CP translation considerations ( new strings?)
+* [42:30](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2550) MP (native/machine code) emitters
+* [43:22](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2602) thought CircuitPython already supported underscores in numeric literals. On 6.2.0 on QT Py, I can do a = 1_000_000; print(a) and it's a number
+* [43:57](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2637) v1.11
+* [45:50](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2750) mpy-cross & mpy-tool
+* [45:52](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2752) will testing with .py possibly give different results from testing with .mpy?
+* [48:22](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=2902) v1.12
+* [51:25](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=3085) littlefs (vs. FAT )
+* [56:56](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=3416) What on chip peripherals are used for a Neo pixel ? One channel of a timer ?
+* [58:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=3500) v1.13
+* [1:06:39](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=3999) Was there a time where people were saying that using foo and bar make IT less accessible and it is not good for STEM and being open? Is that still the opinion?
+* [1:07:03](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=4023) With threading an interrupts couldn't we just write them in a c code block to use that inside circuit python?
+* [1:09:12](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=4152) v1.14
+* [1:12:00](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=4320) Could you rename the cp Ports folder do eliminate all these naming conflicts ?
+* [1:15:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=4520) v1.15
+* [1:22:07](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=4927) v1.11 merge failing checks…
+* [1:24:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=5060) git worktree
+* [1:26:23](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=5183) ​Is there a specific CPython version that you target compatibility with? (2.7, 3.9, etc)
+* [1:27:45](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=5265) fixing atmel-samd build error (openbook_m4)
+* [1:35:04](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=5704) Git commit --amend and cherry picking…
+* [1:37:00](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=5820) Are you getting the diff between MP's v1.x and v1.(x+1), and then cherry-picking that?
+* [1:38:25](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=5905) So how are you bringing in the per-release changes from MP?
+* [1:40:55](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=6055)  Scott’s  ‘other project’ / use git to store laws / HB1336 - 2021-22
+* [1:52:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=6760) Uniform Electronic Legal Access
+* [1:53:55](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=6835) RCW (current state)
+* [1:55:00](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=6900) wa-log.org
+* [1:56:50](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=7010) adoc (asciidoc) vs markdown
+* [2:04:56](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=7496) Gitlab allows adding users
+* [2:11:06](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=7866) Bills and terms of service agreements are things I wish I could track history of it better
+* [2:11:30](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=7890) completely different question from the topic. why adafruit nrf52840 still using softdevice 6.1.1 stack instead of 7.2.0(because of different memory layout)?
+* [2:14:12](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=8052) (4:10pm) wrap up
+* [2:15:30](https://www.youtube.com/watch?v=VIDEO_2021_04_23&t=8130) - headset off (4:12 pm)

--- a/2021/2021-04-23.md
+++ b/2021/2021-04-23.md
@@ -9,67 +9,67 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After I’ll unmute and continue.
-* 7:40 Next week will be on Friday.
+* [7:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=460) Next week will be on Friday.
 
 
 Plan
-* 
+*
 
 Timestamps
-* 1:43 @2:01pm Housekeeping ( 5:15 - above ) adjusted below
-* 8:04 hellos
-* 9:03 CircuitPython intro…
-* 9:16 ( 9:11 ) clap
-* 10:05 Micropython updates / release notes for 6.2.0 based on Jun 2018 Micropython!
-* 11:34 Talk of CP 7.0 - mpy version revisit
-* 11:40 Will circup know what mpy to take based on version of the board? (yes)
-* 15:10 How will the learn guide new zip thing behave?
-* 16:25 Plan for multiple merges from MP to CP
-* 17:25 MP v1.10 merged in S3
-* 18:20 Merge conflict battles…
-* 19:20 Damien's doing faster release cycles now as well - since 1.13, so CP Is going to really want to stay updated more often going forward.
-* 20:45 Sublime Merge
-* 22:01 plans to support the Arduino Portenta?
-* 22:45 Are each of the 1.1x going to be tested, or we only care about the last one?
-* 26:15 anything particular you're looking for in the merge reviews? looked through the 1.11 PR, and built it for the RP2040.
-* 28:28 The changelog will be crazy…
-* 29:20  the merge process explained
-* 32:15 Maybe we can get community to run automation on different boards …
-* 32:40 Arduino Portenta dual core M7/M4
-* 33:48 Does the toolchain allow for a code builder front end ?(edited)
-* 35:08 How often is this done?
-* 36:40 Micropython release notes
-* 37:45 Is there a difference in merging the change from MP into CP... and redoing the change from CP into the last MP? (does that make sense)
-* 39:30 v1.10
-* 40:16 CP translation considerations ( new strings?)
-* 42:30 MP (native/machine code) emitters
-* 43:22 thought CircuitPython already supported underscores in numeric literals. On 6.2.0 on QT Py, I can do a = 1_000_000; print(a) and it's a number
-* 43:57 v1.11
-* 45:50 mpy-cross & mpy-tool 
-* 45:52 will testing with .py possibly give different results from testing with .mpy?
-* 48:22 v1.12
-* 51:25 littlefs (vs. FAT )
-* 56:56 What on chip peripherals are used for a Neo pixel ? One channel of a timer ?
-* 58:20 v1.13
-* 1:06:39 Was there a time where people were saying that using foo and bar make IT less accessible and it is not good for STEM and being open? Is that still the opinion?
-* 1:07:03 With threading an interrupts couldn't we just write them in a c code block to use that inside circuit python?
-* 1:09:12 v1.14
-* 1:12:00 Could you rename the cp Ports folder do eliminate all these naming conflicts ?
-* 1:15:20 v1.15
-* 1:22:07 v1.11 merge failing checks…
-* 1:24:20 git worktree
-* 1:26:23 ​Is there a specific CPython version that you target compatibility with? (2.7, 3.9, etc)
-* 1:27:45 fixing atmel-samd build error (openbook_m4)
-* 1:35:04 Git commit --amend and cherry picking…
-* 1:37:00 Are you getting the diff between MP's v1.x and v1.(x+1), and then cherry-picking that?
-* 1:38:25 So how are you bringing in the per-release changes from MP?
-* 1:40:55  Scott’s  ‘other project’ / use git to store laws / HB1336 - 2021-22
-* 1:52:40 Uniform Electronic Legal Access
-* 1:53:55 RCW (current state)
-* 1:55:00 wa-log.org
-* 1:56:50 adoc (asciidoc) vs markdown
-* 2:04:56 Gitlab allows adding users
-* 2:11:06 Bills and terms of service agreements are things I wish I could track history of it better
-* 2:11:30 completely different question from the topic. why adafruit nrf52840 still using softdevice 6.1.1 stack instead of 7.2.0(because of different memory layout)?
-* 2:14:12 (4:10pm) wrap up
-* 2:15:30 - headset off (4:12 pm)
+* [1:43](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=103) @2:01pm Housekeeping ( 5:15 - above ) adjusted below
+* [8:04](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=484) hellos
+* [9:03](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=543) CircuitPython intro…
+* [9:16](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=556) ( 9:11 ) clap
+* [10:05](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=605) Micropython updates / release notes for 6.2.0 based on Jun 2018 Micropython!
+* [11:34](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=694) Talk of CP 7.0 - mpy version revisit
+* [11:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=700) Will circup know what mpy to take based on version of the board? (yes)
+* [15:10](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=910) How will the learn guide new zip thing behave?
+* [16:25](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=985) Plan for multiple merges from MP to CP
+* [17:25](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1045) MP v1.10 merged in S3
+* [18:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1100) Merge conflict battles…
+* [19:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1160) Damien's doing faster release cycles now as well - since 1.13, so CP Is going to really want to stay updated more often going forward.
+* [20:45](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1245) Sublime Merge
+* [22:01](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1321) plans to support the Arduino Portenta?
+* [22:45](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1365) Are each of the 1.1x going to be tested, or we only care about the last one?
+* [26:15](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1575) anything particular you're looking for in the merge reviews? looked through the 1.11 PR, and built it for the RP2040.
+* [28:28](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1708) The changelog will be crazy…
+* [29:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1760)  the merge process explained
+* [32:15](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1935) Maybe we can get community to run automation on different boards …
+* [32:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=1960) Arduino Portenta dual core M7/M4
+* [33:48](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2028) Does the toolchain allow for a code builder front end ?(edited)
+* [35:08](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2108) How often is this done?
+* [36:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2200) Micropython release notes
+* [37:45](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2265) Is there a difference in merging the change from MP into CP... and redoing the change from CP into the last MP? (does that make sense)
+* [39:30](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2370) v1.10
+* [40:16](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2416) CP translation considerations ( new strings?)
+* [42:30](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2550) MP (native/machine code) emitters
+* [43:22](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2602) thought CircuitPython already supported underscores in numeric literals. On 6.2.0 on QT Py, I can do a = 1_000_000; print(a) and it's a number
+* [43:57](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2637) v1.11
+* [45:50](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2750) mpy-cross & mpy-tool
+* [45:52](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2752) will testing with .py possibly give different results from testing with .mpy?
+* [48:22](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=2902) v1.12
+* [51:25](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=3085) littlefs (vs. FAT )
+* [56:56](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=3416) What on chip peripherals are used for a Neo pixel ? One channel of a timer ?
+* [58:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=3500) v1.13
+* [1:06:39](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=3999) Was there a time where people were saying that using foo and bar make IT less accessible and it is not good for STEM and being open? Is that still the opinion?
+* [1:07:03](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=4023) With threading an interrupts couldn't we just write them in a c code block to use that inside circuit python?
+* [1:09:12](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=4152) v1.14
+* [1:12:00](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=4320) Could you rename the cp Ports folder do eliminate all these naming conflicts ?
+* [1:15:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=4520) v1.15
+* [1:22:07](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=4927) v1.11 merge failing checks…
+* [1:24:20](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=5060) git worktree
+* [1:26:23](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=5183) ​Is there a specific CPython version that you target compatibility with? (2.7, 3.9, etc)
+* [1:27:45](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=5265) fixing atmel-samd build error (openbook_m4)
+* [1:35:04](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=5704) Git commit --amend and cherry picking…
+* [1:37:00](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=5820) Are you getting the diff between MP's v1.x and v1.(x+1), and then cherry-picking that?
+* [1:38:25](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=5905) So how are you bringing in the per-release changes from MP?
+* [1:40:55](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=6055)  Scott’s  ‘other project’ / use git to store laws / HB1336 - 2021-22
+* [1:52:40](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=6760) Uniform Electronic Legal Access
+* [1:53:55](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=6835) RCW (current state)
+* [1:55:00](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=6900) wa-log.org
+* [1:56:50](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=7010) adoc (asciidoc) vs markdown
+* [2:04:56](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=7496) Gitlab allows adding users
+* [2:11:06](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=7866) Bills and terms of service agreements are things I wish I could track history of it better
+* [2:11:30](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=7890) completely different question from the topic. why adafruit nrf52840 still using softdevice 6.1.1 stack instead of 7.2.0(because of different memory layout)?
+* [2:14:12](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=8052) (4:10pm) wrap up
+* [2:15:30](https://www.youtube.com/watch?v=VIDEO_2021_04_23?t=8130) - headset off (4:12 pm)

--- a/2021/2021-04-30.md
+++ b/2021/2021-04-30.md
@@ -13,69 +13,69 @@ Housekeeping
 
 
 Plan
-* 
+*
 
 Timestamps
-* 5:00 housekeeping
-* 5:50 NeoTrinkey
-* 11:00 trying to load circuit python on my new metro esp32-s2, but the firmware doesn't seem to update since I don't see it mount 
-* 13:39 pick up where scott left off…
-* 13:59 Oxide Computer exploit
-* 15:56 Micropython & CircuitPython relationship
-* 16:20 Micropython 8 years old - happy birthday! (April-29)
-* 19:43 adafruit readme on github
-* 20:03 BNO055 project- -> forums.adafruit
-* 21:56 Interrupts/threading MP vs.CP
-* 24:59 - memory related usage
-* 27:25 CircuitPython libs just work cross platform, like using a LoRa RF modem on a RasPi with Blinka.
-* 28:45 Can CircuitPython run on the Adafruit Feather boards? - see circuitpython.org/downloads
-* 29:33 learning regular Python helps learning CircuitPython
-* 31:27 Merge 1.12 completed - pull request
-* 32:10 Thanks Jeff E.
-* 32:35 anyone been able to get circuitpython working on a soft FPGA RISC-V?
-* 33:33 Dan’s pull request for USB stuff!
-* 34:18 - status update ?.merge MP 1.10 ….1.15 into  ( CP 7.0 )
-* 38:40 Sublime merge process description
-* 39:48 VS Code
-* 41:48 forking... making a copy and modding from there, and merging you bring in changes from a newer version of what you forked from?
-* 42:49 pycharm ?
-* 43:35 contributing to github guide
-* 43:57 expanding on 1.12 pull request
-* 45:45 merging…
-* 54:04 meld is free tool similar features
-* 56:15 MP_ERROR_TEXT
-* 57:50 using beyond compare right now to compare two 8GB binary files.
-* 59:23 Source Tree, Visual Studio
-* 1:04:30  Is there an Adafruit BMP280 eagle library? - need to check product…
-* 1:07:20 GC collect - assign 0 to support collecting
-* 1:09:20 under 200 files to merge left
-* 1:14:50 assign 0, then gc vs. del for freeing memory
-* 1:17:09 using del() to unimport
-* 1:17:64 ​Does CircuitPython run any hardware CI to make sure there are no regressions on supported boards?
-* 1:19:35 pairheap - we probably want it :-)
-* 1:26:00 we don’t use mod microsocket
-* 1:28:15 Jeff found places where we don’t have tests…
-* 1:29:12 mp thread
-* 1:31:00 frzqstr.py
-* 1:32:44 in the py folder!
-* 1:36:45 CP has more support in ‘struct’ and turn off non-standard stuff
-* 1:42:35 py/compile.c  # emit bytecode
-* 1:45:35 walrus operator?  PN_annassign
-* 1:48:50 native mpy files? … emitbc.c # emit bytecode
-* 1:52:25 yes - it’s nice to merge each milestone
-* 1:54:32 py/gc.c
-* 1:57:16 CP has f-string support, MP doesn’t
-* 1:59:59 CP gets full version from github
-* 2:00:30 py/malloc.c
-* 2:02:15 “after I’m done with this, it is not going to compile, that’s now how it works”
-* 2:06:07 py/modstruct.c  ( we don’t use it I think )
-* 2:07:10 two spots where we want to say circuitpython…
-* 2:09:12 some things that don’t belong in the py folder…
-* 2:11:50 community broadband…
-* 2:14:25 FCC interested in learning users broadband speeds https://broadbandmap.fcc.gov/#/
-* 2:16:57 py/obj.h (is a big file)
-* 2:19:31 a while ago they changed the capitalizations of things….
-* 2:28:31 six to go
-* 2:32:30 py/objmodule.c  - 99 left
-* 2:34:20 wrap up / thanks
+* [5:00](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=300) housekeeping
+* [5:50](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=350) NeoTrinkey
+* [11:00](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=660) trying to load circuit python on my new metro esp32-s2, but the firmware doesn't seem to update since I don't see it mount
+* [13:39](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=819) pick up where scott left off…
+* [13:59](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=839) Oxide Computer exploit
+* [15:56](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=956) Micropython & CircuitPython relationship
+* [16:20](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=980) Micropython 8 years old - happy birthday! (April-29)
+* [19:43](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1183) adafruit readme on github
+* [20:03](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1203) BNO055 project- -> forums.adafruit
+* [21:56](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1316) Interrupts/threading MP vs.CP
+* [24:59](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1499) - memory related usage
+* [27:25](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1645) CircuitPython libs just work cross platform, like using a LoRa RF modem on a RasPi with Blinka.
+* [28:45](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1725) Can CircuitPython run on the Adafruit Feather boards? - see circuitpython.org/downloads
+* [29:33](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1773) learning regular Python helps learning CircuitPython
+* [31:27](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1887) Merge 1.12 completed - pull request
+* [32:10](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1930) Thanks Jeff E.
+* [32:35](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1955) anyone been able to get circuitpython working on a soft FPGA RISC-V?
+* [33:33](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2013) Dan’s pull request for USB stuff!
+* [34:18](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2058) - status update ?.merge MP 1.10 ….1.15 into  ( CP 7.0 )
+* [38:40](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2320) Sublime merge process description
+* [39:48](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2388) VS Code
+* [41:48](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2508) forking... making a copy and modding from there, and merging you bring in changes from a newer version of what you forked from?
+* [42:49](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2569) pycharm ?
+* [43:35](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2615) contributing to github guide
+* [43:57](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2637) expanding on 1.12 pull request
+* [45:45](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2745) merging…
+* [54:04](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=3244) meld is free tool similar features
+* [56:15](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=3375) MP_ERROR_TEXT
+* [57:50](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=3470) using beyond compare right now to compare two 8GB binary files.
+* [59:23](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=3563) Source Tree, Visual Studio
+* [1:04:30](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=3870)  Is there an Adafruit BMP280 eagle library? - need to check product…
+* [1:07:20](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=4040) GC collect - assign 0 to support collecting
+* [1:09:20](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=4160) under 200 files to merge left
+* [1:14:50](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=4490) assign 0, then gc vs. del for freeing memory
+* [1:17:09](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=4629) using del() to unimport
+* [1:17:47](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=4667) ​Does CircuitPython run any hardware CI to make sure there are no regressions on supported boards?
+* [1:19:35](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=4775) pairheap - we probably want it :-)
+* [1:26:00](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=5160) we don’t use mod microsocket
+* [1:28:15](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=5295) Jeff found places where we don’t have tests…
+* [1:29:12](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=5352) mp thread
+* [1:31:00](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=5460) frzqstr.py
+* [1:32:44](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=5564) in the py folder!
+* [1:36:45](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=5805) CP has more support in ‘struct’ and turn off non-standard stuff
+* [1:42:35](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=6155) py/compile.c  # emit bytecode
+* [1:45:35](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=6335) walrus operator?  PN_annassign
+* [1:48:50](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=6530) native mpy files? … emitbc.c # emit bytecode
+* [1:52:25](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=6745) yes - it’s nice to merge each milestone
+* [1:54:32](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=6872) py/gc.c
+* [1:57:16](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=7036) CP has f-string support, MP doesn’t
+* [1:59:59](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=7199) CP gets full version from github
+* [2:00:30](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=7230) py/malloc.c
+* [2:02:15](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=7335) “after I’m done with this, it is not going to compile, that’s now how it works”
+* [2:06:07](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=7567) py/modstruct.c  ( we don’t use it I think )
+* [2:07:10](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=7630) two spots where we want to say circuitpython…
+* [2:09:12](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=7752) some things that don’t belong in the py folder…
+* [2:11:50](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=7910) community broadband…
+* [2:14:25](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=8065) FCC interested in learning users broadband speeds https://broadbandmap.fcc.gov/#/
+* [2:16:57](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=8217) py/obj.h (is a big file)
+* [2:19:31](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=8371) a while ago they changed the capitalizations of things….
+* [2:28:31](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=8911) six to go
+* [2:32:30](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=9150) py/objmodule.c  - 99 left
+* [2:34:20](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=9260) wrap up / thanks
 # hope this wasn’t too long 2:35:20 4:33 pm

--- a/2021/2021-04-30.md
+++ b/2021/2021-04-30.md
@@ -16,66 +16,66 @@ Plan
 *
 
 Timestamps
-* [5:00](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=300) housekeeping
-* [5:50](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=350) NeoTrinkey
-* [11:00](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=660) trying to load circuit python on my new metro esp32-s2, but the firmware doesn't seem to update since I don't see it mount
-* [13:39](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=819) pick up where scott left off…
-* [13:59](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=839) Oxide Computer exploit
-* [15:56](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=956) Micropython & CircuitPython relationship
-* [16:20](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=980) Micropython 8 years old - happy birthday! (April-29)
-* [19:43](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1183) adafruit readme on github
-* [20:03](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1203) BNO055 project- -> forums.adafruit
-* [21:56](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1316) Interrupts/threading MP vs.CP
-* [24:59](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1499) - memory related usage
-* [27:25](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1645) CircuitPython libs just work cross platform, like using a LoRa RF modem on a RasPi with Blinka.
-* [28:45](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1725) Can CircuitPython run on the Adafruit Feather boards? - see circuitpython.org/downloads
-* [29:33](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1773) learning regular Python helps learning CircuitPython
-* [31:27](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1887) Merge 1.12 completed - pull request
-* [32:10](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1930) Thanks Jeff E.
-* [32:35](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=1955) anyone been able to get circuitpython working on a soft FPGA RISC-V?
-* [33:33](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2013) Dan’s pull request for USB stuff!
-* [34:18](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2058) - status update ?.merge MP 1.10 ….1.15 into  ( CP 7.0 )
-* [38:40](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2320) Sublime merge process description
-* [39:48](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2388) VS Code
-* [41:48](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2508) forking... making a copy and modding from there, and merging you bring in changes from a newer version of what you forked from?
-* [42:49](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2569) pycharm ?
-* [43:35](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2615) contributing to github guide
-* [43:57](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2637) expanding on 1.12 pull request
-* [45:45](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=2745) merging…
-* [54:04](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=3244) meld is free tool similar features
-* [56:15](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=3375) MP_ERROR_TEXT
-* [57:50](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=3470) using beyond compare right now to compare two 8GB binary files.
-* [59:23](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=3563) Source Tree, Visual Studio
-* [1:04:30](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=3870)  Is there an Adafruit BMP280 eagle library? - need to check product…
-* [1:07:20](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=4040) GC collect - assign 0 to support collecting
-* [1:09:20](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=4160) under 200 files to merge left
-* [1:14:50](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=4490) assign 0, then gc vs. del for freeing memory
-* [1:17:09](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=4629) using del() to unimport
-* [1:17:47](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=4667) ​Does CircuitPython run any hardware CI to make sure there are no regressions on supported boards?
-* [1:19:35](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=4775) pairheap - we probably want it :-)
-* [1:26:00](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=5160) we don’t use mod microsocket
-* [1:28:15](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=5295) Jeff found places where we don’t have tests…
-* [1:29:12](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=5352) mp thread
-* [1:31:00](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=5460) frzqstr.py
-* [1:32:44](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=5564) in the py folder!
-* [1:36:45](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=5805) CP has more support in ‘struct’ and turn off non-standard stuff
-* [1:42:35](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=6155) py/compile.c  # emit bytecode
-* [1:45:35](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=6335) walrus operator?  PN_annassign
-* [1:48:50](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=6530) native mpy files? … emitbc.c # emit bytecode
-* [1:52:25](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=6745) yes - it’s nice to merge each milestone
-* [1:54:32](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=6872) py/gc.c
-* [1:57:16](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=7036) CP has f-string support, MP doesn’t
-* [1:59:59](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=7199) CP gets full version from github
-* [2:00:30](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=7230) py/malloc.c
-* [2:02:15](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=7335) “after I’m done with this, it is not going to compile, that’s now how it works”
-* [2:06:07](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=7567) py/modstruct.c  ( we don’t use it I think )
-* [2:07:10](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=7630) two spots where we want to say circuitpython…
-* [2:09:12](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=7752) some things that don’t belong in the py folder…
-* [2:11:50](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=7910) community broadband…
-* [2:14:25](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=8065) FCC interested in learning users broadband speeds https://broadbandmap.fcc.gov/#/
-* [2:16:57](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=8217) py/obj.h (is a big file)
-* [2:19:31](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=8371) a while ago they changed the capitalizations of things….
-* [2:28:31](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=8911) six to go
-* [2:32:30](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=9150) py/objmodule.c  - 99 left
-* [2:34:20](https://www.youtube.com/watch?v=VIDEO_2021_04_30?t=9260) wrap up / thanks
+* [5:00](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=300) housekeeping
+* [5:50](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=350) NeoTrinkey
+* [11:00](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=660) trying to load circuit python on my new metro esp32-s2, but the firmware doesn't seem to update since I don't see it mount
+* [13:39](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=819) pick up where scott left off…
+* [13:59](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=839) Oxide Computer exploit
+* [15:56](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=956) Micropython & CircuitPython relationship
+* [16:20](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=980) Micropython 8 years old - happy birthday! (April-29)
+* [19:43](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=1183) adafruit readme on github
+* [20:03](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=1203) BNO055 project- -> forums.adafruit
+* [21:56](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=1316) Interrupts/threading MP vs.CP
+* [24:59](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=1499) - memory related usage
+* [27:25](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=1645) CircuitPython libs just work cross platform, like using a LoRa RF modem on a RasPi with Blinka.
+* [28:45](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=1725) Can CircuitPython run on the Adafruit Feather boards? - see circuitpython.org/downloads
+* [29:33](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=1773) learning regular Python helps learning CircuitPython
+* [31:27](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=1887) Merge 1.12 completed - pull request
+* [32:10](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=1930) Thanks Jeff E.
+* [32:35](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=1955) anyone been able to get circuitpython working on a soft FPGA RISC-V?
+* [33:33](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=2013) Dan’s pull request for USB stuff!
+* [34:18](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=2058) - status update ?.merge MP 1.10 ….1.15 into  ( CP 7.0 )
+* [38:40](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=2320) Sublime merge process description
+* [39:48](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=2388) VS Code
+* [41:48](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=2508) forking... making a copy and modding from there, and merging you bring in changes from a newer version of what you forked from?
+* [42:49](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=2569) pycharm ?
+* [43:35](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=2615) contributing to github guide
+* [43:57](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=2637) expanding on 1.12 pull request
+* [45:45](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=2745) merging…
+* [54:04](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=3244) meld is free tool similar features
+* [56:15](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=3375) MP_ERROR_TEXT
+* [57:50](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=3470) using beyond compare right now to compare two 8GB binary files.
+* [59:23](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=3563) Source Tree, Visual Studio
+* [1:04:30](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=3870)  Is there an Adafruit BMP280 eagle library? - need to check product…
+* [1:07:20](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=4040) GC collect - assign 0 to support collecting
+* [1:09:20](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=4160) under 200 files to merge left
+* [1:14:50](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=4490) assign 0, then gc vs. del for freeing memory
+* [1:17:09](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=4629) using del() to unimport
+* [1:17:47](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=4667) ​Does CircuitPython run any hardware CI to make sure there are no regressions on supported boards?
+* [1:19:35](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=4775) pairheap - we probably want it :-)
+* [1:26:00](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=5160) we don’t use mod microsocket
+* [1:28:15](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=5295) Jeff found places where we don’t have tests…
+* [1:29:12](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=5352) mp thread
+* [1:31:00](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=5460) frzqstr.py
+* [1:32:44](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=5564) in the py folder!
+* [1:36:45](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=5805) CP has more support in ‘struct’ and turn off non-standard stuff
+* [1:42:35](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=6155) py/compile.c  # emit bytecode
+* [1:45:35](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=6335) walrus operator?  PN_annassign
+* [1:48:50](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=6530) native mpy files? … emitbc.c # emit bytecode
+* [1:52:25](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=6745) yes - it’s nice to merge each milestone
+* [1:54:32](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=6872) py/gc.c
+* [1:57:16](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=7036) CP has f-string support, MP doesn’t
+* [1:59:59](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=7199) CP gets full version from github
+* [2:00:30](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=7230) py/malloc.c
+* [2:02:15](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=7335) “after I’m done with this, it is not going to compile, that’s now how it works”
+* [2:06:07](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=7567) py/modstruct.c  ( we don’t use it I think )
+* [2:07:10](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=7630) two spots where we want to say circuitpython…
+* [2:09:12](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=7752) some things that don’t belong in the py folder…
+* [2:11:50](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=7910) community broadband…
+* [2:14:25](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=8065) FCC interested in learning users broadband speeds https://broadbandmap.fcc.gov/#/
+* [2:16:57](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=8217) py/obj.h (is a big file)
+* [2:19:31](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=8371) a while ago they changed the capitalizations of things….
+* [2:28:31](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=8911) six to go
+* [2:32:30](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=9150) py/objmodule.c  - 99 left
+* [2:34:20](https://www.youtube.com/watch?v=3t8Ul10KmUw&t=9260) wrap up / thanks
 # hope this wasn’t too long 2:35:20 4:33 pm

--- a/2021/2021-05-07.md
+++ b/2021/2021-05-07.md
@@ -61,4 +61,3 @@ Timestamps
 * [2:16:37](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=8197) Wrap up (4:13pm PDT)
 * [2:18:30](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=8310) pet the cat :-)
 * [2:19:03](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=8343) freeze screen
-*

--- a/2021/2021-05-07.md
+++ b/2021/2021-05-07.md
@@ -5,7 +5,7 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Housekeeping
-* 07:20 I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
+* [07:20](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=440) I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After I’ll unmute and continue.
@@ -13,52 +13,52 @@ Housekeeping
 
 
 Plan
-* 
+*
 
 Timestamps
-* 4:40 adafruit jobs ( before housekeeping - not sure if youtube handles it ok )
-* 10:23 what Scott is doing next week - Pycon.org ( virtual 14th & 15th)
-* 14:43 Melborne micropython meetup https://melbournemicropythonmeetup.github.io/
-* 16:40 Merge pull request for 1.13 is out
-* 19:00 1.10, 1.11, 1.12 merged already
-* 19:51 1.14 & 1.15 yesterday
-* 21:35 1.11 & 1.12 cherry picks lost git history (1.13 brings in the history)
-* 23:23 vaccination hesitancy
-* 27:05 advantages of using Circuit Python
-* 29:04 circuitpython-essentials
-* 35:03 dynamic cpu frequency scaling
-* 36:55 python helper tool for micropython merges PR #4725
-* 38:39 TinyLogicFriend #137 sigrokproject kmatch
-* 42:43 Dan’s USB changes Dynamic USB descriptors #4689 (in CP 7.0)
-* 47:01 USB endpoint summary / usb audio?
-* 49:30 Circuitpy_eraser #4722 discussion
-* 51:45 how to enter safe mode from hardware
-* 53:42 board without status LED issue
-* 54:40 safe mode LED?
-* 57:12 uf2 - flip configuration bit?
-* 58:30 replying to pr #4722
-* 1:01:05 Status leds (RGB and/or single color)
-* 1:04:40 eventually CP will be within 100 commits from MP
-* 1:05:16 simplify the status LED flash pattern commit (from 3 weeks ago )
-* 1:11:17 pewpew_m4 speaker as status LED? (we should do that)
-* 1:12:30 can reset into safemode
-* 1:13:30 check out turning off the neopixel ( break into deep dive ) nrf status_leds.c
-* 1:19:10 fixed and demonstrated with neopixel disabled!
-* 1:20:00 review the simplify_status_led code changes
-* 1:28:45 boot loader blinks unchanged ( tinyuf2 )
-* 1:29:15 any way to slow down a crash/reset loop
-* 1:32:15 crash reset loop continue
-* 1:36:28 any differences between connected to computer or powerbank ( no-safe mode is the same )
-* 1:39:30 Amend previous commit / push simplify_status_led
-* 1:40:30 How much space did we win? (checking nrf feather, QT Py, and trinket_m0)
-* 1:42:30 -Os flags when compiling ‘sometimes’
-* 1:51:30 Piunora Raspberry Pi CM4 crowd supply project getting close
-* 1:52:44 Start BLE workflow next week / convert to native
-* 1:57:50 Scott’s R.C.W law project on GitLab 
-* 1:59:40 public broadband utility bills
-* 2:06:55 AT&T definition of ‘broadband’ 56K
-* 2:11:00 efforts to port to other states
-* 2:16:37 Wrap up (4:13pm PDT)
-* 2:18:30 pet the cat :-)
-* 2:19:03 freeze screen 
+* [4:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=280) adafruit jobs ( before housekeeping - not sure if youtube handles it ok )
+* [10:23](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=623) what Scott is doing next week - Pycon.org ( virtual 14th & 15th)
+* [14:43](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=883) Melborne micropython meetup https://melbournemicropythonmeetup.github.io/
+* [16:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=1000) Merge pull request for 1.13 is out
+* [19:00](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=1140) 1.10, 1.11, 1.12 merged already
+* [19:51](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=1191) 1.14 & 1.15 yesterday
+* [21:35](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=1295) 1.11 & 1.12 cherry picks lost git history (1.13 brings in the history)
+* [23:23](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=1403) vaccination hesitancy
+* [27:05](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=1625) advantages of using Circuit Python
+* [29:04](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=1744) circuitpython-essentials
+* [35:03](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=2103) dynamic cpu frequency scaling
+* [36:55](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=2215) python helper tool for micropython merges PR #4725
+* [38:39](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=2319) TinyLogicFriend #137 sigrokproject kmatch
+* [42:43](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=2563) Dan’s USB changes Dynamic USB descriptors #4689 (in CP 7.0)
+* [47:01](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=2821) USB endpoint summary / usb audio?
+* [49:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=2970) Circuitpy_eraser #4722 discussion
+* [51:45](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=3105) how to enter safe mode from hardware
+* [53:42](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=3222) board without status LED issue
+* [54:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=3280) safe mode LED?
+* [57:12](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=3432) uf2 - flip configuration bit?
+* [58:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=3510) replying to pr #4722
+* [1:01:05](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=3665) Status leds (RGB and/or single color)
+* [1:04:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=3880) eventually CP will be within 100 commits from MP
+* [1:05:16](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=3916) simplify the status LED flash pattern commit (from 3 weeks ago )
+* [1:11:17](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=4277) pewpew_m4 speaker as status LED? (we should do that)
+* [1:12:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=4350) can reset into safemode
+* [1:13:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=4410) check out turning off the neopixel ( break into deep dive ) nrf status_leds.c
+* [1:19:10](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=4750) fixed and demonstrated with neopixel disabled!
+* [1:20:00](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=4800) review the simplify_status_led code changes
+* [1:28:45](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=5325) boot loader blinks unchanged ( tinyuf2 )
+* [1:29:15](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=5355) any way to slow down a crash/reset loop
+* [1:32:15](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=5535) crash reset loop continue
+* [1:36:28](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=5788) any differences between connected to computer or powerbank ( no-safe mode is the same )
+* [1:39:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=5970) Amend previous commit / push simplify_status_led
+* [1:40:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=6030) How much space did we win? (checking nrf feather, QT Py, and trinket_m0)
+* [1:42:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=6150) -Os flags when compiling ‘sometimes’
+* [1:51:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=6690) Piunora Raspberry Pi CM4 crowd supply project getting close
+* [1:52:44](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=6764) Start BLE workflow next week / convert to native
+* [1:57:50](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=7070) Scott’s R.C.W law project on GitLab
+* [1:59:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=7180) public broadband utility bills
+* [2:06:55](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=7615) AT&T definition of ‘broadband’ 56K
+* [2:11:00](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=7860) efforts to port to other states
+* [2:16:37](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=8197) Wrap up (4:13pm PDT)
+* [2:18:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=8310) pet the cat :-)
+* [2:19:03](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=8343) freeze screen
 *

--- a/2021/2021-05-07.md
+++ b/2021/2021-05-07.md
@@ -5,7 +5,7 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Housekeeping
-* [07:20](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=440) I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
+* [07:20](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=440) I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After I’ll unmute and continue.
@@ -16,49 +16,49 @@ Plan
 *
 
 Timestamps
-* [4:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=280) adafruit jobs ( before housekeeping - not sure if youtube handles it ok )
-* [10:23](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=623) what Scott is doing next week - Pycon.org ( virtual 14th & 15th)
-* [14:43](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=883) Melborne micropython meetup https://melbournemicropythonmeetup.github.io/
-* [16:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=1000) Merge pull request for 1.13 is out
-* [19:00](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=1140) 1.10, 1.11, 1.12 merged already
-* [19:51](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=1191) 1.14 & 1.15 yesterday
-* [21:35](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=1295) 1.11 & 1.12 cherry picks lost git history (1.13 brings in the history)
-* [23:23](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=1403) vaccination hesitancy
-* [27:05](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=1625) advantages of using Circuit Python
-* [29:04](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=1744) circuitpython-essentials
-* [35:03](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=2103) dynamic cpu frequency scaling
-* [36:55](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=2215) python helper tool for micropython merges PR #4725
-* [38:39](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=2319) TinyLogicFriend #137 sigrokproject kmatch
-* [42:43](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=2563) Dan’s USB changes Dynamic USB descriptors #4689 (in CP 7.0)
-* [47:01](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=2821) USB endpoint summary / usb audio?
-* [49:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=2970) Circuitpy_eraser #4722 discussion
-* [51:45](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=3105) how to enter safe mode from hardware
-* [53:42](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=3222) board without status LED issue
-* [54:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=3280) safe mode LED?
-* [57:12](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=3432) uf2 - flip configuration bit?
-* [58:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=3510) replying to pr #4722
-* [1:01:05](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=3665) Status leds (RGB and/or single color)
-* [1:04:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=3880) eventually CP will be within 100 commits from MP
-* [1:05:16](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=3916) simplify the status LED flash pattern commit (from 3 weeks ago )
-* [1:11:17](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=4277) pewpew_m4 speaker as status LED? (we should do that)
-* [1:12:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=4350) can reset into safemode
-* [1:13:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=4410) check out turning off the neopixel ( break into deep dive ) nrf status_leds.c
-* [1:19:10](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=4750) fixed and demonstrated with neopixel disabled!
-* [1:20:00](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=4800) review the simplify_status_led code changes
-* [1:28:45](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=5325) boot loader blinks unchanged ( tinyuf2 )
-* [1:29:15](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=5355) any way to slow down a crash/reset loop
-* [1:32:15](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=5535) crash reset loop continue
-* [1:36:28](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=5788) any differences between connected to computer or powerbank ( no-safe mode is the same )
-* [1:39:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=5970) Amend previous commit / push simplify_status_led
-* [1:40:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=6030) How much space did we win? (checking nrf feather, QT Py, and trinket_m0)
-* [1:42:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=6150) -Os flags when compiling ‘sometimes’
-* [1:51:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=6690) Piunora Raspberry Pi CM4 crowd supply project getting close
-* [1:52:44](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=6764) Start BLE workflow next week / convert to native
-* [1:57:50](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=7070) Scott’s R.C.W law project on GitLab
-* [1:59:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=7180) public broadband utility bills
-* [2:06:55](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=7615) AT&T definition of ‘broadband’ 56K
-* [2:11:00](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=7860) efforts to port to other states
-* [2:16:37](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=8197) Wrap up (4:13pm PDT)
-* [2:18:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=8310) pet the cat :-)
-* [2:19:03](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=8343) freeze screen
+* [4:40](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=280) adafruit jobs ( before housekeeping - not sure if youtube handles it ok )
+* [10:23](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=623) what Scott is doing next week - Pycon.org ( virtual 14th & 15th)
+* [14:43](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=883) Melborne micropython meetup https://melbournemicropythonmeetup.github.io/
+* [16:40](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=1000) Merge pull request for 1.13 is out
+* [19:00](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=1140) 1.10, 1.11, 1.12 merged already
+* [19:51](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=1191) 1.14 & 1.15 yesterday
+* [21:35](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=1295) 1.11 & 1.12 cherry picks lost git history (1.13 brings in the history)
+* [23:23](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=1403) vaccination hesitancy
+* [27:05](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=1625) advantages of using Circuit Python
+* [29:04](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=1744) circuitpython-essentials
+* [35:03](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=2103) dynamic cpu frequency scaling
+* [36:55](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=2215) python helper tool for micropython merges PR #4725
+* [38:39](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=2319) TinyLogicFriend #137 sigrokproject kmatch
+* [42:43](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=2563) Dan’s USB changes Dynamic USB descriptors #4689 (in CP 7.0)
+* [47:01](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=2821) USB endpoint summary / usb audio?
+* [49:30](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=2970) Circuitpy_eraser #4722 discussion
+* [51:45](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=3105) how to enter safe mode from hardware
+* [53:42](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=3222) board without status LED issue
+* [54:40](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=3280) safe mode LED?
+* [57:12](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=3432) uf2 - flip configuration bit?
+* [58:30](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=3510) replying to pr #4722
+* [1:01:05](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=3665) Status leds (RGB and/or single color)
+* [1:04:40](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=3880) eventually CP will be within 100 commits from MP
+* [1:05:16](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=3916) simplify the status LED flash pattern commit (from 3 weeks ago )
+* [1:11:17](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=4277) pewpew_m4 speaker as status LED? (we should do that)
+* [1:12:30](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=4350) can reset into safemode
+* [1:13:30](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=4410) check out turning off the neopixel ( break into deep dive ) nrf status_leds.c
+* [1:19:10](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=4750) fixed and demonstrated with neopixel disabled!
+* [1:20:00](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=4800) review the simplify_status_led code changes
+* [1:28:45](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=5325) boot loader blinks unchanged ( tinyuf2 )
+* [1:29:15](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=5355) any way to slow down a crash/reset loop
+* [1:32:15](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=5535) crash reset loop continue
+* [1:36:28](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=5788) any differences between connected to computer or powerbank ( no-safe mode is the same )
+* [1:39:30](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=5970) Amend previous commit / push simplify_status_led
+* [1:40:30](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=6030) How much space did we win? (checking nrf feather, QT Py, and trinket_m0)
+* [1:42:30](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=6150) -Os flags when compiling ‘sometimes’
+* [1:51:30](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=6690) Piunora Raspberry Pi CM4 crowd supply project getting close
+* [1:52:44](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=6764) Start BLE workflow next week / convert to native
+* [1:57:50](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=7070) Scott’s R.C.W law project on GitLab
+* [1:59:40](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=7180) public broadband utility bills
+* [2:06:55](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=7615) AT&T definition of ‘broadband’ 56K
+* [2:11:00](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=7860) efforts to port to other states
+* [2:16:37](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=8197) Wrap up (4:13pm PDT)
+* [2:18:30](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=8310) pet the cat :-)
+* [2:19:03](https://www.youtube.com/watch?v=cbLXRjjc-Yg&t=8343) freeze screen
 *

--- a/2021/2021-05-07.md
+++ b/2021/2021-05-07.md
@@ -5,7 +5,7 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Housekeeping
-* [07:20](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=440) I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
+* [07:20](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=440) I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After I’ll unmute and continue.
@@ -16,49 +16,49 @@ Plan
 *
 
 Timestamps
-* [4:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=280) adafruit jobs ( before housekeeping - not sure if youtube handles it ok )
-* [10:23](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=623) what Scott is doing next week - Pycon.org ( virtual 14th & 15th)
-* [14:43](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=883) Melborne micropython meetup https://melbournemicropythonmeetup.github.io/
-* [16:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=1000) Merge pull request for 1.13 is out
-* [19:00](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=1140) 1.10, 1.11, 1.12 merged already
-* [19:51](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=1191) 1.14 & 1.15 yesterday
-* [21:35](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=1295) 1.11 & 1.12 cherry picks lost git history (1.13 brings in the history)
-* [23:23](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=1403) vaccination hesitancy
-* [27:05](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=1625) advantages of using Circuit Python
-* [29:04](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=1744) circuitpython-essentials
-* [35:03](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=2103) dynamic cpu frequency scaling
-* [36:55](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=2215) python helper tool for micropython merges PR #4725
-* [38:39](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=2319) TinyLogicFriend #137 sigrokproject kmatch
-* [42:43](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=2563) Dan’s USB changes Dynamic USB descriptors #4689 (in CP 7.0)
-* [47:01](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=2821) USB endpoint summary / usb audio?
-* [49:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=2970) Circuitpy_eraser #4722 discussion
-* [51:45](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=3105) how to enter safe mode from hardware
-* [53:42](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=3222) board without status LED issue
-* [54:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=3280) safe mode LED?
-* [57:12](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=3432) uf2 - flip configuration bit?
-* [58:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=3510) replying to pr #4722
-* [1:01:05](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=3665) Status leds (RGB and/or single color)
-* [1:04:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=3880) eventually CP will be within 100 commits from MP
-* [1:05:16](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=3916) simplify the status LED flash pattern commit (from 3 weeks ago )
-* [1:11:17](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=4277) pewpew_m4 speaker as status LED? (we should do that)
-* [1:12:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=4350) can reset into safemode
-* [1:13:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=4410) check out turning off the neopixel ( break into deep dive ) nrf status_leds.c
-* [1:19:10](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=4750) fixed and demonstrated with neopixel disabled!
-* [1:20:00](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=4800) review the simplify_status_led code changes
-* [1:28:45](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=5325) boot loader blinks unchanged ( tinyuf2 )
-* [1:29:15](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=5355) any way to slow down a crash/reset loop
-* [1:32:15](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=5535) crash reset loop continue
-* [1:36:28](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=5788) any differences between connected to computer or powerbank ( no-safe mode is the same )
-* [1:39:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=5970) Amend previous commit / push simplify_status_led
-* [1:40:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=6030) How much space did we win? (checking nrf feather, QT Py, and trinket_m0)
-* [1:42:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=6150) -Os flags when compiling ‘sometimes’
-* [1:51:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=6690) Piunora Raspberry Pi CM4 crowd supply project getting close
-* [1:52:44](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=6764) Start BLE workflow next week / convert to native
-* [1:57:50](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=7070) Scott’s R.C.W law project on GitLab
-* [1:59:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=7180) public broadband utility bills
-* [2:06:55](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=7615) AT&T definition of ‘broadband’ 56K
-* [2:11:00](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=7860) efforts to port to other states
-* [2:16:37](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=8197) Wrap up (4:13pm PDT)
-* [2:18:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=8310) pet the cat :-)
-* [2:19:03](https://www.youtube.com/watch?v=VIDEO_2021_05_07?t=8343) freeze screen
+* [4:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=280) adafruit jobs ( before housekeeping - not sure if youtube handles it ok )
+* [10:23](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=623) what Scott is doing next week - Pycon.org ( virtual 14th & 15th)
+* [14:43](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=883) Melborne micropython meetup https://melbournemicropythonmeetup.github.io/
+* [16:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=1000) Merge pull request for 1.13 is out
+* [19:00](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=1140) 1.10, 1.11, 1.12 merged already
+* [19:51](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=1191) 1.14 & 1.15 yesterday
+* [21:35](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=1295) 1.11 & 1.12 cherry picks lost git history (1.13 brings in the history)
+* [23:23](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=1403) vaccination hesitancy
+* [27:05](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=1625) advantages of using Circuit Python
+* [29:04](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=1744) circuitpython-essentials
+* [35:03](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=2103) dynamic cpu frequency scaling
+* [36:55](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=2215) python helper tool for micropython merges PR #4725
+* [38:39](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=2319) TinyLogicFriend #137 sigrokproject kmatch
+* [42:43](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=2563) Dan’s USB changes Dynamic USB descriptors #4689 (in CP 7.0)
+* [47:01](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=2821) USB endpoint summary / usb audio?
+* [49:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=2970) Circuitpy_eraser #4722 discussion
+* [51:45](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=3105) how to enter safe mode from hardware
+* [53:42](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=3222) board without status LED issue
+* [54:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=3280) safe mode LED?
+* [57:12](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=3432) uf2 - flip configuration bit?
+* [58:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=3510) replying to pr #4722
+* [1:01:05](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=3665) Status leds (RGB and/or single color)
+* [1:04:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=3880) eventually CP will be within 100 commits from MP
+* [1:05:16](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=3916) simplify the status LED flash pattern commit (from 3 weeks ago )
+* [1:11:17](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=4277) pewpew_m4 speaker as status LED? (we should do that)
+* [1:12:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=4350) can reset into safemode
+* [1:13:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=4410) check out turning off the neopixel ( break into deep dive ) nrf status_leds.c
+* [1:19:10](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=4750) fixed and demonstrated with neopixel disabled!
+* [1:20:00](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=4800) review the simplify_status_led code changes
+* [1:28:45](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=5325) boot loader blinks unchanged ( tinyuf2 )
+* [1:29:15](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=5355) any way to slow down a crash/reset loop
+* [1:32:15](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=5535) crash reset loop continue
+* [1:36:28](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=5788) any differences between connected to computer or powerbank ( no-safe mode is the same )
+* [1:39:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=5970) Amend previous commit / push simplify_status_led
+* [1:40:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=6030) How much space did we win? (checking nrf feather, QT Py, and trinket_m0)
+* [1:42:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=6150) -Os flags when compiling ‘sometimes’
+* [1:51:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=6690) Piunora Raspberry Pi CM4 crowd supply project getting close
+* [1:52:44](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=6764) Start BLE workflow next week / convert to native
+* [1:57:50](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=7070) Scott’s R.C.W law project on GitLab
+* [1:59:40](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=7180) public broadband utility bills
+* [2:06:55](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=7615) AT&T definition of ‘broadband’ 56K
+* [2:11:00](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=7860) efforts to port to other states
+* [2:16:37](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=8197) Wrap up (4:13pm PDT)
+* [2:18:30](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=8310) pet the cat :-)
+* [2:19:03](https://www.youtube.com/watch?v=VIDEO_2021_05_07&t=8343) freeze screen
 *

--- a/2021/2021-05-14.md
+++ b/2021/2021-05-14.md
@@ -5,11 +5,11 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Housekeeping
-* 0:03:36 I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
+* [0:03:36](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=216) I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After I’ll unmute and continue.
-* 0:05:51 Next week will be on Friday.
+* [0:05:51](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=351) Next week will be on Friday.
 
 
 Plan
@@ -21,43 +21,43 @@ Plan
 
 Timestamps
 * 0:7:52 Micropython 1.15 merged in
-* 0:11:53 back to BLE? Next week
-* 0:14:30 Piunora un-bagging
-* 0:27:20 First Steps - TinyUSB on CM4
-* 0:33:24 Python Language Summit Talk / Lightning talk
-* 0:36:36 CPython -> CircuitPython slides
-* 0:38:36 CircuitPython builtins
-* 0:39:25 CircuitPython Modules
-* 0:42:50 Things that people ask for:
-* 0:43:20 CP and Pip?
-* 0:46:46 f’strings implementation differently between CP and CPython
-* 0:49:27 Python Parse - (CPython) for parsing from UART vs. comma separated and split (and alternates )
-* 0:52:00 Broadband Map
-* 0:58:13 fiber-deserts.net
-* 1:09:50 muninetwork.org podcast
-* 1:11:26 broadband access  www.commerce.wa.gov (speed survey)
-* 1:12:10 www.argic.com survey results
-* 1:14:43 LED Debugging deep dive
-* 1:15:37 Feather NRF status LED
-* 1:18:11 Status LED on USB & battery
-* 1:20:15  no additional current draw for code running a sleep/wake cycle?
-* 1:21:10 main.c
-* 1:23:35 “Wasn’t working on SAMD”
-* 1:25:10 code works with single LED (blue LED)
-* 1:25:30 Did you see on #showandtell that Micha (@2231puppy) plan to work on CP bare metal on Pi4 and he hope you saw it: https://www.youtube.com/watch?v=TadsJYIkkig&t=1200s
-* 1:27:01 feather M4 with Blue neopixel - supposed to be white (in REPL)
-* 1:27:56 supposed to flash yellow, but it’s flashing green
-* 1:35:56 atmel-samd neopixel assembly code SAM_D5X_E5X
-* 1:42:40 Salea Logic 2 neopixel capture
-* 1:46:35 adjusting timing - “make this gap longer”
-* 2:03:48 no longer “safe-mode-ing” because of debug
-* 2:05:15 commit and rebasing in git
-* 2:06:50 “Delete old debug code - rarely useful in the future.”
-* 2:12:20 git commit --amend
-* 2:12:44 git push
-* 2:13:06 pull request - fix SAMD
-* 2:14:11 wrap up
-* 2:14:55 next week - Friday as well
-* 2:16:40 see you next week
+* [0:11:53](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=713) back to BLE? Next week
+* [0:14:30](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=870) Piunora un-bagging
+* [0:27:20](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=1640) First Steps - TinyUSB on CM4
+* [0:33:24](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=2004) Python Language Summit Talk / Lightning talk
+* [0:36:36](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=2196) CPython -> CircuitPython slides
+* [0:38:36](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=2316) CircuitPython builtins
+* [0:39:25](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=2365) CircuitPython Modules
+* [0:42:50](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=2570) Things that people ask for:
+* [0:43:20](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=2600) CP and Pip?
+* [0:46:46](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=2806) f’strings implementation differently between CP and CPython
+* [0:49:27](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=2967) Python Parse - (CPython) for parsing from UART vs. comma separated and split (and alternates )
+* [0:52:00](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=3120) Broadband Map
+* [0:58:13](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=3493) fiber-deserts.net
+* [1:09:50](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=4190) muninetwork.org podcast
+* [1:11:26](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=4286) broadband access  www.commerce.wa.gov (speed survey)
+* [1:12:10](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=4330) www.argic.com survey results
+* [1:14:43](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=4483) LED Debugging deep dive
+* [1:15:37](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=4537) Feather NRF status LED
+* [1:18:11](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=4691) Status LED on USB & battery
+* [1:20:15](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=4815)  no additional current draw for code running a sleep/wake cycle?
+* [1:21:10](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=4870) main.c
+* [1:23:35](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=5015) “Wasn’t working on SAMD”
+* [1:25:10](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=5110) code works with single LED (blue LED)
+* [1:25:30](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=5130) Did you see on #showandtell that Micha (@2231puppy) plan to work on CP bare metal on Pi4 and he hope you saw it: https://www.youtube.com/watch?v=TadsJYIkkig&t=1200s
+* [1:27:01](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=5221) feather M4 with Blue neopixel - supposed to be white (in REPL)
+* [1:27:56](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=5276) supposed to flash yellow, but it’s flashing green
+* [1:35:56](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=5756) atmel-samd neopixel assembly code SAM_D5X_E5X
+* [1:42:40](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=6160) Salea Logic 2 neopixel capture
+* [1:46:35](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=6395) adjusting timing - “make this gap longer”
+* [2:03:48](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=7428) no longer “safe-mode-ing” because of debug
+* [2:05:15](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=7515) commit and rebasing in git
+* [2:06:50](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=7610) “Delete old debug code - rarely useful in the future.”
+* [2:12:20](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=7940) git commit --amend
+* [2:12:44](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=7964) git push
+* [2:13:06](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=7986) pull request - fix SAMD
+* [2:14:11](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=8051) wrap up
+* [2:14:55](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=8095) next week - Friday as well
+* [2:16:40](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=8200) see you next week
 * # timestamps might be off by 15 seconds from youtube
 *

--- a/2021/2021-05-14.md
+++ b/2021/2021-05-14.md
@@ -20,7 +20,7 @@ Plan
 
 
 Timestamps
-* 0:7:52 Micropython 1.15 merged in
+* [0:7:52](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=472) Micropython 1.15 merged in
 * [0:11:53](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=713) back to BLE? Next week
 * [0:14:30](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=870) Piunora un-bagging
 * [0:27:20](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=1640) First Steps - TinyUSB on CM4
@@ -60,4 +60,3 @@ Timestamps
 * [2:14:55](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=8095) next week - Friday as well
 * [2:16:40](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=8200) see you next week
 * # timestamps might be off by 15 seconds from youtube
-*

--- a/2021/2021-05-14.md
+++ b/2021/2021-05-14.md
@@ -5,11 +5,11 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Housekeeping
-* [0:03:36](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=216) I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
+* [0:03:36](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=216) I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After I’ll unmute and continue.
-* [0:05:51](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=351) Next week will be on Friday.
+* [0:05:51](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=351) Next week will be on Friday.
 
 
 Plan
@@ -21,43 +21,43 @@ Plan
 
 Timestamps
 * 0:7:52 Micropython 1.15 merged in
-* [0:11:53](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=713) back to BLE? Next week
-* [0:14:30](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=870) Piunora un-bagging
-* [0:27:20](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=1640) First Steps - TinyUSB on CM4
-* [0:33:24](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=2004) Python Language Summit Talk / Lightning talk
-* [0:36:36](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=2196) CPython -> CircuitPython slides
-* [0:38:36](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=2316) CircuitPython builtins
-* [0:39:25](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=2365) CircuitPython Modules
-* [0:42:50](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=2570) Things that people ask for:
-* [0:43:20](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=2600) CP and Pip?
-* [0:46:46](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=2806) f’strings implementation differently between CP and CPython
-* [0:49:27](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=2967) Python Parse - (CPython) for parsing from UART vs. comma separated and split (and alternates )
-* [0:52:00](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=3120) Broadband Map
-* [0:58:13](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=3493) fiber-deserts.net
-* [1:09:50](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=4190) muninetwork.org podcast
-* [1:11:26](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=4286) broadband access  www.commerce.wa.gov (speed survey)
-* [1:12:10](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=4330) www.argic.com survey results
-* [1:14:43](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=4483) LED Debugging deep dive
-* [1:15:37](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=4537) Feather NRF status LED
-* [1:18:11](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=4691) Status LED on USB & battery
-* [1:20:15](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=4815)  no additional current draw for code running a sleep/wake cycle?
-* [1:21:10](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=4870) main.c
-* [1:23:35](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=5015) “Wasn’t working on SAMD”
-* [1:25:10](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=5110) code works with single LED (blue LED)
-* [1:25:30](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=5130) Did you see on #showandtell that Micha (@2231puppy) plan to work on CP bare metal on Pi4 and he hope you saw it: https://www.youtube.com/watch?v=TadsJYIkkig&t=1200s
-* [1:27:01](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=5221) feather M4 with Blue neopixel - supposed to be white (in REPL)
-* [1:27:56](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=5276) supposed to flash yellow, but it’s flashing green
-* [1:35:56](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=5756) atmel-samd neopixel assembly code SAM_D5X_E5X
-* [1:42:40](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=6160) Salea Logic 2 neopixel capture
-* [1:46:35](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=6395) adjusting timing - “make this gap longer”
-* [2:03:48](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=7428) no longer “safe-mode-ing” because of debug
-* [2:05:15](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=7515) commit and rebasing in git
-* [2:06:50](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=7610) “Delete old debug code - rarely useful in the future.”
-* [2:12:20](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=7940) git commit --amend
-* [2:12:44](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=7964) git push
-* [2:13:06](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=7986) pull request - fix SAMD
-* [2:14:11](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=8051) wrap up
-* [2:14:55](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=8095) next week - Friday as well
-* [2:16:40](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=8200) see you next week
+* [0:11:53](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=713) back to BLE? Next week
+* [0:14:30](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=870) Piunora un-bagging
+* [0:27:20](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=1640) First Steps - TinyUSB on CM4
+* [0:33:24](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=2004) Python Language Summit Talk / Lightning talk
+* [0:36:36](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=2196) CPython -> CircuitPython slides
+* [0:38:36](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=2316) CircuitPython builtins
+* [0:39:25](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=2365) CircuitPython Modules
+* [0:42:50](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=2570) Things that people ask for:
+* [0:43:20](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=2600) CP and Pip?
+* [0:46:46](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=2806) f’strings implementation differently between CP and CPython
+* [0:49:27](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=2967) Python Parse - (CPython) for parsing from UART vs. comma separated and split (and alternates )
+* [0:52:00](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=3120) Broadband Map
+* [0:58:13](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=3493) fiber-deserts.net
+* [1:09:50](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=4190) muninetwork.org podcast
+* [1:11:26](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=4286) broadband access  www.commerce.wa.gov (speed survey)
+* [1:12:10](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=4330) www.argic.com survey results
+* [1:14:43](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=4483) LED Debugging deep dive
+* [1:15:37](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=4537) Feather NRF status LED
+* [1:18:11](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=4691) Status LED on USB & battery
+* [1:20:15](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=4815)  no additional current draw for code running a sleep/wake cycle?
+* [1:21:10](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=4870) main.c
+* [1:23:35](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=5015) “Wasn’t working on SAMD”
+* [1:25:10](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=5110) code works with single LED (blue LED)
+* [1:25:30](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=5130) Did you see on #showandtell that Micha (@2231puppy) plan to work on CP bare metal on Pi4 and he hope you saw it: https://www.youtube.com/watch?v=TadsJYIkkig&t=1200s
+* [1:27:01](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=5221) feather M4 with Blue neopixel - supposed to be white (in REPL)
+* [1:27:56](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=5276) supposed to flash yellow, but it’s flashing green
+* [1:35:56](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=5756) atmel-samd neopixel assembly code SAM_D5X_E5X
+* [1:42:40](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=6160) Salea Logic 2 neopixel capture
+* [1:46:35](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=6395) adjusting timing - “make this gap longer”
+* [2:03:48](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=7428) no longer “safe-mode-ing” because of debug
+* [2:05:15](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=7515) commit and rebasing in git
+* [2:06:50](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=7610) “Delete old debug code - rarely useful in the future.”
+* [2:12:20](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=7940) git commit --amend
+* [2:12:44](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=7964) git push
+* [2:13:06](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=7986) pull request - fix SAMD
+* [2:14:11](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=8051) wrap up
+* [2:14:55](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=8095) next week - Friday as well
+* [2:16:40](https://www.youtube.com/watch?v=8wxxaZ9sRVE&t=8200) see you next week
 * # timestamps might be off by 15 seconds from youtube
 *

--- a/2021/2021-05-14.md
+++ b/2021/2021-05-14.md
@@ -5,11 +5,11 @@ Hi all, this doc is try and track topics and timecodes for my deep dive stream. 
 
 
 Housekeeping
-* [0:03:36](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=216) I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
+* [0:03:36](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=216) I’m sponsored by Adafruit to work on CircuitPython. Support them, and by extension me, by purchasing hardware from https://adafruit.com
 * Chat with me and lot of others on the Adafruit Discord at https://adafru.it/discord.
 * Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome.
 * Heads up that the cat is epileptic. If he has a seizure I will mute and watch him to make sure he’s ok. After I’ll unmute and continue.
-* [0:05:51](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=351) Next week will be on Friday.
+* [0:05:51](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=351) Next week will be on Friday.
 
 
 Plan
@@ -21,43 +21,43 @@ Plan
 
 Timestamps
 * 0:7:52 Micropython 1.15 merged in
-* [0:11:53](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=713) back to BLE? Next week
-* [0:14:30](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=870) Piunora un-bagging
-* [0:27:20](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=1640) First Steps - TinyUSB on CM4
-* [0:33:24](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=2004) Python Language Summit Talk / Lightning talk
-* [0:36:36](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=2196) CPython -> CircuitPython slides
-* [0:38:36](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=2316) CircuitPython builtins
-* [0:39:25](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=2365) CircuitPython Modules
-* [0:42:50](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=2570) Things that people ask for:
-* [0:43:20](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=2600) CP and Pip?
-* [0:46:46](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=2806) f’strings implementation differently between CP and CPython
-* [0:49:27](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=2967) Python Parse - (CPython) for parsing from UART vs. comma separated and split (and alternates )
-* [0:52:00](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=3120) Broadband Map
-* [0:58:13](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=3493) fiber-deserts.net
-* [1:09:50](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=4190) muninetwork.org podcast
-* [1:11:26](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=4286) broadband access  www.commerce.wa.gov (speed survey)
-* [1:12:10](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=4330) www.argic.com survey results
-* [1:14:43](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=4483) LED Debugging deep dive
-* [1:15:37](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=4537) Feather NRF status LED
-* [1:18:11](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=4691) Status LED on USB & battery
-* [1:20:15](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=4815)  no additional current draw for code running a sleep/wake cycle?
-* [1:21:10](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=4870) main.c
-* [1:23:35](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=5015) “Wasn’t working on SAMD”
-* [1:25:10](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=5110) code works with single LED (blue LED)
-* [1:25:30](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=5130) Did you see on #showandtell that Micha (@2231puppy) plan to work on CP bare metal on Pi4 and he hope you saw it: https://www.youtube.com/watch?v=TadsJYIkkig&t=1200s
-* [1:27:01](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=5221) feather M4 with Blue neopixel - supposed to be white (in REPL)
-* [1:27:56](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=5276) supposed to flash yellow, but it’s flashing green
-* [1:35:56](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=5756) atmel-samd neopixel assembly code SAM_D5X_E5X
-* [1:42:40](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=6160) Salea Logic 2 neopixel capture
-* [1:46:35](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=6395) adjusting timing - “make this gap longer”
-* [2:03:48](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=7428) no longer “safe-mode-ing” because of debug
-* [2:05:15](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=7515) commit and rebasing in git
-* [2:06:50](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=7610) “Delete old debug code - rarely useful in the future.”
-* [2:12:20](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=7940) git commit --amend
-* [2:12:44](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=7964) git push
-* [2:13:06](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=7986) pull request - fix SAMD
-* [2:14:11](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=8051) wrap up
-* [2:14:55](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=8095) next week - Friday as well
-* [2:16:40](https://www.youtube.com/watch?v=VIDEO_2021_05_14?t=8200) see you next week
+* [0:11:53](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=713) back to BLE? Next week
+* [0:14:30](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=870) Piunora un-bagging
+* [0:27:20](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=1640) First Steps - TinyUSB on CM4
+* [0:33:24](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=2004) Python Language Summit Talk / Lightning talk
+* [0:36:36](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=2196) CPython -> CircuitPython slides
+* [0:38:36](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=2316) CircuitPython builtins
+* [0:39:25](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=2365) CircuitPython Modules
+* [0:42:50](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=2570) Things that people ask for:
+* [0:43:20](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=2600) CP and Pip?
+* [0:46:46](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=2806) f’strings implementation differently between CP and CPython
+* [0:49:27](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=2967) Python Parse - (CPython) for parsing from UART vs. comma separated and split (and alternates )
+* [0:52:00](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=3120) Broadband Map
+* [0:58:13](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=3493) fiber-deserts.net
+* [1:09:50](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=4190) muninetwork.org podcast
+* [1:11:26](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=4286) broadband access  www.commerce.wa.gov (speed survey)
+* [1:12:10](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=4330) www.argic.com survey results
+* [1:14:43](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=4483) LED Debugging deep dive
+* [1:15:37](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=4537) Feather NRF status LED
+* [1:18:11](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=4691) Status LED on USB & battery
+* [1:20:15](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=4815)  no additional current draw for code running a sleep/wake cycle?
+* [1:21:10](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=4870) main.c
+* [1:23:35](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=5015) “Wasn’t working on SAMD”
+* [1:25:10](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=5110) code works with single LED (blue LED)
+* [1:25:30](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=5130) Did you see on #showandtell that Micha (@2231puppy) plan to work on CP bare metal on Pi4 and he hope you saw it: https://www.youtube.com/watch?v=TadsJYIkkig&t=1200s
+* [1:27:01](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=5221) feather M4 with Blue neopixel - supposed to be white (in REPL)
+* [1:27:56](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=5276) supposed to flash yellow, but it’s flashing green
+* [1:35:56](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=5756) atmel-samd neopixel assembly code SAM_D5X_E5X
+* [1:42:40](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=6160) Salea Logic 2 neopixel capture
+* [1:46:35](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=6395) adjusting timing - “make this gap longer”
+* [2:03:48](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=7428) no longer “safe-mode-ing” because of debug
+* [2:05:15](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=7515) commit and rebasing in git
+* [2:06:50](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=7610) “Delete old debug code - rarely useful in the future.”
+* [2:12:20](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=7940) git commit --amend
+* [2:12:44](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=7964) git push
+* [2:13:06](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=7986) pull request - fix SAMD
+* [2:14:11](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=8051) wrap up
+* [2:14:55](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=8095) next week - Friday as well
+* [2:16:40](https://www.youtube.com/watch?v=VIDEO_2021_05_14&t=8200) see you next week
 * # timestamps might be off by 15 seconds from youtube
 *

--- a/2021/2021-05-21.md
+++ b/2021/2021-05-21.md
@@ -16,42 +16,42 @@ Plan
 
 
 Timestamps
-* [0:20:20](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=1220) ESP32-S2 SPI display speed updates
-* [0:11:09](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=669) Would you consider yourself an IOT/Embedded Systems Engineer?
-* [0:12:33](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=753) Sublime text editor
-* [0:13:10](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=790) ​Is there a way to import lib folder modules from the REPL?
-* [0:13:53](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=833) How come red breaking is common?
-* [0:14:15](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=855)  implement a TCP stack in rust
-* [0:15:08](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=908) Could there be an "editor" in the REPL to modify a python file from the "console"?
-* [0:16:18](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=978) REPL - import error
-* [0:17:38](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=1058) Fiber Deserts http://fiber-deserts.net/  and https://datasette.io/
-* [0:22:10](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=1330) Google Cloud Run
-* [0:23:38](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=1418) Is there an Adafruit BLE file system protocol out there by now? Or how have you solved the issue of managing BLE device storage?
+* [0:20:20](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=1220) ESP32-S2 SPI display speed updates
+* [0:11:09](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=669) Would you consider yourself an IOT/Embedded Systems Engineer?
+* [0:12:33](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=753) Sublime text editor
+* [0:13:10](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=790) ​Is there a way to import lib folder modules from the REPL?
+* [0:13:53](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=833) How come red breaking is common?
+* [0:14:15](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=855)  implement a TCP stack in rust
+* [0:15:08](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=908) Could there be an "editor" in the REPL to modify a python file from the "console"?
+* [0:16:18](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=978) REPL - import error
+* [0:17:38](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=1058) Fiber Deserts http://fiber-deserts.net/  and https://datasette.io/
+* [0:22:10](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=1330) Google Cloud Run
+* [0:23:38](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=1418) Is there an Adafruit BLE file system protocol out there by now? Or how have you solved the issue of managing BLE device storage?
 https://github.com/adafruit/Adafruit_CircuitPython_BLE_File_Transfer
-* [0:25:20](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=1520) video demos (https://github.com/antonio-openroad )
-* [30:23](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=1823)  supervisor/shared/bluetooth.c
+* [0:25:20](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=1520) video demos (https://github.com/antonio-openroad )
+* [30:23](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=1823)  supervisor/shared/bluetooth.c
 * https://wiki.pine64.org/index.php/PineTime
-* [0:35:22](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=2122) CircuitPython on a LIDAR lite v4 / nRF52 + an FPGA for the sensor timing stuff
-* [0:35:35](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=2135) nRF5340
-* [0:38:05](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=2285) BlueNRG-1 by ST being replaced by the STM32WB
-* [0:40:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=2400) return to CP bluetooth.c
-* [0:45:20](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=2720) - no - we have not started an android glider :-)
-* [0:46:08](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=2768) mirror android screen
-* [0:50:45](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=3045) NRF dongle
-* [0:54:19](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=3259) BLE on esp32
-* [0:55:44](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=3344) new version of bluetooth.c
-* [1:02:36](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=3756) hint: in gdb use “break reset_into_safe_mode”
-* [1:07:09](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=4029) Bluetooth specs  core specifications 5.2 ( to look up BLE advertising )
-* [1:14:25](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=4465) As prototypers, do we have to be careful what we push over BLE ?
-* [1:16:05](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=4565) ​After you setup a connection and you're in an encrypted channel, are you allowed to send a BLE ADT packet to say that "Actually, I can also do these things.
-* [1:22:05](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=4925) how to clear bonding
-* [1:22:40](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=4960) Ubertooth One -
-* [1:22:59](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=4979) Phone NRF app or dongle
-* [1:24:30](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=5070) Can you use advertisements to simulate something like an espnow mesh?
-* [1:27:56](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=5276) -  ble the rest of the time
-* [1:40:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=6000) Breaking Adapter.c
-* [1:45:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=6300)  IDE/editors for programming
-* [1:48:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=6480) Verbose BLE
-* [1:52:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=6720) Have you ever tried a weird keyboard layout like dvorak?
-* [1:54:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=6840) Is BLE turned off?
-* [2:00:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=7200) Wrap up
+* [0:35:22](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=2122) CircuitPython on a LIDAR lite v4 / nRF52 + an FPGA for the sensor timing stuff
+* [0:35:35](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=2135) nRF5340
+* [0:38:05](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=2285) BlueNRG-1 by ST being replaced by the STM32WB
+* [0:40:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=2400) return to CP bluetooth.c
+* [0:45:20](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=2720) - no - we have not started an android glider :-)
+* [0:46:08](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=2768) mirror android screen
+* [0:50:45](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=3045) NRF dongle
+* [0:54:19](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=3259) BLE on esp32
+* [0:55:44](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=3344) new version of bluetooth.c
+* [1:02:36](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=3756) hint: in gdb use “break reset_into_safe_mode”
+* [1:07:09](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=4029) Bluetooth specs  core specifications 5.2 ( to look up BLE advertising )
+* [1:14:25](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=4465) As prototypers, do we have to be careful what we push over BLE ?
+* [1:16:05](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=4565) ​After you setup a connection and you're in an encrypted channel, are you allowed to send a BLE ADT packet to say that "Actually, I can also do these things.
+* [1:22:05](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=4925) how to clear bonding
+* [1:22:40](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=4960) Ubertooth One -
+* [1:22:59](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=4979) Phone NRF app or dongle
+* [1:24:30](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=5070) Can you use advertisements to simulate something like an espnow mesh?
+* [1:27:56](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=5276) -  ble the rest of the time
+* [1:40:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=6000) Breaking Adapter.c
+* [1:45:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=6300)  IDE/editors for programming
+* [1:48:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=6480) Verbose BLE
+* [1:52:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=6720) Have you ever tried a weird keyboard layout like dvorak?
+* [1:54:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=6840) Is BLE turned off?
+* [2:00:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=7200) Wrap up

--- a/2021/2021-05-21.md
+++ b/2021/2021-05-21.md
@@ -16,42 +16,42 @@ Plan
 
 
 Timestamps
-* 0:20:20 ESP32-S2 SPI display speed updates
-* 0:11:09 Would you consider yourself an IOT/Embedded Systems Engineer?
-* 0:12:33 Sublime text editor
-* 0:13:10 ​Is there a way to import lib folder modules from the REPL?
-* 0:13:53 How come red breaking is common?
-* 0:14:15  implement a TCP stack in rust
-* 0:15:08 Could there be an "editor" in the REPL to modify a python file from the "console"?
-* 0:16:18 REPL - import error
-* 0:17:38 Fiber Deserts http://fiber-deserts.net/  and https://datasette.io/
-* 0:22:10 Google Cloud Run
-* 0:23:38 Is there an Adafruit BLE file system protocol out there by now? Or how have you solved the issue of managing BLE device storage?
+* [0:20:20](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=1220) ESP32-S2 SPI display speed updates
+* [0:11:09](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=669) Would you consider yourself an IOT/Embedded Systems Engineer?
+* [0:12:33](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=753) Sublime text editor
+* [0:13:10](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=790) ​Is there a way to import lib folder modules from the REPL?
+* [0:13:53](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=833) How come red breaking is common?
+* [0:14:15](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=855)  implement a TCP stack in rust
+* [0:15:08](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=908) Could there be an "editor" in the REPL to modify a python file from the "console"?
+* [0:16:18](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=978) REPL - import error
+* [0:17:38](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=1058) Fiber Deserts http://fiber-deserts.net/  and https://datasette.io/
+* [0:22:10](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=1330) Google Cloud Run
+* [0:23:38](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=1418) Is there an Adafruit BLE file system protocol out there by now? Or how have you solved the issue of managing BLE device storage?
 https://github.com/adafruit/Adafruit_CircuitPython_BLE_File_Transfer
-* 0:25:20 video demos (https://github.com/antonio-openroad )
-* 30:23  supervisor/shared/bluetooth.c
+* [0:25:20](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=1520) video demos (https://github.com/antonio-openroad )
+* [30:23](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=1823)  supervisor/shared/bluetooth.c
 * https://wiki.pine64.org/index.php/PineTime
-* 0:35:22 CircuitPython on a LIDAR lite v4 / nRF52 + an FPGA for the sensor timing stuff
-* 0:35:35 nRF5340
-* 0:38:05 BlueNRG-1 by ST being replaced by the STM32WB
-* 0:40:00 return to CP bluetooth.c
-* 0:45:20 - no - we have not started an android glider :-)
-* 0:46:08 mirror android screen
-* 0:50:45 NRF dongle
-* 0:54:19 BLE on esp32
-* 0:55:44 new version of bluetooth.c
-* 1:02:36 hint: in gdb use “break reset_into_safe_mode”
-* 1:07:09 Bluetooth specs  core specifications 5.2 ( to look up BLE advertising )
-* 1:14:25 As prototypers, do we have to be careful what we push over BLE ?
-* 1:16:05 ​After you setup a connection and you're in an encrypted channel, are you allowed to send a BLE ADT packet to say that "Actually, I can also do these things.
-* 1:22:05 how to clear bonding
-* 1:22:40 Ubertooth One -
-* 1:22:59 Phone NRF app or dongle
-* 1:24:30 Can you use advertisements to simulate something like an espnow mesh?
-* 1:27:56 -  ble the rest of the time
-* 1:40:00 Breaking Adapter.c
-* 1:45:00  IDE/editors for programming
-* 1:48:00 Verbose BLE
-* 1:52:00 Have you ever tried a weird keyboard layout like dvorak?
-* 1:54:00 Is BLE turned off?
-* 2:00:00 Wrap up
+* [0:35:22](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=2122) CircuitPython on a LIDAR lite v4 / nRF52 + an FPGA for the sensor timing stuff
+* [0:35:35](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=2135) nRF5340
+* [0:38:05](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=2285) BlueNRG-1 by ST being replaced by the STM32WB
+* [0:40:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=2400) return to CP bluetooth.c
+* [0:45:20](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=2720) - no - we have not started an android glider :-)
+* [0:46:08](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=2768) mirror android screen
+* [0:50:45](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=3045) NRF dongle
+* [0:54:19](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=3259) BLE on esp32
+* [0:55:44](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=3344) new version of bluetooth.c
+* [1:02:36](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=3756) hint: in gdb use “break reset_into_safe_mode”
+* [1:07:09](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=4029) Bluetooth specs  core specifications 5.2 ( to look up BLE advertising )
+* [1:14:25](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=4465) As prototypers, do we have to be careful what we push over BLE ?
+* [1:16:05](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=4565) ​After you setup a connection and you're in an encrypted channel, are you allowed to send a BLE ADT packet to say that "Actually, I can also do these things.
+* [1:22:05](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=4925) how to clear bonding
+* [1:22:40](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=4960) Ubertooth One -
+* [1:22:59](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=4979) Phone NRF app or dongle
+* [1:24:30](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=5070) Can you use advertisements to simulate something like an espnow mesh?
+* [1:27:56](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=5276) -  ble the rest of the time
+* [1:40:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=6000) Breaking Adapter.c
+* [1:45:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=6300)  IDE/editors for programming
+* [1:48:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=6480) Verbose BLE
+* [1:52:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=6720) Have you ever tried a weird keyboard layout like dvorak?
+* [1:54:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=6840) Is BLE turned off?
+* [2:00:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21?t=7200) Wrap up

--- a/2021/2021-05-21.md
+++ b/2021/2021-05-21.md
@@ -16,42 +16,42 @@ Plan
 
 
 Timestamps
-* [0:20:20](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=1220) ESP32-S2 SPI display speed updates
-* [0:11:09](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=669) Would you consider yourself an IOT/Embedded Systems Engineer?
-* [0:12:33](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=753) Sublime text editor
-* [0:13:10](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=790) ​Is there a way to import lib folder modules from the REPL?
-* [0:13:53](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=833) How come red breaking is common?
-* [0:14:15](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=855)  implement a TCP stack in rust
-* [0:15:08](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=908) Could there be an "editor" in the REPL to modify a python file from the "console"?
-* [0:16:18](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=978) REPL - import error
-* [0:17:38](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=1058) Fiber Deserts http://fiber-deserts.net/  and https://datasette.io/
-* [0:22:10](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=1330) Google Cloud Run
-* [0:23:38](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=1418) Is there an Adafruit BLE file system protocol out there by now? Or how have you solved the issue of managing BLE device storage?
+* [0:20:20](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=1220) ESP32-S2 SPI display speed updates
+* [0:11:09](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=669) Would you consider yourself an IOT/Embedded Systems Engineer?
+* [0:12:33](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=753) Sublime text editor
+* [0:13:10](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=790) ​Is there a way to import lib folder modules from the REPL?
+* [0:13:53](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=833) How come red breaking is common?
+* [0:14:15](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=855)  implement a TCP stack in rust
+* [0:15:08](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=908) Could there be an "editor" in the REPL to modify a python file from the "console"?
+* [0:16:18](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=978) REPL - import error
+* [0:17:38](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=1058) Fiber Deserts http://fiber-deserts.net/  and https://datasette.io/
+* [0:22:10](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=1330) Google Cloud Run
+* [0:23:38](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=1418) Is there an Adafruit BLE file system protocol out there by now? Or how have you solved the issue of managing BLE device storage?
 https://github.com/adafruit/Adafruit_CircuitPython_BLE_File_Transfer
-* [0:25:20](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=1520) video demos (https://github.com/antonio-openroad )
-* [30:23](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=1823)  supervisor/shared/bluetooth.c
+* [0:25:20](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=1520) video demos (https://github.com/antonio-openroad )
+* [30:23](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=1823)  supervisor/shared/bluetooth.c
 * https://wiki.pine64.org/index.php/PineTime
-* [0:35:22](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=2122) CircuitPython on a LIDAR lite v4 / nRF52 + an FPGA for the sensor timing stuff
-* [0:35:35](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=2135) nRF5340
-* [0:38:05](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=2285) BlueNRG-1 by ST being replaced by the STM32WB
-* [0:40:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=2400) return to CP bluetooth.c
-* [0:45:20](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=2720) - no - we have not started an android glider :-)
-* [0:46:08](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=2768) mirror android screen
-* [0:50:45](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=3045) NRF dongle
-* [0:54:19](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=3259) BLE on esp32
-* [0:55:44](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=3344) new version of bluetooth.c
-* [1:02:36](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=3756) hint: in gdb use “break reset_into_safe_mode”
-* [1:07:09](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=4029) Bluetooth specs  core specifications 5.2 ( to look up BLE advertising )
-* [1:14:25](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=4465) As prototypers, do we have to be careful what we push over BLE ?
-* [1:16:05](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=4565) ​After you setup a connection and you're in an encrypted channel, are you allowed to send a BLE ADT packet to say that "Actually, I can also do these things.
-* [1:22:05](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=4925) how to clear bonding
-* [1:22:40](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=4960) Ubertooth One -
-* [1:22:59](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=4979) Phone NRF app or dongle
-* [1:24:30](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=5070) Can you use advertisements to simulate something like an espnow mesh?
-* [1:27:56](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=5276) -  ble the rest of the time
-* [1:40:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=6000) Breaking Adapter.c
-* [1:45:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=6300)  IDE/editors for programming
-* [1:48:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=6480) Verbose BLE
-* [1:52:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=6720) Have you ever tried a weird keyboard layout like dvorak?
-* [1:54:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=6840) Is BLE turned off?
-* [2:00:00](https://www.youtube.com/watch?v=VIDEO_2021_05_21&t=7200) Wrap up
+* [0:35:22](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=2122) CircuitPython on a LIDAR lite v4 / nRF52 + an FPGA for the sensor timing stuff
+* [0:35:35](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=2135) nRF5340
+* [0:38:05](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=2285) BlueNRG-1 by ST being replaced by the STM32WB
+* [0:40:00](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=2400) return to CP bluetooth.c
+* [0:45:20](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=2720) - no - we have not started an android glider :-)
+* [0:46:08](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=2768) mirror android screen
+* [0:50:45](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=3045) NRF dongle
+* [0:54:19](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=3259) BLE on esp32
+* [0:55:44](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=3344) new version of bluetooth.c
+* [1:02:36](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=3756) hint: in gdb use “break reset_into_safe_mode”
+* [1:07:09](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=4029) Bluetooth specs  core specifications 5.2 ( to look up BLE advertising )
+* [1:14:25](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=4465) As prototypers, do we have to be careful what we push over BLE ?
+* [1:16:05](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=4565) ​After you setup a connection and you're in an encrypted channel, are you allowed to send a BLE ADT packet to say that "Actually, I can also do these things.
+* [1:22:05](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=4925) how to clear bonding
+* [1:22:40](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=4960) Ubertooth One -
+* [1:22:59](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=4979) Phone NRF app or dongle
+* [1:24:30](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=5070) Can you use advertisements to simulate something like an espnow mesh?
+* [1:27:56](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=5276) -  ble the rest of the time
+* [1:40:00](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=6000) Breaking Adapter.c
+* [1:45:00](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=6300)  IDE/editors for programming
+* [1:48:00](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=6480) Verbose BLE
+* [1:52:00](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=6720) Have you ever tried a weird keyboard layout like dvorak?
+* [1:54:00](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=6840) Is BLE turned off?
+* [2:00:00](https://www.youtube.com/watch?v=QCnK75ZFbIs&t=7200) Wrap up

--- a/2021/2021-05-27.md
+++ b/2021/2021-05-27.md
@@ -24,7 +24,7 @@ Timestamps
 * [14:22](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=862) wave file
 * [15:17](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=917) atecc chip
 * [17:25](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=1045) CP target
-* ~19:00 “Feature rich” question of board & chips
+* [19:00](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=1140) “Feature rich” question of board & chips
    * Support matrix: https://circuitpython.readthedocs.io/en/latest/shared-bindings/support_matrix.html
    * How to choose a microcontroller: https://learn.adafruit.com/how-to-choose-a-microcontroller/overrview
 * [23:02](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=1382) does sleep go into low power
@@ -44,6 +44,6 @@ Timestamps
    * Should we determine whether any file transfer has happened over BLE to determine if USB should connect read/write?
 * [1:44:00](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=6240) Q (summarized) “Could a proxy running on the device handle read/writes for BLE, USB and others?”
    * Scott mentions GhostFS that we could do, that Microsoft did for UF2
-* ~1:54:00 Discussion about how to handle mounting the filesystem Read/Write vs. Read-Only when connecting a device over USB as Mass Storage
+* [1:54:00](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=6840) Discussion about how to handle mounting the filesystem Read/Write vs. Read-Only when connecting a device over USB as Mass Storage
 * [1:59:40](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=7180) (T-2:00) “I think I can knock that out now” - talking about altering the way the filesystem behaves with USB connection
 * [2:06:03](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=7563)

--- a/2021/2021-05-27.md
+++ b/2021/2021-05-27.md
@@ -18,32 +18,32 @@ Plan
 
 
 Timestamps
-* 4:48
-* 11:05 bluetooth mesh
-* 12:40 robotics start
-* 14:22 wave file
-* 15:17 atecc chip
-* 17:25 CP target
+* [4:48](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=288)
+* [11:05](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=665) bluetooth mesh
+* [12:40](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=760) robotics start
+* [14:22](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=862) wave file
+* [15:17](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=917) atecc chip
+* [17:25](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=1045) CP target
 * ~19:00 “Feature rich” question of board & chips
    * Support matrix: https://circuitpython.readthedocs.io/en/latest/shared-bindings/support_matrix.html
    * How to choose a microcontroller: https://learn.adafruit.com/how-to-choose-a-microcontroller/overrview
-* 23:02 does sleep go into low power
-* 24:58 will there be interrupts in circuitpython?
-* 26:45 BLE workflow
+* [23:02](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=1382) does sleep go into low power
+* [24:58](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=1498) will there be interrupts in circuitpython?
+* [26:45](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=1605) BLE workflow
    * Glider app for BLE workflow from mobile device
    * Will be on iOS app store later (when ready)
    * Open protocol for file transfer over BLE
-* 40:00 Disclose phone PIN on-stream
-* 35:00 Start covering BLE workflow
+* [40:00](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=2400) Disclose phone PIN on-stream
+* [35:00](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=2100) Start covering BLE workflow
    * Devices, pairing and bonding
-* 1:06:15 Kitty Interlude
-* 1:31:36 Q: “What is the hardest board to get up and running?”
-* 1:38:30 Q: “What do you think is the hardest sensor/module to interface with for beginners or advanced creators?”
-* 1:40:10 Going back to this file sharing stuff - Between BLE and USB (?)
+* [1:06:15](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=3975) Kitty Interlude
+* [1:31:36](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=5496) Q: “What is the hardest board to get up and running?”
+* [1:38:30](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=5910) Q: “What do you think is the hardest sensor/module to interface with for beginners or advanced creators?”
+* [1:40:10](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=6010) Going back to this file sharing stuff - Between BLE and USB (?)
    * What should happen if the device is already bonded over BLE, but then connect USB?
    * Should we determine whether any file transfer has happened over BLE to determine if USB should connect read/write?
-* 1:44:00 Q (summarized) “Could a proxy running on the device handle read/writes for BLE, USB and others?”
+* [1:44:00](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=6240) Q (summarized) “Could a proxy running on the device handle read/writes for BLE, USB and others?”
    * Scott mentions GhostFS that we could do, that Microsoft did for UF2
 * ~1:54:00 Discussion about how to handle mounting the filesystem Read/Write vs. Read-Only when connecting a device over USB as Mass Storage
-* 1:59:40 (T-2:00) “I think I can knock that out now” - talking about altering the way the filesystem behaves with USB connection
-* 2:06:03
+* [1:59:40](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=7180) (T-2:00) “I think I can knock that out now” - talking about altering the way the filesystem behaves with USB connection
+* [2:06:03](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=7563)

--- a/2021/2021-05-27.md
+++ b/2021/2021-05-27.md
@@ -18,32 +18,32 @@ Plan
 
 
 Timestamps
-* [4:48](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=288)
-* [11:05](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=665) bluetooth mesh
-* [12:40](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=760) robotics start
-* [14:22](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=862) wave file
-* [15:17](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=917) atecc chip
-* [17:25](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=1045) CP target
+* [4:48](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=288)
+* [11:05](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=665) bluetooth mesh
+* [12:40](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=760) robotics start
+* [14:22](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=862) wave file
+* [15:17](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=917) atecc chip
+* [17:25](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=1045) CP target
 * ~19:00 “Feature rich” question of board & chips
    * Support matrix: https://circuitpython.readthedocs.io/en/latest/shared-bindings/support_matrix.html
    * How to choose a microcontroller: https://learn.adafruit.com/how-to-choose-a-microcontroller/overrview
-* [23:02](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=1382) does sleep go into low power
-* [24:58](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=1498) will there be interrupts in circuitpython?
-* [26:45](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=1605) BLE workflow
+* [23:02](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=1382) does sleep go into low power
+* [24:58](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=1498) will there be interrupts in circuitpython?
+* [26:45](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=1605) BLE workflow
    * Glider app for BLE workflow from mobile device
    * Will be on iOS app store later (when ready)
    * Open protocol for file transfer over BLE
-* [40:00](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=2400) Disclose phone PIN on-stream
-* [35:00](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=2100) Start covering BLE workflow
+* [40:00](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=2400) Disclose phone PIN on-stream
+* [35:00](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=2100) Start covering BLE workflow
    * Devices, pairing and bonding
-* [1:06:15](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=3975) Kitty Interlude
-* [1:31:36](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=5496) Q: “What is the hardest board to get up and running?”
-* [1:38:30](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=5910) Q: “What do you think is the hardest sensor/module to interface with for beginners or advanced creators?”
-* [1:40:10](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=6010) Going back to this file sharing stuff - Between BLE and USB (?)
+* [1:06:15](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=3975) Kitty Interlude
+* [1:31:36](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=5496) Q: “What is the hardest board to get up and running?”
+* [1:38:30](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=5910) Q: “What do you think is the hardest sensor/module to interface with for beginners or advanced creators?”
+* [1:40:10](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=6010) Going back to this file sharing stuff - Between BLE and USB (?)
    * What should happen if the device is already bonded over BLE, but then connect USB?
    * Should we determine whether any file transfer has happened over BLE to determine if USB should connect read/write?
-* [1:44:00](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=6240) Q (summarized) “Could a proxy running on the device handle read/writes for BLE, USB and others?”
+* [1:44:00](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=6240) Q (summarized) “Could a proxy running on the device handle read/writes for BLE, USB and others?”
    * Scott mentions GhostFS that we could do, that Microsoft did for UF2
 * ~1:54:00 Discussion about how to handle mounting the filesystem Read/Write vs. Read-Only when connecting a device over USB as Mass Storage
-* [1:59:40](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=7180) (T-2:00) “I think I can knock that out now” - talking about altering the way the filesystem behaves with USB connection
-* [2:06:03](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=7563)
+* [1:59:40](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=7180) (T-2:00) “I think I can knock that out now” - talking about altering the way the filesystem behaves with USB connection
+* [2:06:03](https://www.youtube.com/watch?v=xBLlKkfjUaY&t=7563)

--- a/2021/2021-05-27.md
+++ b/2021/2021-05-27.md
@@ -18,32 +18,32 @@ Plan
 
 
 Timestamps
-* [4:48](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=288)
-* [11:05](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=665) bluetooth mesh
-* [12:40](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=760) robotics start
-* [14:22](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=862) wave file
-* [15:17](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=917) atecc chip
-* [17:25](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=1045) CP target
+* [4:48](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=288)
+* [11:05](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=665) bluetooth mesh
+* [12:40](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=760) robotics start
+* [14:22](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=862) wave file
+* [15:17](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=917) atecc chip
+* [17:25](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=1045) CP target
 * ~19:00 “Feature rich” question of board & chips
    * Support matrix: https://circuitpython.readthedocs.io/en/latest/shared-bindings/support_matrix.html
    * How to choose a microcontroller: https://learn.adafruit.com/how-to-choose-a-microcontroller/overrview
-* [23:02](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=1382) does sleep go into low power
-* [24:58](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=1498) will there be interrupts in circuitpython?
-* [26:45](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=1605) BLE workflow
+* [23:02](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=1382) does sleep go into low power
+* [24:58](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=1498) will there be interrupts in circuitpython?
+* [26:45](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=1605) BLE workflow
    * Glider app for BLE workflow from mobile device
    * Will be on iOS app store later (when ready)
    * Open protocol for file transfer over BLE
-* [40:00](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=2400) Disclose phone PIN on-stream
-* [35:00](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=2100) Start covering BLE workflow
+* [40:00](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=2400) Disclose phone PIN on-stream
+* [35:00](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=2100) Start covering BLE workflow
    * Devices, pairing and bonding
-* [1:06:15](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=3975) Kitty Interlude
-* [1:31:36](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=5496) Q: “What is the hardest board to get up and running?”
-* [1:38:30](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=5910) Q: “What do you think is the hardest sensor/module to interface with for beginners or advanced creators?”
-* [1:40:10](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=6010) Going back to this file sharing stuff - Between BLE and USB (?)
+* [1:06:15](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=3975) Kitty Interlude
+* [1:31:36](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=5496) Q: “What is the hardest board to get up and running?”
+* [1:38:30](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=5910) Q: “What do you think is the hardest sensor/module to interface with for beginners or advanced creators?”
+* [1:40:10](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=6010) Going back to this file sharing stuff - Between BLE and USB (?)
    * What should happen if the device is already bonded over BLE, but then connect USB?
    * Should we determine whether any file transfer has happened over BLE to determine if USB should connect read/write?
-* [1:44:00](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=6240) Q (summarized) “Could a proxy running on the device handle read/writes for BLE, USB and others?”
+* [1:44:00](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=6240) Q (summarized) “Could a proxy running on the device handle read/writes for BLE, USB and others?”
    * Scott mentions GhostFS that we could do, that Microsoft did for UF2
 * ~1:54:00 Discussion about how to handle mounting the filesystem Read/Write vs. Read-Only when connecting a device over USB as Mass Storage
-* [1:59:40](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=7180) (T-2:00) “I think I can knock that out now” - talking about altering the way the filesystem behaves with USB connection
-* [2:06:03](https://www.youtube.com/watch?v=VIDEO_2021_05_27?t=7563)
+* [1:59:40](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=7180) (T-2:00) “I think I can knock that out now” - talking about altering the way the filesystem behaves with USB connection
+* [2:06:03](https://www.youtube.com/watch?v=VIDEO_2021_05_27&t=7563)

--- a/2021/2021-06-04.md
+++ b/2021/2021-06-04.md
@@ -20,9 +20,9 @@ Plan
 
 
 Timestamps
-* [6:12](https://www.youtube.com/watch?v=VIDEO_2021_06_04?t=372) Housekeeping
-* [8:38](https://www.youtube.com/watch?v=VIDEO_2021_06_04?t=518) chatting with JP
-* [53:05](https://www.youtube.com/watch?v=VIDEO_2021_06_04?t=3185) answering questions
-* [1:20:00](https://www.youtube.com/watch?v=VIDEO_2021_06_04?t=4800) BLE transfer is now working on Glider
-* [1:53:27](https://www.youtube.com/watch?v=VIDEO_2021_06_04?t=6807) fiber deserts
-* [2:24:08](https://www.youtube.com/watch?v=VIDEO_2021_06_04?t=8648) wrap up
+* [6:12](https://www.youtube.com/watch?v=VIDEO_2021_06_04&t=372) Housekeeping
+* [8:38](https://www.youtube.com/watch?v=VIDEO_2021_06_04&t=518) chatting with JP
+* [53:05](https://www.youtube.com/watch?v=VIDEO_2021_06_04&t=3185) answering questions
+* [1:20:00](https://www.youtube.com/watch?v=VIDEO_2021_06_04&t=4800) BLE transfer is now working on Glider
+* [1:53:27](https://www.youtube.com/watch?v=VIDEO_2021_06_04&t=6807) fiber deserts
+* [2:24:08](https://www.youtube.com/watch?v=VIDEO_2021_06_04&t=8648) wrap up

--- a/2021/2021-06-04.md
+++ b/2021/2021-06-04.md
@@ -20,9 +20,9 @@ Plan
 
 
 Timestamps
-* 6:12 Housekeeping
-* 8:38 chatting with JP
-* 53:05 answering questions
-* 1:20:00 BLE transfer is now working on Glider
-* 1:53:27 fiber deserts
-* 2:24:08 wrap up
+* [6:12](https://www.youtube.com/watch?v=VIDEO_2021_06_04?t=372) Housekeeping
+* [8:38](https://www.youtube.com/watch?v=VIDEO_2021_06_04?t=518) chatting with JP
+* [53:05](https://www.youtube.com/watch?v=VIDEO_2021_06_04?t=3185) answering questions
+* [1:20:00](https://www.youtube.com/watch?v=VIDEO_2021_06_04?t=4800) BLE transfer is now working on Glider
+* [1:53:27](https://www.youtube.com/watch?v=VIDEO_2021_06_04?t=6807) fiber deserts
+* [2:24:08](https://www.youtube.com/watch?v=VIDEO_2021_06_04?t=8648) wrap up

--- a/2021/2021-06-04.md
+++ b/2021/2021-06-04.md
@@ -20,9 +20,9 @@ Plan
 
 
 Timestamps
-* [6:12](https://www.youtube.com/watch?v=VIDEO_2021_06_04&t=372) Housekeeping
-* [8:38](https://www.youtube.com/watch?v=VIDEO_2021_06_04&t=518) chatting with JP
-* [53:05](https://www.youtube.com/watch?v=VIDEO_2021_06_04&t=3185) answering questions
-* [1:20:00](https://www.youtube.com/watch?v=VIDEO_2021_06_04&t=4800) BLE transfer is now working on Glider
-* [1:53:27](https://www.youtube.com/watch?v=VIDEO_2021_06_04&t=6807) fiber deserts
-* [2:24:08](https://www.youtube.com/watch?v=VIDEO_2021_06_04&t=8648) wrap up
+* [6:12](https://www.youtube.com/watch?v=Wc5xCt9TjPI&t=372) Housekeeping
+* [8:38](https://www.youtube.com/watch?v=Wc5xCt9TjPI&t=518) chatting with JP
+* [53:05](https://www.youtube.com/watch?v=Wc5xCt9TjPI&t=3185) answering questions
+* [1:20:00](https://www.youtube.com/watch?v=Wc5xCt9TjPI&t=4800) BLE transfer is now working on Glider
+* [1:53:27](https://www.youtube.com/watch?v=Wc5xCt9TjPI&t=6807) fiber deserts
+* [2:24:08](https://www.youtube.com/watch?v=Wc5xCt9TjPI&t=8648) wrap up

--- a/2021/2021-06-25.md
+++ b/2021/2021-06-25.md
@@ -41,4 +41,3 @@ Timestamps
 * [2:00:20](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=7220) display version of code running
 * [2:01:10](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=7270) Talk to the clock with android
 * [2:04:00](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=7440) timecode handoff
-*

--- a/2021/2021-06-25.md
+++ b/2021/2021-06-25.md
@@ -13,32 +13,32 @@ Housekeeping
 
 
 Plan
-* 
+*
 
 Timestamps
-* 4:10 housekeeping
-* 7:50 time code sync
-* 8:56 The Display_Shapes library does not have an arc function. Do you know a good way to draw arcs?
-* 9:30 Adafruit mailbag ( Kitty Paw https://www.adafruit.com/product/4972 )
-* 10:50 TinyUSB 
-* 12:40 E-Ink clock https://www.adafruit.com/product/5023
-* 19:04 MacroPad and keys
-* 26:37 MacroPad assembly
-* 43:50 Scott’s keypad collection box
-* 57:00 powered up the MacroPad
-* 58:47 build CircuitPython for the MacroPad
-* 1:03:00 git submodules in submodules
-* 1:11:05 reset Macropad to boot loader
-* 1:17:00 Demo the Macropad code
-* 1:18:53 Transition to BLE workflow
-* 1:25:00 Off topic... But I noticed the ability to customise USB endpoints in CP7. Any chance of allowing an SD card to be mounted as a (2nd) USB MSC drive?
-* 1:29:00 phone dropping the connection and just not reestablishing it? Or is the CP device not advertising?
-* 1:31:00 glider app scanning
-* 1:32:25 oh, no - it’s in “safe mode”
-* 1:35:39 debug in safe mode hints
-* 1:44:16 disable the usb device
-* 1:58:57 BLE connected to glider app 
-* 2:00:20 display version of code running
-* 2:01:10 Talk to the clock with android
-* 2:04:00 timecode handoff
+* [4:10](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=250) housekeeping
+* [7:50](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=470) time code sync
+* [8:56](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=536) The Display_Shapes library does not have an arc function. Do you know a good way to draw arcs?
+* [9:30](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=570) Adafruit mailbag ( Kitty Paw https://www.adafruit.com/product/4972 )
+* [10:50](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=650) TinyUSB
+* [12:40](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=760) E-Ink clock https://www.adafruit.com/product/5023
+* [19:04](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=1144) MacroPad and keys
+* [26:37](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=1597) MacroPad assembly
+* [43:50](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=2630) Scott’s keypad collection box
+* [57:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=3420) powered up the MacroPad
+* [58:47](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=3527) build CircuitPython for the MacroPad
+* [1:03:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=3780) git submodules in submodules
+* [1:11:05](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=4265) reset Macropad to boot loader
+* [1:17:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=4620) Demo the Macropad code
+* [1:18:53](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=4733) Transition to BLE workflow
+* [1:25:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=5100) Off topic... But I noticed the ability to customise USB endpoints in CP7. Any chance of allowing an SD card to be mounted as a (2nd) USB MSC drive?
+* [1:29:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=5340) phone dropping the connection and just not reestablishing it? Or is the CP device not advertising?
+* [1:31:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=5460) glider app scanning
+* [1:32:25](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=5545) oh, no - it’s in “safe mode”
+* [1:35:39](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=5739) debug in safe mode hints
+* [1:44:16](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=6256) disable the usb device
+* [1:58:57](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=7137) BLE connected to glider app
+* [2:00:20](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=7220) display version of code running
+* [2:01:10](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=7270) Talk to the clock with android
+* [2:04:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=7440) timecode handoff
 *

--- a/2021/2021-06-25.md
+++ b/2021/2021-06-25.md
@@ -16,29 +16,29 @@ Plan
 *
 
 Timestamps
-* [4:10](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=250) housekeeping
-* [7:50](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=470) time code sync
-* [8:56](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=536) The Display_Shapes library does not have an arc function. Do you know a good way to draw arcs?
-* [9:30](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=570) Adafruit mailbag ( Kitty Paw https://www.adafruit.com/product/4972 )
-* [10:50](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=650) TinyUSB
-* [12:40](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=760) E-Ink clock https://www.adafruit.com/product/5023
-* [19:04](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=1144) MacroPad and keys
-* [26:37](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=1597) MacroPad assembly
-* [43:50](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=2630) Scott’s keypad collection box
-* [57:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=3420) powered up the MacroPad
-* [58:47](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=3527) build CircuitPython for the MacroPad
-* [1:03:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=3780) git submodules in submodules
-* [1:11:05](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=4265) reset Macropad to boot loader
-* [1:17:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=4620) Demo the Macropad code
-* [1:18:53](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=4733) Transition to BLE workflow
-* [1:25:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=5100) Off topic... But I noticed the ability to customise USB endpoints in CP7. Any chance of allowing an SD card to be mounted as a (2nd) USB MSC drive?
-* [1:29:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=5340) phone dropping the connection and just not reestablishing it? Or is the CP device not advertising?
-* [1:31:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=5460) glider app scanning
-* [1:32:25](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=5545) oh, no - it’s in “safe mode”
-* [1:35:39](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=5739) debug in safe mode hints
-* [1:44:16](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=6256) disable the usb device
-* [1:58:57](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=7137) BLE connected to glider app
-* [2:00:20](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=7220) display version of code running
-* [2:01:10](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=7270) Talk to the clock with android
-* [2:04:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25?t=7440) timecode handoff
+* [4:10](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=250) housekeeping
+* [7:50](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=470) time code sync
+* [8:56](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=536) The Display_Shapes library does not have an arc function. Do you know a good way to draw arcs?
+* [9:30](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=570) Adafruit mailbag ( Kitty Paw https://www.adafruit.com/product/4972 )
+* [10:50](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=650) TinyUSB
+* [12:40](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=760) E-Ink clock https://www.adafruit.com/product/5023
+* [19:04](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=1144) MacroPad and keys
+* [26:37](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=1597) MacroPad assembly
+* [43:50](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=2630) Scott’s keypad collection box
+* [57:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=3420) powered up the MacroPad
+* [58:47](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=3527) build CircuitPython for the MacroPad
+* [1:03:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=3780) git submodules in submodules
+* [1:11:05](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=4265) reset Macropad to boot loader
+* [1:17:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=4620) Demo the Macropad code
+* [1:18:53](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=4733) Transition to BLE workflow
+* [1:25:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=5100) Off topic... But I noticed the ability to customise USB endpoints in CP7. Any chance of allowing an SD card to be mounted as a (2nd) USB MSC drive?
+* [1:29:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=5340) phone dropping the connection and just not reestablishing it? Or is the CP device not advertising?
+* [1:31:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=5460) glider app scanning
+* [1:32:25](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=5545) oh, no - it’s in “safe mode”
+* [1:35:39](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=5739) debug in safe mode hints
+* [1:44:16](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=6256) disable the usb device
+* [1:58:57](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=7137) BLE connected to glider app
+* [2:00:20](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=7220) display version of code running
+* [2:01:10](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=7270) Talk to the clock with android
+* [2:04:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=7440) timecode handoff
 *

--- a/2021/2021-06-25.md
+++ b/2021/2021-06-25.md
@@ -16,29 +16,29 @@ Plan
 *
 
 Timestamps
-* [4:10](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=250) housekeeping
-* [7:50](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=470) time code sync
-* [8:56](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=536) The Display_Shapes library does not have an arc function. Do you know a good way to draw arcs?
-* [9:30](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=570) Adafruit mailbag ( Kitty Paw https://www.adafruit.com/product/4972 )
-* [10:50](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=650) TinyUSB
-* [12:40](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=760) E-Ink clock https://www.adafruit.com/product/5023
-* [19:04](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=1144) MacroPad and keys
-* [26:37](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=1597) MacroPad assembly
-* [43:50](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=2630) Scott’s keypad collection box
-* [57:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=3420) powered up the MacroPad
-* [58:47](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=3527) build CircuitPython for the MacroPad
-* [1:03:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=3780) git submodules in submodules
-* [1:11:05](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=4265) reset Macropad to boot loader
-* [1:17:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=4620) Demo the Macropad code
-* [1:18:53](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=4733) Transition to BLE workflow
-* [1:25:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=5100) Off topic... But I noticed the ability to customise USB endpoints in CP7. Any chance of allowing an SD card to be mounted as a (2nd) USB MSC drive?
-* [1:29:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=5340) phone dropping the connection and just not reestablishing it? Or is the CP device not advertising?
-* [1:31:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=5460) glider app scanning
-* [1:32:25](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=5545) oh, no - it’s in “safe mode”
-* [1:35:39](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=5739) debug in safe mode hints
-* [1:44:16](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=6256) disable the usb device
-* [1:58:57](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=7137) BLE connected to glider app
-* [2:00:20](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=7220) display version of code running
-* [2:01:10](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=7270) Talk to the clock with android
-* [2:04:00](https://www.youtube.com/watch?v=VIDEO_2021_06_25&t=7440) timecode handoff
+* [4:10](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=250) housekeeping
+* [7:50](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=470) time code sync
+* [8:56](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=536) The Display_Shapes library does not have an arc function. Do you know a good way to draw arcs?
+* [9:30](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=570) Adafruit mailbag ( Kitty Paw https://www.adafruit.com/product/4972 )
+* [10:50](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=650) TinyUSB
+* [12:40](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=760) E-Ink clock https://www.adafruit.com/product/5023
+* [19:04](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=1144) MacroPad and keys
+* [26:37](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=1597) MacroPad assembly
+* [43:50](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=2630) Scott’s keypad collection box
+* [57:00](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=3420) powered up the MacroPad
+* [58:47](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=3527) build CircuitPython for the MacroPad
+* [1:03:00](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=3780) git submodules in submodules
+* [1:11:05](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=4265) reset Macropad to boot loader
+* [1:17:00](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=4620) Demo the Macropad code
+* [1:18:53](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=4733) Transition to BLE workflow
+* [1:25:00](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=5100) Off topic... But I noticed the ability to customise USB endpoints in CP7. Any chance of allowing an SD card to be mounted as a (2nd) USB MSC drive?
+* [1:29:00](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=5340) phone dropping the connection and just not reestablishing it? Or is the CP device not advertising?
+* [1:31:00](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=5460) glider app scanning
+* [1:32:25](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=5545) oh, no - it’s in “safe mode”
+* [1:35:39](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=5739) debug in safe mode hints
+* [1:44:16](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=6256) disable the usb device
+* [1:58:57](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=7137) BLE connected to glider app
+* [2:00:20](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=7220) display version of code running
+* [2:01:10](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=7270) Talk to the clock with android
+* [2:04:00](https://www.youtube.com/watch?v=nhnJoOyk6e4&t=7440) timecode handoff
 *

--- a/2021/2021-07-02.md
+++ b/2021/2021-07-02.md
@@ -35,7 +35,7 @@ Timestamps
 * [0:27:00](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1620) Adafruit_CircuitPython_BLE_File_Transfer repo
 * [0:27:45](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1665) circuitpython/web-editor repo
 * [0:28:00](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1680) adafruit/ble-file-transfer-js
-* ​0:29:00  works in Chrome then it should work in Deno ... As that's V8 under the hood and they are making their JavaScript isomorphic. (Works in browser, works in Deno.)
+* [​0:29:00](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1740) works in Chrome then it should work in Deno ... As that's V8 under the hood and they are making their JavaScript isomorphic. (Works in browser, works in Deno.)
 * [0:30:00](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1800) - CP save button - use timer instead
 * [0:30:45](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1845) codemirror.net/6 editor
 * [0:31:40](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1900)  https://deno.land/
@@ -91,4 +91,3 @@ Timestamps
 * [2:10:45](https://www.youtube.com/watch?v=lS8eJsIYYno&t=7845) microbit will take some more work
 * [2:11:45](https://www.youtube.com/watch?v=lS8eJsIYYno&t=7905) wrap up
 * [2:13:48](https://www.youtube.com/watch?v=lS8eJsIYYno&t=8028) -bye all
-*

--- a/2021/2021-07-02.md
+++ b/2021/2021-07-02.md
@@ -18,77 +18,77 @@ Plan
 
 
 Timestamps
-* [0:04:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=240) Hello everyone
-* [0:08:56](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=536) Intro to bluetooth
-* [0:09:57](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=597) WebBLE - spoiler (android phone/ experimental API)
-* [0:11:27](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=687) Makerdiary serial console web device CLI
-* [0:12:47](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=767) chrome::/inspect/#devices ( mirror phone screen web page )
-* [0:14:54](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=894) repl is working
-* [0:17:47](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1067) code.circuitpython.org
-* [0:19:01](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1141) prompt to start advertising yellow / fast blue / solid blue - broadcast publicly
-* [0:19:52](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1192) pair serpi / bond
-* [0:21:38](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1298) debugging output on the right
-* [0:22:27](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1347) edit code in web page - using emoji as variable names!
-* [0:24:41](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1481) “editing code from phone”
-* [0:25:29](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1529) What would be the difference with linux?
-* [0:26:16](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1576) Could something like this be replicated using ble cli tools in linux?
-* [0:27:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1620) Adafruit_CircuitPython_BLE_File_Transfer repo
-* [0:27:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1665) circuitpython/web-editor repo
-* [0:28:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1680) adafruit/ble-file-transfer-js
+* [0:04:00](https://www.youtube.com/watch?v=lS8eJsIYYno&t=240) Hello everyone
+* [0:08:56](https://www.youtube.com/watch?v=lS8eJsIYYno&t=536) Intro to bluetooth
+* [0:09:57](https://www.youtube.com/watch?v=lS8eJsIYYno&t=597) WebBLE - spoiler (android phone/ experimental API)
+* [0:11:27](https://www.youtube.com/watch?v=lS8eJsIYYno&t=687) Makerdiary serial console web device CLI
+* [0:12:47](https://www.youtube.com/watch?v=lS8eJsIYYno&t=767) chrome::/inspect/#devices ( mirror phone screen web page )
+* [0:14:54](https://www.youtube.com/watch?v=lS8eJsIYYno&t=894) repl is working
+* [0:17:47](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1067) code.circuitpython.org
+* [0:19:01](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1141) prompt to start advertising yellow / fast blue / solid blue - broadcast publicly
+* [0:19:52](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1192) pair serpi / bond
+* [0:21:38](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1298) debugging output on the right
+* [0:22:27](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1347) edit code in web page - using emoji as variable names!
+* [0:24:41](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1481) “editing code from phone”
+* [0:25:29](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1529) What would be the difference with linux?
+* [0:26:16](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1576) Could something like this be replicated using ble cli tools in linux?
+* [0:27:00](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1620) Adafruit_CircuitPython_BLE_File_Transfer repo
+* [0:27:45](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1665) circuitpython/web-editor repo
+* [0:28:00](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1680) adafruit/ble-file-transfer-js
 * ​0:29:00  works in Chrome then it should work in Deno ... As that's V8 under the hood and they are making their JavaScript isomorphic. (Works in browser, works in Deno.)
-* [0:30:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1800) - CP save button - use timer instead
-* [0:30:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1845) codemirror.net/6 editor
-* [0:31:40](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1900)  https://deno.land/
-* [0:32:59](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1979) Does code mirror handle python/ :blinka:  stubs?
-* [0:34:10](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2050) use absolute latest CP from amazon and NRF 8240(Sp)
-* [0:35:21](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2121) nice to add autocomplete
-* [0:35:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2145) now, to test it on the Micro:bit v2
-* [0:36:40](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2200) device disconnects after writes
-* [0:37:10](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2230) some code outthere to user antlr with Monaco, since antlr can generate parsers in many languages including JS and TS
-* [0:37:30](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2250) there is a python parser in codemirror
-* [0:37:52](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2272) microbit V2
-* [0:39:15](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2355) that’s how you know you are in a deep dive - when alpha 3 is too old
-* [0:40:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2445) new git microbitv2 repo
-* [0:42:10](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2530) CircuitPython Online Editor
-* [0:42:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2565) JS question - how to show a file directory
-* [0:44:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2640) microbit v2 cpu nRF52833
-* [0:47:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2820) CIRCUITPY_CREATOR / CREATION_ID
-* [0:47:18](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2838) searching for microbit v2 schematic from tech.microbit.org/hardware/schematic
-* [0:50:20](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3020) schematic displays MicroBit_V2.0.0_S_schematic.PDF
-* [0:51:40](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3100) Where can I find documentation on Adafruit_PIOasm? - readthedocs.io pioasm latest
-* [0:55:11](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3311) edit the pinouts on Expansion connector
-* [0:57:14](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3434) how microbit references the pins and map them to CP internal names
-* [0:57:40](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3460) and buttons - to match board creators documentation
-* [0:58:59](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3539) microbit documentation
-* [1:00:25](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3625) Edge connector pins
-* [1:02:15](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3735) If the MicroBit v2 doesn't expose USB, how does one install CircuitPython onto it? Does it have a Bluetooth-enabled bootloader?
-* [1:04:43](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3883) make -j 32 BOARD=microbit_v2 ( fix errors )
-* [1:09:10](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=4150) this is the first time we built CP Non-usb BLE only device
-* [1:11:20](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=4280)  how to send data over laser.. Is PWM the way to go?
-* [1:13:30](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=4410) resolve linker undefined symbols
-* [1:15:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=4545)  this is the birth of USB-less CP
-* [1:22:35](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=4955) always a good idea to do a make clean and try again when experiencing CP build problems
-* [1:26:30](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=5190) Serial_write_substring undefined
-* [1:28:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=5280) ​you can't raise an exception from boot py / goes to boot.out
-* [1:36:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=5760) - it’s too big :-(
-* [1:39:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=5940) review the configuration flags
-* [1:41:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6105) play the make it fit game - turn off POW3
-* [1:43:20](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6200) ​Is your USB / BT a subset of something else? So you can access it through another doorway?
-* [1:43:48](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6228) - got 500 bytes back
-* [1:45:48](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6348) look what does the “simmel”  do -Os
-* [1:46:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6405) nrf52833 flash size (- 512KB Flash )
-* [1:47:50](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6470) Refer to the linker file template common.lk
-* [1:50:30](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6630) What is that magic optimization and why would it not always be enabled?
-* [1:53:40](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6820) What is soft device ( binary blob from nordic )
-* [1:55:40](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6940) using S140 SoftDevices   https:nordicsemi.com/products/nrf52833
-* [1:58:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7080) Consider peripheral only / what is S113 size
-* [2:00:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7200) Soft device memory resource map
-* [2:02:35](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7355) softdevice provided by Dynastream ( thisisant.com )
-* [2:04:37](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7477) S140 release notes
-* [2:07:57](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7677) end by trying out the binary
-* [2:08:13](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7693) not sure if downloading the hex file did anything
-* [2:09:14](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7754) next step - connect a debugger
-* [2:10:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7845) microbit will take some more work
-* [2:11:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7905) wrap up
-* [2:13:48](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=8028) -bye all
+* [0:30:00](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1800) - CP save button - use timer instead
+* [0:30:45](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1845) codemirror.net/6 editor
+* [0:31:40](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1900)  https://deno.land/
+* [0:32:59](https://www.youtube.com/watch?v=lS8eJsIYYno&t=1979) Does code mirror handle python/ :blinka:  stubs?
+* [0:34:10](https://www.youtube.com/watch?v=lS8eJsIYYno&t=2050) use absolute latest CP from amazon and NRF 8240(Sp)
+* [0:35:21](https://www.youtube.com/watch?v=lS8eJsIYYno&t=2121) nice to add autocomplete
+* [0:35:45](https://www.youtube.com/watch?v=lS8eJsIYYno&t=2145) now, to test it on the Micro:bit v2
+* [0:36:40](https://www.youtube.com/watch?v=lS8eJsIYYno&t=2200) device disconnects after writes
+* [0:37:10](https://www.youtube.com/watch?v=lS8eJsIYYno&t=2230) some code outthere to user antlr with Monaco, since antlr can generate parsers in many languages including JS and TS
+* [0:37:30](https://www.youtube.com/watch?v=lS8eJsIYYno&t=2250) there is a python parser in codemirror
+* [0:37:52](https://www.youtube.com/watch?v=lS8eJsIYYno&t=2272) microbit V2
+* [0:39:15](https://www.youtube.com/watch?v=lS8eJsIYYno&t=2355) that’s how you know you are in a deep dive - when alpha 3 is too old
+* [0:40:45](https://www.youtube.com/watch?v=lS8eJsIYYno&t=2445) new git microbitv2 repo
+* [0:42:10](https://www.youtube.com/watch?v=lS8eJsIYYno&t=2530) CircuitPython Online Editor
+* [0:42:45](https://www.youtube.com/watch?v=lS8eJsIYYno&t=2565) JS question - how to show a file directory
+* [0:44:00](https://www.youtube.com/watch?v=lS8eJsIYYno&t=2640) microbit v2 cpu nRF52833
+* [0:47:00](https://www.youtube.com/watch?v=lS8eJsIYYno&t=2820) CIRCUITPY_CREATOR / CREATION_ID
+* [0:47:18](https://www.youtube.com/watch?v=lS8eJsIYYno&t=2838) searching for microbit v2 schematic from tech.microbit.org/hardware/schematic
+* [0:50:20](https://www.youtube.com/watch?v=lS8eJsIYYno&t=3020) schematic displays MicroBit_V2.0.0_S_schematic.PDF
+* [0:51:40](https://www.youtube.com/watch?v=lS8eJsIYYno&t=3100) Where can I find documentation on Adafruit_PIOasm? - readthedocs.io pioasm latest
+* [0:55:11](https://www.youtube.com/watch?v=lS8eJsIYYno&t=3311) edit the pinouts on Expansion connector
+* [0:57:14](https://www.youtube.com/watch?v=lS8eJsIYYno&t=3434) how microbit references the pins and map them to CP internal names
+* [0:57:40](https://www.youtube.com/watch?v=lS8eJsIYYno&t=3460) and buttons - to match board creators documentation
+* [0:58:59](https://www.youtube.com/watch?v=lS8eJsIYYno&t=3539) microbit documentation
+* [1:00:25](https://www.youtube.com/watch?v=lS8eJsIYYno&t=3625) Edge connector pins
+* [1:02:15](https://www.youtube.com/watch?v=lS8eJsIYYno&t=3735) If the MicroBit v2 doesn't expose USB, how does one install CircuitPython onto it? Does it have a Bluetooth-enabled bootloader?
+* [1:04:43](https://www.youtube.com/watch?v=lS8eJsIYYno&t=3883) make -j 32 BOARD=microbit_v2 ( fix errors )
+* [1:09:10](https://www.youtube.com/watch?v=lS8eJsIYYno&t=4150) this is the first time we built CP Non-usb BLE only device
+* [1:11:20](https://www.youtube.com/watch?v=lS8eJsIYYno&t=4280)  how to send data over laser.. Is PWM the way to go?
+* [1:13:30](https://www.youtube.com/watch?v=lS8eJsIYYno&t=4410) resolve linker undefined symbols
+* [1:15:45](https://www.youtube.com/watch?v=lS8eJsIYYno&t=4545)  this is the birth of USB-less CP
+* [1:22:35](https://www.youtube.com/watch?v=lS8eJsIYYno&t=4955) always a good idea to do a make clean and try again when experiencing CP build problems
+* [1:26:30](https://www.youtube.com/watch?v=lS8eJsIYYno&t=5190) Serial_write_substring undefined
+* [1:28:00](https://www.youtube.com/watch?v=lS8eJsIYYno&t=5280) ​you can't raise an exception from boot py / goes to boot.out
+* [1:36:00](https://www.youtube.com/watch?v=lS8eJsIYYno&t=5760) - it’s too big :-(
+* [1:39:00](https://www.youtube.com/watch?v=lS8eJsIYYno&t=5940) review the configuration flags
+* [1:41:45](https://www.youtube.com/watch?v=lS8eJsIYYno&t=6105) play the make it fit game - turn off POW3
+* [1:43:20](https://www.youtube.com/watch?v=lS8eJsIYYno&t=6200) ​Is your USB / BT a subset of something else? So you can access it through another doorway?
+* [1:43:48](https://www.youtube.com/watch?v=lS8eJsIYYno&t=6228) - got 500 bytes back
+* [1:45:48](https://www.youtube.com/watch?v=lS8eJsIYYno&t=6348) look what does the “simmel”  do -Os
+* [1:46:45](https://www.youtube.com/watch?v=lS8eJsIYYno&t=6405) nrf52833 flash size (- 512KB Flash )
+* [1:47:50](https://www.youtube.com/watch?v=lS8eJsIYYno&t=6470) Refer to the linker file template common.lk
+* [1:50:30](https://www.youtube.com/watch?v=lS8eJsIYYno&t=6630) What is that magic optimization and why would it not always be enabled?
+* [1:53:40](https://www.youtube.com/watch?v=lS8eJsIYYno&t=6820) What is soft device ( binary blob from nordic )
+* [1:55:40](https://www.youtube.com/watch?v=lS8eJsIYYno&t=6940) using S140 SoftDevices   https:nordicsemi.com/products/nrf52833
+* [1:58:00](https://www.youtube.com/watch?v=lS8eJsIYYno&t=7080) Consider peripheral only / what is S113 size
+* [2:00:00](https://www.youtube.com/watch?v=lS8eJsIYYno&t=7200) Soft device memory resource map
+* [2:02:35](https://www.youtube.com/watch?v=lS8eJsIYYno&t=7355) softdevice provided by Dynastream ( thisisant.com )
+* [2:04:37](https://www.youtube.com/watch?v=lS8eJsIYYno&t=7477) S140 release notes
+* [2:07:57](https://www.youtube.com/watch?v=lS8eJsIYYno&t=7677) end by trying out the binary
+* [2:08:13](https://www.youtube.com/watch?v=lS8eJsIYYno&t=7693) not sure if downloading the hex file did anything
+* [2:09:14](https://www.youtube.com/watch?v=lS8eJsIYYno&t=7754) next step - connect a debugger
+* [2:10:45](https://www.youtube.com/watch?v=lS8eJsIYYno&t=7845) microbit will take some more work
+* [2:11:45](https://www.youtube.com/watch?v=lS8eJsIYYno&t=7905) wrap up
+* [2:13:48](https://www.youtube.com/watch?v=lS8eJsIYYno&t=8028) -bye all
 *

--- a/2021/2021-07-02.md
+++ b/2021/2021-07-02.md
@@ -18,77 +18,77 @@ Plan
 
 
 Timestamps
-* 0:04:00 Hello everyone
-* 0:08:56 Intro to bluetooth
-* 0:09:57 WebBLE - spoiler (android phone/ experimental API)
-* 0:11:27 Makerdiary serial console web device CLI
-* 0:12:47 chrome::/inspect/#devices ( mirror phone screen web page )
-* 0:14:54 repl is working
-* 0:17:47 code.circuitpython.org
-* 0:19:01 prompt to start advertising yellow / fast blue / solid blue - broadcast publicly 
-* 0:19:52 pair serpi / bond
-* 0:21:38 debugging output on the right
-* 0:22:27 edit code in web page - using emoji as variable names!
-* 0:24:41 “editing code from phone”
-* 0:25:29 What would be the difference with linux?
-* 0:26:16 Could something like this be replicated using ble cli tools in linux?
-* 0:27:00 Adafruit_CircuitPython_BLE_File_Transfer repo
-* 0:27:45 circuitpython/web-editor repo
-* 0:28:00 adafruit/ble-file-transfer-js 
+* [0:04:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=240) Hello everyone
+* [0:08:56](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=536) Intro to bluetooth
+* [0:09:57](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=597) WebBLE - spoiler (android phone/ experimental API)
+* [0:11:27](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=687) Makerdiary serial console web device CLI
+* [0:12:47](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=767) chrome::/inspect/#devices ( mirror phone screen web page )
+* [0:14:54](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=894) repl is working
+* [0:17:47](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1067) code.circuitpython.org
+* [0:19:01](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1141) prompt to start advertising yellow / fast blue / solid blue - broadcast publicly
+* [0:19:52](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1192) pair serpi / bond
+* [0:21:38](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1298) debugging output on the right
+* [0:22:27](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1347) edit code in web page - using emoji as variable names!
+* [0:24:41](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1481) “editing code from phone”
+* [0:25:29](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1529) What would be the difference with linux?
+* [0:26:16](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1576) Could something like this be replicated using ble cli tools in linux?
+* [0:27:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1620) Adafruit_CircuitPython_BLE_File_Transfer repo
+* [0:27:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1665) circuitpython/web-editor repo
+* [0:28:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1680) adafruit/ble-file-transfer-js
 * ​0:29:00  works in Chrome then it should work in Deno ... As that's V8 under the hood and they are making their JavaScript isomorphic. (Works in browser, works in Deno.)
-* 0:30:00 - CP save button - use timer instead
-* 0:30:45 codemirror.net/6 editor 
-* 0:31:40  https://deno.land/
-* 0:32:59 Does code mirror handle python/ :blinka:  stubs?
-* 0:34:10 use absolute latest CP from amazon and NRF 8240(Sp)
-* 0:35:21 nice to add autocomplete
-* 0:35:45 now, to test it on the Micro:bit v2 
-* 0:36:40 device disconnects after writes
-* 0:37:10 some code outthere to user antlr with Monaco, since antlr can generate parsers in many languages including JS and TS
-* 0:37:30 there is a python parser in codemirror
-* 0:37:52 microbit V2
-* 0:39:15 that’s how you know you are in a deep dive - when alpha 3 is too old
-* 0:40:45 new git microbitv2 repo
-* 0:42:10 CircuitPython Online Editor 
-* 0:42:45 JS question - how to show a file directory 
-* 0:44:00 microbit v2 cpu nRF52833
-* 0:47:00 CIRCUITPY_CREATOR / CREATION_ID
-* 0:47:18 searching for microbit v2 schematic from tech.microbit.org/hardware/schematic
-* 0:50:20 schematic displays MicroBit_V2.0.0_S_schematic.PDF
-* 0:51:40 Where can I find documentation on Adafruit_PIOasm? - readthedocs.io pioasm latest
-* 0:55:11 edit the pinouts on Expansion connector
-* 0:57:14 how microbit references the pins and map them to CP internal names
-* 0:57:40 and buttons - to match board creators documentation
-* 0:58:59 microbit documentation  
-* 1:00:25 Edge connector pins
-* 1:02:15 If the MicroBit v2 doesn't expose USB, how does one install CircuitPython onto it? Does it have a Bluetooth-enabled bootloader?
-* 1:04:43 make -j 32 BOARD=microbit_v2 ( fix errors )
-* 1:09:10 this is the first time we built CP Non-usb BLE only device
-* 1:11:20  how to send data over laser.. Is PWM the way to go?
-* 1:13:30 resolve linker undefined symbols
-* 1:15:45  this is the birth of USB-less CP
-* 1:22:35 always a good idea to do a make clean and try again when experiencing CP build problems
-* 1:26:30 Serial_write_substring undefined
-* 1:28:00 ​you can't raise an exception from boot py / goes to boot.out
-* 1:36:00 - it’s too big :-(
-* 1:39:00 review the configuration flags
-* 1:41:45 play the make it fit game - turn off POW3
-* 1:43:20 ​Is your USB / BT a subset of something else? So you can access it through another doorway?
-* 1:43:48 - got 500 bytes back
-* 1:45:48 look what does the “simmel”  do -Os
-* 1:46:45 nrf52833 flash size (- 512KB Flash )
-* 1:47:50 Refer to the linker file template common.lk
-* 1:50:30 What is that magic optimization and why would it not always be enabled?
-* 1:53:40 What is soft device ( binary blob from nordic )
-* 1:55:40 using S140 SoftDevices   https:nordicsemi.com/products/nrf52833
-* 1:58:00 Consider peripheral only / what is S113 size 
-* 2:00:00 Soft device memory resource map
-* 2:02:35 softdevice provided by Dynastream ( thisisant.com )
-* 2:04:37 S140 release notes
-* 2:07:57 end by trying out the binary 
-* 2:08:13 not sure if downloading the hex file did anything
-* 2:09:14 next step - connect a debugger
-* 2:10:45 microbit will take some more work 
-* 2:11:45 wrap up
-* 2:13:48 -bye all
+* [0:30:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1800) - CP save button - use timer instead
+* [0:30:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1845) codemirror.net/6 editor
+* [0:31:40](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1900)  https://deno.land/
+* [0:32:59](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=1979) Does code mirror handle python/ :blinka:  stubs?
+* [0:34:10](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2050) use absolute latest CP from amazon and NRF 8240(Sp)
+* [0:35:21](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2121) nice to add autocomplete
+* [0:35:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2145) now, to test it on the Micro:bit v2
+* [0:36:40](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2200) device disconnects after writes
+* [0:37:10](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2230) some code outthere to user antlr with Monaco, since antlr can generate parsers in many languages including JS and TS
+* [0:37:30](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2250) there is a python parser in codemirror
+* [0:37:52](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2272) microbit V2
+* [0:39:15](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2355) that’s how you know you are in a deep dive - when alpha 3 is too old
+* [0:40:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2445) new git microbitv2 repo
+* [0:42:10](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2530) CircuitPython Online Editor
+* [0:42:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2565) JS question - how to show a file directory
+* [0:44:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2640) microbit v2 cpu nRF52833
+* [0:47:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2820) CIRCUITPY_CREATOR / CREATION_ID
+* [0:47:18](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=2838) searching for microbit v2 schematic from tech.microbit.org/hardware/schematic
+* [0:50:20](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3020) schematic displays MicroBit_V2.0.0_S_schematic.PDF
+* [0:51:40](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3100) Where can I find documentation on Adafruit_PIOasm? - readthedocs.io pioasm latest
+* [0:55:11](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3311) edit the pinouts on Expansion connector
+* [0:57:14](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3434) how microbit references the pins and map them to CP internal names
+* [0:57:40](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3460) and buttons - to match board creators documentation
+* [0:58:59](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3539) microbit documentation
+* [1:00:25](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3625) Edge connector pins
+* [1:02:15](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3735) If the MicroBit v2 doesn't expose USB, how does one install CircuitPython onto it? Does it have a Bluetooth-enabled bootloader?
+* [1:04:43](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=3883) make -j 32 BOARD=microbit_v2 ( fix errors )
+* [1:09:10](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=4150) this is the first time we built CP Non-usb BLE only device
+* [1:11:20](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=4280)  how to send data over laser.. Is PWM the way to go?
+* [1:13:30](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=4410) resolve linker undefined symbols
+* [1:15:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=4545)  this is the birth of USB-less CP
+* [1:22:35](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=4955) always a good idea to do a make clean and try again when experiencing CP build problems
+* [1:26:30](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=5190) Serial_write_substring undefined
+* [1:28:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=5280) ​you can't raise an exception from boot py / goes to boot.out
+* [1:36:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=5760) - it’s too big :-(
+* [1:39:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=5940) review the configuration flags
+* [1:41:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6105) play the make it fit game - turn off POW3
+* [1:43:20](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6200) ​Is your USB / BT a subset of something else? So you can access it through another doorway?
+* [1:43:48](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6228) - got 500 bytes back
+* [1:45:48](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6348) look what does the “simmel”  do -Os
+* [1:46:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6405) nrf52833 flash size (- 512KB Flash )
+* [1:47:50](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6470) Refer to the linker file template common.lk
+* [1:50:30](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6630) What is that magic optimization and why would it not always be enabled?
+* [1:53:40](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6820) What is soft device ( binary blob from nordic )
+* [1:55:40](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=6940) using S140 SoftDevices   https:nordicsemi.com/products/nrf52833
+* [1:58:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7080) Consider peripheral only / what is S113 size
+* [2:00:00](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7200) Soft device memory resource map
+* [2:02:35](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7355) softdevice provided by Dynastream ( thisisant.com )
+* [2:04:37](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7477) S140 release notes
+* [2:07:57](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7677) end by trying out the binary
+* [2:08:13](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7693) not sure if downloading the hex file did anything
+* [2:09:14](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7754) next step - connect a debugger
+* [2:10:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7845) microbit will take some more work
+* [2:11:45](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=7905) wrap up
+* [2:13:48](https://www.youtube.com/watch?v=VIDEO_2021_07_02?t=8028) -bye all
 *

--- a/2021/2021-07-09.md
+++ b/2021/2021-07-09.md
@@ -17,42 +17,42 @@ Plan
 
 
 Timestamps
-* 0:07:15 housekeeping
-* 0:09:25 What would be the most expensive  :blinka:  board? 
-* 0:12:20 Does CP slow down the microcontroller.
-* 0:13:36 explain Circuit Playground Express pinout ‘legend’ https://cdn-learn.adafruit.com/assets/assets/000/047/156/original/circuit_playground_Adafruit_Circuit_Playground_Express_Pinout.png?1507829017
-* 0:27:04 is there a way to change Io that has specific functions like using a crossbar or IOMUX in the SAMD outside of bootloader settings?
-* 0:29:04 Dive into SAMD hal busio i2c
-* 0:32:00 ~ CP ‘bootloader’
-* 0:32:43 CP essentials guide i2c - list all combinations if I2C
-* 0:34:31  CP bug#4638: I2C_STEMMA vs STEMMA_I2C? ( how does board.i2c work? )
-* 0:37:24 looking at old CP issues list
-* 0:39:50 Is it time for a ‘native’ display driver for the microbit?
-* 0:41:18 PewPew display ( pewpew10 )
-* 0:43:06 pewpep10 issue 4979  / youtube PewPew 10 with CP - idea: debug interrupts with logic analyzer 
-* 0:46:24 microbit update - microphone LED on bootup / discovery / “ello”
-* 0:48:58 the first build of CP that doesn’t have USB!
-* 0:51:02 code.circuitpython.org WebBluetooth
-* 0:53:55 plug podcast talk-python-with-me  CircuitPython and MicroPython - Talk Python Live Stream
-* 0:57:30 Connect web-serial to USB-serial
-* 0:58:40 Javascript people doing cool things!
-* 1:03:15 Web Serial API
-* 1:05:35 Adafruit code reviews / transition to pull requests to support continuous integration
-* 1:09:40 request serial port  serial.getPorts()
-* 1:11:18 Readable / Writable stream
-* 1:13:56 multiple serial ports from the same device
-* 1:14:30  has anyone used a CP board to manage LED strips? I have a couple govee rgb strips that have an IOS app, but would like to control them without the app.
-* 1:16:55 web usb spec https://web.dev/usb/
-* 1:20:20 switchToSerial(device)
-* 1:24:10 example has a bit more context around the while readable - https://wicg.github.io/serial/#close-method
-* 1:26:30 console.log is so nice - debugging switchToSerial device.open()
-* 1:30:55 How many reviewers does CP have? ( 5 or 6 )
-* 1:33:20 that looks promising! ( getting data from the particle sensor )
-* 1:35:40 Difference between “var” and “let”
-* 1:37:40 “It’s alive” - text decoder displaying data!
-* 1:47:20 have to say your are in an async function if you “await”
-* 1:50:05 code running again - summarize limitations
-* 1:51:11 check in the terrible code - as it is https://github.com/circuitpython/web-editor
-* 1:54:13 wrapping up ( timecodes drifted over time - about a minute or so )
-* 1:55:44 timecodes back in sync
-* 1:58:38
+* [0:07:15](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=435) housekeeping
+* [0:09:25](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=565) What would be the most expensive  :blinka:  board?
+* [0:12:20](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=740) Does CP slow down the microcontroller.
+* [0:13:36](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=816) explain Circuit Playground Express pinout ‘legend’ https://cdn-learn.adafruit.com/assets/assets/000/047/156/original/circuit_playground_Adafruit_Circuit_Playground_Express_Pinout.png?1507829017
+* [0:27:04](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=1624) is there a way to change Io that has specific functions like using a crossbar or IOMUX in the SAMD outside of bootloader settings?
+* [0:29:04](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=1744) Dive into SAMD hal busio i2c
+* [0:32:00](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=1920) ~ CP ‘bootloader’
+* [0:32:43](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=1963) CP essentials guide i2c - list all combinations if I2C
+* [0:34:31](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=2071)  CP bug#4638: I2C_STEMMA vs STEMMA_I2C? ( how does board.i2c work? )
+* [0:37:24](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=2244) looking at old CP issues list
+* [0:39:50](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=2390) Is it time for a ‘native’ display driver for the microbit?
+* [0:41:18](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=2478) PewPew display ( pewpew10 )
+* [0:43:06](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=2586) pewpep10 issue 4979  / youtube PewPew 10 with CP - idea: debug interrupts with logic analyzer
+* [0:46:24](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=2784) microbit update - microphone LED on bootup / discovery / “ello”
+* [0:48:58](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=2938) the first build of CP that doesn’t have USB!
+* [0:51:02](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=3062) code.circuitpython.org WebBluetooth
+* [0:53:55](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=3235) plug podcast talk-python-with-me  CircuitPython and MicroPython - Talk Python Live Stream
+* [0:57:30](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=3450) Connect web-serial to USB-serial
+* [0:58:40](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=3520) Javascript people doing cool things!
+* [1:03:15](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=3795) Web Serial API
+* [1:05:35](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=3935) Adafruit code reviews / transition to pull requests to support continuous integration
+* [1:09:40](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=4180) request serial port  serial.getPorts()
+* [1:11:18](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=4278) Readable / Writable stream
+* [1:13:56](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=4436) multiple serial ports from the same device
+* [1:14:30](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=4470)  has anyone used a CP board to manage LED strips? I have a couple govee rgb strips that have an IOS app, but would like to control them without the app.
+* [1:16:55](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=4615) web usb spec https://web.dev/usb/
+* [1:20:20](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=4820) switchToSerial(device)
+* [1:24:10](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=5050) example has a bit more context around the while readable - https://wicg.github.io/serial/#close-method
+* [1:26:30](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=5190) console.log is so nice - debugging switchToSerial device.open()
+* [1:30:55](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=5455) How many reviewers does CP have? ( 5 or 6 )
+* [1:33:20](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=5600) that looks promising! ( getting data from the particle sensor )
+* [1:35:40](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=5740) Difference between “var” and “let”
+* [1:37:40](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=5860) “It’s alive” - text decoder displaying data!
+* [1:47:20](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=6440) have to say your are in an async function if you “await”
+* [1:50:05](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=6605) code running again - summarize limitations
+* [1:51:11](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=6671) check in the terrible code - as it is https://github.com/circuitpython/web-editor
+* [1:54:13](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=6853) wrapping up ( timecodes drifted over time - about a minute or so )
+* [1:55:44](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=6944) timecodes back in sync
+* [1:58:38](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=7118)

--- a/2021/2021-07-09.md
+++ b/2021/2021-07-09.md
@@ -17,42 +17,42 @@ Plan
 
 
 Timestamps
-* [0:07:15](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=435) housekeeping
-* [0:09:25](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=565) What would be the most expensive  :blinka:  board?
-* [0:12:20](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=740) Does CP slow down the microcontroller.
-* [0:13:36](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=816) explain Circuit Playground Express pinout ‘legend’ https://cdn-learn.adafruit.com/assets/assets/000/047/156/original/circuit_playground_Adafruit_Circuit_Playground_Express_Pinout.png?1507829017
-* [0:27:04](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=1624) is there a way to change Io that has specific functions like using a crossbar or IOMUX in the SAMD outside of bootloader settings?
-* [0:29:04](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=1744) Dive into SAMD hal busio i2c
-* [0:32:00](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=1920) ~ CP ‘bootloader’
-* [0:32:43](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=1963) CP essentials guide i2c - list all combinations if I2C
-* [0:34:31](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=2071)  CP bug#4638: I2C_STEMMA vs STEMMA_I2C? ( how does board.i2c work? )
-* [0:37:24](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=2244) looking at old CP issues list
-* [0:39:50](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=2390) Is it time for a ‘native’ display driver for the microbit?
-* [0:41:18](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=2478) PewPew display ( pewpew10 )
-* [0:43:06](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=2586) pewpep10 issue 4979  / youtube PewPew 10 with CP - idea: debug interrupts with logic analyzer
-* [0:46:24](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=2784) microbit update - microphone LED on bootup / discovery / “ello”
-* [0:48:58](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=2938) the first build of CP that doesn’t have USB!
-* [0:51:02](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=3062) code.circuitpython.org WebBluetooth
-* [0:53:55](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=3235) plug podcast talk-python-with-me  CircuitPython and MicroPython - Talk Python Live Stream
-* [0:57:30](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=3450) Connect web-serial to USB-serial
-* [0:58:40](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=3520) Javascript people doing cool things!
-* [1:03:15](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=3795) Web Serial API
-* [1:05:35](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=3935) Adafruit code reviews / transition to pull requests to support continuous integration
-* [1:09:40](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=4180) request serial port  serial.getPorts()
-* [1:11:18](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=4278) Readable / Writable stream
-* [1:13:56](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=4436) multiple serial ports from the same device
-* [1:14:30](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=4470)  has anyone used a CP board to manage LED strips? I have a couple govee rgb strips that have an IOS app, but would like to control them without the app.
-* [1:16:55](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=4615) web usb spec https://web.dev/usb/
-* [1:20:20](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=4820) switchToSerial(device)
-* [1:24:10](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=5050) example has a bit more context around the while readable - https://wicg.github.io/serial/#close-method
-* [1:26:30](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=5190) console.log is so nice - debugging switchToSerial device.open()
-* [1:30:55](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=5455) How many reviewers does CP have? ( 5 or 6 )
-* [1:33:20](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=5600) that looks promising! ( getting data from the particle sensor )
-* [1:35:40](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=5740) Difference between “var” and “let”
-* [1:37:40](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=5860) “It’s alive” - text decoder displaying data!
-* [1:47:20](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=6440) have to say your are in an async function if you “await”
-* [1:50:05](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=6605) code running again - summarize limitations
-* [1:51:11](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=6671) check in the terrible code - as it is https://github.com/circuitpython/web-editor
-* [1:54:13](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=6853) wrapping up ( timecodes drifted over time - about a minute or so )
-* [1:55:44](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=6944) timecodes back in sync
-* [1:58:38](https://www.youtube.com/watch?v=VIDEO_2021_07_09?t=7118)
+* [0:07:15](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=435) housekeeping
+* [0:09:25](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=565) What would be the most expensive  :blinka:  board?
+* [0:12:20](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=740) Does CP slow down the microcontroller.
+* [0:13:36](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=816) explain Circuit Playground Express pinout ‘legend’ https://cdn-learn.adafruit.com/assets/assets/000/047/156/original/circuit_playground_Adafruit_Circuit_Playground_Express_Pinout.png?1507829017
+* [0:27:04](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=1624) is there a way to change Io that has specific functions like using a crossbar or IOMUX in the SAMD outside of bootloader settings?
+* [0:29:04](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=1744) Dive into SAMD hal busio i2c
+* [0:32:00](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=1920) ~ CP ‘bootloader’
+* [0:32:43](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=1963) CP essentials guide i2c - list all combinations if I2C
+* [0:34:31](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=2071)  CP bug#4638: I2C_STEMMA vs STEMMA_I2C? ( how does board.i2c work? )
+* [0:37:24](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=2244) looking at old CP issues list
+* [0:39:50](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=2390) Is it time for a ‘native’ display driver for the microbit?
+* [0:41:18](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=2478) PewPew display ( pewpew10 )
+* [0:43:06](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=2586) pewpep10 issue 4979  / youtube PewPew 10 with CP - idea: debug interrupts with logic analyzer
+* [0:46:24](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=2784) microbit update - microphone LED on bootup / discovery / “ello”
+* [0:48:58](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=2938) the first build of CP that doesn’t have USB!
+* [0:51:02](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=3062) code.circuitpython.org WebBluetooth
+* [0:53:55](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=3235) plug podcast talk-python-with-me  CircuitPython and MicroPython - Talk Python Live Stream
+* [0:57:30](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=3450) Connect web-serial to USB-serial
+* [0:58:40](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=3520) Javascript people doing cool things!
+* [1:03:15](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=3795) Web Serial API
+* [1:05:35](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=3935) Adafruit code reviews / transition to pull requests to support continuous integration
+* [1:09:40](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=4180) request serial port  serial.getPorts()
+* [1:11:18](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=4278) Readable / Writable stream
+* [1:13:56](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=4436) multiple serial ports from the same device
+* [1:14:30](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=4470)  has anyone used a CP board to manage LED strips? I have a couple govee rgb strips that have an IOS app, but would like to control them without the app.
+* [1:16:55](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=4615) web usb spec https://web.dev/usb/
+* [1:20:20](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=4820) switchToSerial(device)
+* [1:24:10](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=5050) example has a bit more context around the while readable - https://wicg.github.io/serial/#close-method
+* [1:26:30](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=5190) console.log is so nice - debugging switchToSerial device.open()
+* [1:30:55](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=5455) How many reviewers does CP have? ( 5 or 6 )
+* [1:33:20](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=5600) that looks promising! ( getting data from the particle sensor )
+* [1:35:40](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=5740) Difference between “var” and “let”
+* [1:37:40](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=5860) “It’s alive” - text decoder displaying data!
+* [1:47:20](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=6440) have to say your are in an async function if you “await”
+* [1:50:05](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=6605) code running again - summarize limitations
+* [1:51:11](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=6671) check in the terrible code - as it is https://github.com/circuitpython/web-editor
+* [1:54:13](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=6853) wrapping up ( timecodes drifted over time - about a minute or so )
+* [1:55:44](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=6944) timecodes back in sync
+* [1:58:38](https://www.youtube.com/watch?v=YXpXSfQkvuk&t=7118)

--- a/2021/2021-07-16.md
+++ b/2021/2021-07-16.md
@@ -13,70 +13,70 @@ Housekeeping
 
 
 Plan
-* 
+*
 
 Timestamps
-* 0:03:43 Welcome Jim @jim_mussared
-* 0:07:44 Black box with blinky lights on the wall
-* 0:08:50 http://megaprocessor.com/
-* 0:12:00 - black screen - ( obs transition / rearrange screen)
-* 0:15:16 Jim’s desktop 
-* 0:17:00 @micropython.native decorator - compile to native thumb code in RAM
-* 0:20:00 freezing code moves it to flash
-* 0:21:55 import mic0ropython discussion - to catch code not portable to cpython
-* 0:23:00 const variables, and _ prefixed variables
-* 0:25:23 thumb code ( ARM and thumb ( native cortex machine code ) )
-* 0:26:55 ISA - (RISC-V api )
-* 0:30:20 instruction lookahead - deep pipelining
-* 0:31:15 Spectre / speculative look ahead / security issues
-* 0:32:25 Jim’s secret agenda for the deep dive - native emitter for RISC-V (esp32)
-* 0:34:20 CP needs BLE if not native USB
-* 0:35:35 micropython.native code incorrect execution
-* 0:36:10 mpr - micropython remote “mpr run”
-* 0:36:50 mpr mount - access to remote REPL
-* 0:37:40 CP-like workflow over serial (esp32)
-* 0:38:35 @micropython.viper - optimization by skipping the python object overhead
-* 0:40:10 MP type hints - normally ignored
-* 0:40:45 type hints as IDE help
-* 0:41:20 If you have repeating numbers like your 255s and 0s, is it a bad idea to make them consts? Are they already treated like consts internally?
-* 0:43:44  disassemble (alias blaze = ‘make -j 16’  / on linux port )
-* 0:47:00 microcpython -v -v -v to disassemble to micropython VM bytecode - walk through the byte code
-* 0:51:15 - 3 stacks to discuss later
-* 0:53:30 mp binary op internals
-* 0:55:40 what is an emitter - lexical analysis , parse into tree, emit code from parse tree ( byte code, emit native code, or emit viper code )
-* 0:57:50 byte code emitter emitbc.c
-* 0:58:59 compile.c calls emitter, or emitnative.c
-* 1:01:30 Is .native and .viper just at a method level? Class level too?
-* 1:02:50 native ‘everything’ by saving the python to a code
-* 1:08:00 continue in emit native
-* 1:10:10 what if we use a local variable?
-* 1:11:34 gdb ./micropython ( oops - rebuild first )
-* 1:13:35 mp_obj_t ( the most useful point of this deep dive )
-* 1:15:20 type tagging ( see mpconfig.h )
-* 1:16:45 some builds of CP don’t support long integers
-* 1:18:35 . is there anything else than micropython that emit micropython bytecode? Like at one point everyone was making JVM bytecode even not being java
-* 1:20:05 everything is a 32 bit integer - ( or a pointer to an object )
-* 1:21:10 Why (3) is really 1 and 0x1ff
-* 1:22:25 gdb backtrace doesn’t work with native emitter
-* 1:23:10 anybody doing "hand written" bytecode to do something smart or super optimised?
-* 1:25:00 Write part of the core in the python
-* 1:27:55 looking at the native code generated in a file
-* 1:29:49 Is there a byte code to python "decompiler"?
-* 1:30:30 debug the debugging code
-* 1:32:03 objdump to disassemble the generated code (x86-64 code)
-* 1:34:50 rbp is pointer to functable - ( there is no linker)
-* 1:41:03 viper generation
-* 1:45:40 emit_native_jump_helper 
-* 1:47:08 3 different stacks ( processor, MP function stack, emitter stack (while emitting )
-* 1:49:00 optimization
-* 1:51:50 - another optimization - keep variables in registers 
-* 1:53:50 - clobber EAX 
-* 1:55:40 RISC-V ISA/calling conventions  ( ABI - binary interface )
-* 1:57:30 one character fix  ( use EDI instead of EAX )
-* 1:58:52 Write a test to verify the fix
-* 1:59:45 fixed on thumb code
-* 2:00:00 MP issue #7523
-* Thanks to Jim and https://www.robotshop.com/en/george-robotics.html 
-* 2:08:00 wrap up!
-* 2:08;30 - final frame :-)
+* [0:03:43](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=223) Welcome Jim @jim_mussared
+* [0:07:44](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=464) Black box with blinky lights on the wall
+* [0:08:50](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=530) http://megaprocessor.com/
+* [0:12:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=720) - black screen - ( obs transition / rearrange screen)
+* [0:15:16](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=916) Jim’s desktop
+* [0:17:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1020) @micropython.native decorator - compile to native thumb code in RAM
+* [0:20:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1200) freezing code moves it to flash
+* [0:21:55](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1315) import mic0ropython discussion - to catch code not portable to cpython
+* [0:23:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1380) const variables, and _ prefixed variables
+* [0:25:23](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1523) thumb code ( ARM and thumb ( native cortex machine code ) )
+* [0:26:55](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1615) ISA - (RISC-V api )
+* [0:30:20](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1820) instruction lookahead - deep pipelining
+* [0:31:15](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1875) Spectre / speculative look ahead / security issues
+* [0:32:25](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1945) Jim’s secret agenda for the deep dive - native emitter for RISC-V (esp32)
+* [0:34:20](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2060) CP needs BLE if not native USB
+* [0:35:35](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2135) micropython.native code incorrect execution
+* [0:36:10](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2170) mpr - micropython remote “mpr run”
+* [0:36:50](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2210) mpr mount - access to remote REPL
+* [0:37:40](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2260) CP-like workflow over serial (esp32)
+* [0:38:35](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2315) @micropython.viper - optimization by skipping the python object overhead
+* [0:40:10](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2410) MP type hints - normally ignored
+* [0:40:45](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2445) type hints as IDE help
+* [0:41:20](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2480) If you have repeating numbers like your 255s and 0s, is it a bad idea to make them consts? Are they already treated like consts internally?
+* [0:43:44](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2624)  disassemble (alias blaze = ‘make -j 16’  / on linux port )
+* [0:47:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2820) microcpython -v -v -v to disassemble to micropython VM bytecode - walk through the byte code
+* [0:51:15](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=3075) - 3 stacks to discuss later
+* [0:53:30](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=3210) mp binary op internals
+* [0:55:40](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=3340) what is an emitter - lexical analysis , parse into tree, emit code from parse tree ( byte code, emit native code, or emit viper code )
+* [0:57:50](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=3470) byte code emitter emitbc.c
+* [0:58:59](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=3539) compile.c calls emitter, or emitnative.c
+* [1:01:30](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=3690) Is .native and .viper just at a method level? Class level too?
+* [1:02:50](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=3770) native ‘everything’ by saving the python to a code
+* [1:08:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4080) continue in emit native
+* [1:10:10](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4210) what if we use a local variable?
+* [1:11:34](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4294) gdb ./micropython ( oops - rebuild first )
+* [1:13:35](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4415) mp_obj_t ( the most useful point of this deep dive )
+* [1:15:20](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4520) type tagging ( see mpconfig.h )
+* [1:16:45](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4605) some builds of CP don’t support long integers
+* [1:18:35](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4715) . is there anything else than micropython that emit micropython bytecode? Like at one point everyone was making JVM bytecode even not being java
+* [1:20:05](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4805) everything is a 32 bit integer - ( or a pointer to an object )
+* [1:21:10](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4870) Why (3) is really 1 and 0x1ff
+* [1:22:25](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4945) gdb backtrace doesn’t work with native emitter
+* [1:23:10](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4990) anybody doing "hand written" bytecode to do something smart or super optimised?
+* [1:25:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=5100) Write part of the core in the python
+* [1:27:55](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=5275) looking at the native code generated in a file
+* [1:29:49](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=5389) Is there a byte code to python "decompiler"?
+* [1:30:30](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=5430) debug the debugging code
+* [1:32:03](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=5523) objdump to disassemble the generated code (x86-64 code)
+* [1:34:50](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=5690) rbp is pointer to functable - ( there is no linker)
+* [1:41:03](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=6063) viper generation
+* [1:45:40](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=6340) emit_native_jump_helper
+* [1:47:08](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=6428) 3 different stacks ( processor, MP function stack, emitter stack (while emitting )
+* [1:49:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=6540) optimization
+* [1:51:50](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=6710) - another optimization - keep variables in registers
+* [1:53:50](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=6830) - clobber EAX
+* [1:55:40](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=6940) RISC-V ISA/calling conventions  ( ABI - binary interface )
+* [1:57:30](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=7050) one character fix  ( use EDI instead of EAX )
+* [1:58:52](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=7132) Write a test to verify the fix
+* [1:59:45](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=7185) fixed on thumb code
+* [2:00:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=7200) MP issue #7523
+* Thanks to Jim and https://www.robotshop.com/en/george-robotics.html
+* [2:08:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=7680) wrap up!
+* [2:08](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=128);30 - final frame :-)
 *

--- a/2021/2021-07-16.md
+++ b/2021/2021-07-16.md
@@ -67,7 +67,7 @@ Timestamps
 * [1:34:50](https://www.youtube.com/watch?v=bciRImf0_Ts&t=5690) rbp is pointer to functable - ( there is no linker)
 * [1:41:03](https://www.youtube.com/watch?v=bciRImf0_Ts&t=6063) viper generation
 * [1:45:40](https://www.youtube.com/watch?v=bciRImf0_Ts&t=6340) emit_native_jump_helper
-* [1:47:08](https://www.youtube.com/watch?v=bciRImf0_Ts&t=6428) 3 different stacks ( processor, MP function stack, emitter stack (while emitting )
+* [1:47:08](https://www.youtube.com/watch?v=bciRImf0_Ts&t=6428) 3 different stacks ( processor, MP function stack, emitter stack) (while emitting )
 * [1:49:00](https://www.youtube.com/watch?v=bciRImf0_Ts&t=6540) optimization
 * [1:51:50](https://www.youtube.com/watch?v=bciRImf0_Ts&t=6710) - another optimization - keep variables in registers
 * [1:53:50](https://www.youtube.com/watch?v=bciRImf0_Ts&t=6830) - clobber EAX
@@ -78,5 +78,4 @@ Timestamps
 * [2:00:00](https://www.youtube.com/watch?v=bciRImf0_Ts&t=7200) MP issue #7523
 * Thanks to Jim and https://www.robotshop.com/en/george-robotics.html
 * [2:08:00](https://www.youtube.com/watch?v=bciRImf0_Ts&t=7680) wrap up!
-* [2:08](https://www.youtube.com/watch?v=bciRImf0_Ts&t=128);30 - final frame :-)
-*
+* [2:08:30](https://www.youtube.com/watch?v=bciRImf0_Ts&t=7710) - final frame :-)

--- a/2021/2021-07-16.md
+++ b/2021/2021-07-16.md
@@ -16,67 +16,67 @@ Plan
 *
 
 Timestamps
-* [0:03:43](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=223) Welcome Jim @jim_mussared
-* [0:07:44](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=464) Black box with blinky lights on the wall
-* [0:08:50](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=530) http://megaprocessor.com/
-* [0:12:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=720) - black screen - ( obs transition / rearrange screen)
-* [0:15:16](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=916) Jim’s desktop
-* [0:17:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1020) @micropython.native decorator - compile to native thumb code in RAM
-* [0:20:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1200) freezing code moves it to flash
-* [0:21:55](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1315) import mic0ropython discussion - to catch code not portable to cpython
-* [0:23:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1380) const variables, and _ prefixed variables
-* [0:25:23](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1523) thumb code ( ARM and thumb ( native cortex machine code ) )
-* [0:26:55](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1615) ISA - (RISC-V api )
-* [0:30:20](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1820) instruction lookahead - deep pipelining
-* [0:31:15](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1875) Spectre / speculative look ahead / security issues
-* [0:32:25](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=1945) Jim’s secret agenda for the deep dive - native emitter for RISC-V (esp32)
-* [0:34:20](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2060) CP needs BLE if not native USB
-* [0:35:35](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2135) micropython.native code incorrect execution
-* [0:36:10](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2170) mpr - micropython remote “mpr run”
-* [0:36:50](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2210) mpr mount - access to remote REPL
-* [0:37:40](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2260) CP-like workflow over serial (esp32)
-* [0:38:35](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2315) @micropython.viper - optimization by skipping the python object overhead
-* [0:40:10](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2410) MP type hints - normally ignored
-* [0:40:45](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2445) type hints as IDE help
-* [0:41:20](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2480) If you have repeating numbers like your 255s and 0s, is it a bad idea to make them consts? Are they already treated like consts internally?
-* [0:43:44](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2624)  disassemble (alias blaze = ‘make -j 16’  / on linux port )
-* [0:47:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=2820) microcpython -v -v -v to disassemble to micropython VM bytecode - walk through the byte code
-* [0:51:15](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=3075) - 3 stacks to discuss later
-* [0:53:30](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=3210) mp binary op internals
-* [0:55:40](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=3340) what is an emitter - lexical analysis , parse into tree, emit code from parse tree ( byte code, emit native code, or emit viper code )
-* [0:57:50](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=3470) byte code emitter emitbc.c
-* [0:58:59](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=3539) compile.c calls emitter, or emitnative.c
-* [1:01:30](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=3690) Is .native and .viper just at a method level? Class level too?
-* [1:02:50](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=3770) native ‘everything’ by saving the python to a code
-* [1:08:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4080) continue in emit native
-* [1:10:10](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4210) what if we use a local variable?
-* [1:11:34](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4294) gdb ./micropython ( oops - rebuild first )
-* [1:13:35](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4415) mp_obj_t ( the most useful point of this deep dive )
-* [1:15:20](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4520) type tagging ( see mpconfig.h )
-* [1:16:45](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4605) some builds of CP don’t support long integers
-* [1:18:35](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4715) . is there anything else than micropython that emit micropython bytecode? Like at one point everyone was making JVM bytecode even not being java
-* [1:20:05](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4805) everything is a 32 bit integer - ( or a pointer to an object )
-* [1:21:10](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4870) Why (3) is really 1 and 0x1ff
-* [1:22:25](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4945) gdb backtrace doesn’t work with native emitter
-* [1:23:10](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=4990) anybody doing "hand written" bytecode to do something smart or super optimised?
-* [1:25:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=5100) Write part of the core in the python
-* [1:27:55](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=5275) looking at the native code generated in a file
-* [1:29:49](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=5389) Is there a byte code to python "decompiler"?
-* [1:30:30](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=5430) debug the debugging code
-* [1:32:03](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=5523) objdump to disassemble the generated code (x86-64 code)
-* [1:34:50](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=5690) rbp is pointer to functable - ( there is no linker)
-* [1:41:03](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=6063) viper generation
-* [1:45:40](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=6340) emit_native_jump_helper
-* [1:47:08](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=6428) 3 different stacks ( processor, MP function stack, emitter stack (while emitting )
-* [1:49:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=6540) optimization
-* [1:51:50](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=6710) - another optimization - keep variables in registers
-* [1:53:50](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=6830) - clobber EAX
-* [1:55:40](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=6940) RISC-V ISA/calling conventions  ( ABI - binary interface )
-* [1:57:30](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=7050) one character fix  ( use EDI instead of EAX )
-* [1:58:52](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=7132) Write a test to verify the fix
-* [1:59:45](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=7185) fixed on thumb code
-* [2:00:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=7200) MP issue #7523
+* [0:03:43](https://www.youtube.com/watch?v=bciRImf0_Ts&t=223) Welcome Jim @jim_mussared
+* [0:07:44](https://www.youtube.com/watch?v=bciRImf0_Ts&t=464) Black box with blinky lights on the wall
+* [0:08:50](https://www.youtube.com/watch?v=bciRImf0_Ts&t=530) http://megaprocessor.com/
+* [0:12:00](https://www.youtube.com/watch?v=bciRImf0_Ts&t=720) - black screen - ( obs transition / rearrange screen)
+* [0:15:16](https://www.youtube.com/watch?v=bciRImf0_Ts&t=916) Jim’s desktop
+* [0:17:00](https://www.youtube.com/watch?v=bciRImf0_Ts&t=1020) @micropython.native decorator - compile to native thumb code in RAM
+* [0:20:00](https://www.youtube.com/watch?v=bciRImf0_Ts&t=1200) freezing code moves it to flash
+* [0:21:55](https://www.youtube.com/watch?v=bciRImf0_Ts&t=1315) import mic0ropython discussion - to catch code not portable to cpython
+* [0:23:00](https://www.youtube.com/watch?v=bciRImf0_Ts&t=1380) const variables, and _ prefixed variables
+* [0:25:23](https://www.youtube.com/watch?v=bciRImf0_Ts&t=1523) thumb code ( ARM and thumb ( native cortex machine code ) )
+* [0:26:55](https://www.youtube.com/watch?v=bciRImf0_Ts&t=1615) ISA - (RISC-V api )
+* [0:30:20](https://www.youtube.com/watch?v=bciRImf0_Ts&t=1820) instruction lookahead - deep pipelining
+* [0:31:15](https://www.youtube.com/watch?v=bciRImf0_Ts&t=1875) Spectre / speculative look ahead / security issues
+* [0:32:25](https://www.youtube.com/watch?v=bciRImf0_Ts&t=1945) Jim’s secret agenda for the deep dive - native emitter for RISC-V (esp32)
+* [0:34:20](https://www.youtube.com/watch?v=bciRImf0_Ts&t=2060) CP needs BLE if not native USB
+* [0:35:35](https://www.youtube.com/watch?v=bciRImf0_Ts&t=2135) micropython.native code incorrect execution
+* [0:36:10](https://www.youtube.com/watch?v=bciRImf0_Ts&t=2170) mpr - micropython remote “mpr run”
+* [0:36:50](https://www.youtube.com/watch?v=bciRImf0_Ts&t=2210) mpr mount - access to remote REPL
+* [0:37:40](https://www.youtube.com/watch?v=bciRImf0_Ts&t=2260) CP-like workflow over serial (esp32)
+* [0:38:35](https://www.youtube.com/watch?v=bciRImf0_Ts&t=2315) @micropython.viper - optimization by skipping the python object overhead
+* [0:40:10](https://www.youtube.com/watch?v=bciRImf0_Ts&t=2410) MP type hints - normally ignored
+* [0:40:45](https://www.youtube.com/watch?v=bciRImf0_Ts&t=2445) type hints as IDE help
+* [0:41:20](https://www.youtube.com/watch?v=bciRImf0_Ts&t=2480) If you have repeating numbers like your 255s and 0s, is it a bad idea to make them consts? Are they already treated like consts internally?
+* [0:43:44](https://www.youtube.com/watch?v=bciRImf0_Ts&t=2624)  disassemble (alias blaze = ‘make -j 16’  / on linux port )
+* [0:47:00](https://www.youtube.com/watch?v=bciRImf0_Ts&t=2820) microcpython -v -v -v to disassemble to micropython VM bytecode - walk through the byte code
+* [0:51:15](https://www.youtube.com/watch?v=bciRImf0_Ts&t=3075) - 3 stacks to discuss later
+* [0:53:30](https://www.youtube.com/watch?v=bciRImf0_Ts&t=3210) mp binary op internals
+* [0:55:40](https://www.youtube.com/watch?v=bciRImf0_Ts&t=3340) what is an emitter - lexical analysis , parse into tree, emit code from parse tree ( byte code, emit native code, or emit viper code )
+* [0:57:50](https://www.youtube.com/watch?v=bciRImf0_Ts&t=3470) byte code emitter emitbc.c
+* [0:58:59](https://www.youtube.com/watch?v=bciRImf0_Ts&t=3539) compile.c calls emitter, or emitnative.c
+* [1:01:30](https://www.youtube.com/watch?v=bciRImf0_Ts&t=3690) Is .native and .viper just at a method level? Class level too?
+* [1:02:50](https://www.youtube.com/watch?v=bciRImf0_Ts&t=3770) native ‘everything’ by saving the python to a code
+* [1:08:00](https://www.youtube.com/watch?v=bciRImf0_Ts&t=4080) continue in emit native
+* [1:10:10](https://www.youtube.com/watch?v=bciRImf0_Ts&t=4210) what if we use a local variable?
+* [1:11:34](https://www.youtube.com/watch?v=bciRImf0_Ts&t=4294) gdb ./micropython ( oops - rebuild first )
+* [1:13:35](https://www.youtube.com/watch?v=bciRImf0_Ts&t=4415) mp_obj_t ( the most useful point of this deep dive )
+* [1:15:20](https://www.youtube.com/watch?v=bciRImf0_Ts&t=4520) type tagging ( see mpconfig.h )
+* [1:16:45](https://www.youtube.com/watch?v=bciRImf0_Ts&t=4605) some builds of CP don’t support long integers
+* [1:18:35](https://www.youtube.com/watch?v=bciRImf0_Ts&t=4715) . is there anything else than micropython that emit micropython bytecode? Like at one point everyone was making JVM bytecode even not being java
+* [1:20:05](https://www.youtube.com/watch?v=bciRImf0_Ts&t=4805) everything is a 32 bit integer - ( or a pointer to an object )
+* [1:21:10](https://www.youtube.com/watch?v=bciRImf0_Ts&t=4870) Why (3) is really 1 and 0x1ff
+* [1:22:25](https://www.youtube.com/watch?v=bciRImf0_Ts&t=4945) gdb backtrace doesn’t work with native emitter
+* [1:23:10](https://www.youtube.com/watch?v=bciRImf0_Ts&t=4990) anybody doing "hand written" bytecode to do something smart or super optimised?
+* [1:25:00](https://www.youtube.com/watch?v=bciRImf0_Ts&t=5100) Write part of the core in the python
+* [1:27:55](https://www.youtube.com/watch?v=bciRImf0_Ts&t=5275) looking at the native code generated in a file
+* [1:29:49](https://www.youtube.com/watch?v=bciRImf0_Ts&t=5389) Is there a byte code to python "decompiler"?
+* [1:30:30](https://www.youtube.com/watch?v=bciRImf0_Ts&t=5430) debug the debugging code
+* [1:32:03](https://www.youtube.com/watch?v=bciRImf0_Ts&t=5523) objdump to disassemble the generated code (x86-64 code)
+* [1:34:50](https://www.youtube.com/watch?v=bciRImf0_Ts&t=5690) rbp is pointer to functable - ( there is no linker)
+* [1:41:03](https://www.youtube.com/watch?v=bciRImf0_Ts&t=6063) viper generation
+* [1:45:40](https://www.youtube.com/watch?v=bciRImf0_Ts&t=6340) emit_native_jump_helper
+* [1:47:08](https://www.youtube.com/watch?v=bciRImf0_Ts&t=6428) 3 different stacks ( processor, MP function stack, emitter stack (while emitting )
+* [1:49:00](https://www.youtube.com/watch?v=bciRImf0_Ts&t=6540) optimization
+* [1:51:50](https://www.youtube.com/watch?v=bciRImf0_Ts&t=6710) - another optimization - keep variables in registers
+* [1:53:50](https://www.youtube.com/watch?v=bciRImf0_Ts&t=6830) - clobber EAX
+* [1:55:40](https://www.youtube.com/watch?v=bciRImf0_Ts&t=6940) RISC-V ISA/calling conventions  ( ABI - binary interface )
+* [1:57:30](https://www.youtube.com/watch?v=bciRImf0_Ts&t=7050) one character fix  ( use EDI instead of EAX )
+* [1:58:52](https://www.youtube.com/watch?v=bciRImf0_Ts&t=7132) Write a test to verify the fix
+* [1:59:45](https://www.youtube.com/watch?v=bciRImf0_Ts&t=7185) fixed on thumb code
+* [2:00:00](https://www.youtube.com/watch?v=bciRImf0_Ts&t=7200) MP issue #7523
 * Thanks to Jim and https://www.robotshop.com/en/george-robotics.html
-* [2:08:00](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=7680) wrap up!
-* [2:08](https://www.youtube.com/watch?v=VIDEO_2021_07_16?t=128);30 - final frame :-)
+* [2:08:00](https://www.youtube.com/watch?v=bciRImf0_Ts&t=7680) wrap up!
+* [2:08](https://www.youtube.com/watch?v=bciRImf0_Ts&t=128);30 - final frame :-)
 *

--- a/2021/2021-07-23.md
+++ b/2021/2021-07-23.md
@@ -16,63 +16,63 @@ Plan
 *
 
 Timestamps
-* [0:05:00](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=300) - what made it into CP 7.0
-* [0:07:52](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=472) housekeeping
-* [0:11:02](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=662)  2 x Arduino Nano RP2040 Connect, BLE device to device. As soon as the BLE obj on the Central is active it appears the RGB led cannot be controlled ( not CP )
+* [0:05:00](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=300) - what made it into CP 7.0
+* [0:07:52](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=472) housekeeping
+* [0:11:02](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=662)  2 x Arduino Nano RP2040 Connect, BLE device to device. As soon as the BLE obj on the Central is active it appears the RGB led cannot be controlled ( not CP )
 * 013:36 keboardio
-* [0:16:31](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=991) CP 7.0 - pull request review and issues
-* [0:20:30](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=1230) If Native CP on the Pi was a thing, would we get real multi-core support? And would that gain multi-core support on the Pico?
-* [0:23:55](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=1435) trying to do a pull from main, get the issue with ports/raspberrypi/sdk/lib/tinyusb has moved to some new point in time. what's the best way to get it all straight
-* [0:24:50](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=1490) “git status” always
-* [0:25:22](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=1522) RP2040 flash size fix
-* [0:29:44](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=1784) ScanEntry.matches fix
-* [0:31:00](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=1860) Don’t blink blue….
-* [0:32:11](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=1931) Fix crash when UART construct fails
-* [0:34:00](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2040) only push main to S3
-* [0:34:20](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2060) Remove OSError(0) and old network modules
-* [0:35:18](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2118) nrf52840 build not booting
-* [0:35:40](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2140) refactor pulseout to no take PWMOut
-* [0:36:00](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2160) Ctrl-C is not interrupting deep sleep
-* [0:37:36](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2256) start with pulseout_switch ( git commands )
-* [0:40:34](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2434) source code in sublime
-* [0:45:17](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2717) in terms of microcontroller support, do you think we're coming to the point where the SAMD21 is just too small to be productive for future CircuitPython releases?
-* [0:46:30](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2790) practical metrics on RAM usage in 6 versus 7
-* [0:47:50](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2870) finding adafruit schematics - NEOSENSE_SWITCH
-* [0:52:00](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=3120) overhead camera)
-* [0:54:00](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=3240) oh look - it works :-)
-* [0:54:25](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=3265) Adafruit board) Circuit playground bluefruit revisions rev (G)
-* [0:58:23](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=3503) board.c - reset_board - turning off power switch
-* [1:00:01](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=3601) Is there a description of the different board revisions? I have a Circuit Playground Bluefruit Rev D and I'm not seeing anything here: https://github.com/adafruit/Adafruit-Circuit-Playground-Bluefruit-PCB
-* [1:00:00](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=3600) review the product page description
-* [1:02:43](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=3763) board init and board_deinit ( supervisor/port.c )
-* [1:08:30](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=4110) back to the schematic -
-* [1:11:59](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=4319) make and test one more time - perfect!
-* [1:13:27](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=4407) not to Atmel SAMD
-* [1:18:32](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=4712) Serial/by-id  in linux /dev/ as argument to tio
-* [1:21:19](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=4879) git commit support  multiple status neopixels fix #5039
-* [1:23:20](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5000) Should be Blue for Bluetototh?
-* [1:24:35](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5075) Refactor pulseout
-* [1:26:20](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5180) monitor CI ( continuous integration ) in the background
-* [1:26:50](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5210) CP 6.3 readthedocs / pulseio.pulseout
-* [1:28:00](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5280) pull/3279/files pull request
-* [1:32:40](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5560) - not quite backwards compatible
-* [1:33:50](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5630) need to test a bunch of ports
-* [1:35:54](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5754) fetch the test program from other board
-* [1:37:34](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5854) connect new board
-* [1:38:30](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5910) there are other things in CP 7.0 that will be changes
-* [1:39:20](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5960) would love people to make the CI faster
-* [1:41:11](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6071) this test was even more accurate
-* [1:42:40](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6160) STM32f405_express  feather boot loader
-* [1:43:40](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6220) that PR had a bug in it - need to fix that - add a default value for the count
-* [1:47:15](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6435) pulseout_switch testing after git rebase
-* [1:47:50](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6470) return to the learn guide for STM32F405 - Enabling DFU bootloader mode
-* [1:48:40](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6520) dfu-util command ( in fish history! )
-* [1:49:15](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6555) dfu vs. uf2 for updates
-* [1:50:07](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6607) is there support for stm32 in tinyuf2
-* [1:50:58](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6658) now we are in safe mode - again tio /dev/serial/by-id provides value!
-* [1:53:10](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6790) this is the problem with having the source code on the device :-)
-* [1:55:40](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6940) - back to the Logic 2 - see that the deinit didn’t work
-* [1:57:05](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=7025) plug for discotool
-* [2:04:08](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=7448) save code.py
-* [2:08:18](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=7698) wrapping up / rambling :-)
-* [2:11:21](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=7881) have a great one…
+* [0:16:31](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=991) CP 7.0 - pull request review and issues
+* [0:20:30](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=1230) If Native CP on the Pi was a thing, would we get real multi-core support? And would that gain multi-core support on the Pico?
+* [0:23:55](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=1435) trying to do a pull from main, get the issue with ports/raspberrypi/sdk/lib/tinyusb has moved to some new point in time. what's the best way to get it all straight
+* [0:24:50](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=1490) “git status” always
+* [0:25:22](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=1522) RP2040 flash size fix
+* [0:29:44](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=1784) ScanEntry.matches fix
+* [0:31:00](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=1860) Don’t blink blue….
+* [0:32:11](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=1931) Fix crash when UART construct fails
+* [0:34:00](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=2040) only push main to S3
+* [0:34:20](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=2060) Remove OSError(0) and old network modules
+* [0:35:18](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=2118) nrf52840 build not booting
+* [0:35:40](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=2140) refactor pulseout to no take PWMOut
+* [0:36:00](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=2160) Ctrl-C is not interrupting deep sleep
+* [0:37:36](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=2256) start with pulseout_switch ( git commands )
+* [0:40:34](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=2434) source code in sublime
+* [0:45:17](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=2717) in terms of microcontroller support, do you think we're coming to the point where the SAMD21 is just too small to be productive for future CircuitPython releases?
+* [0:46:30](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=2790) practical metrics on RAM usage in 6 versus 7
+* [0:47:50](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=2870) finding adafruit schematics - NEOSENSE_SWITCH
+* [0:52:00](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=3120) overhead camera)
+* [0:54:00](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=3240) oh look - it works :-)
+* [0:54:25](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=3265) Adafruit board) Circuit playground bluefruit revisions rev (G)
+* [0:58:23](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=3503) board.c - reset_board - turning off power switch
+* [1:00:01](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=3601) Is there a description of the different board revisions? I have a Circuit Playground Bluefruit Rev D and I'm not seeing anything here: https://github.com/adafruit/Adafruit-Circuit-Playground-Bluefruit-PCB
+* [1:00:00](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=3600) review the product page description
+* [1:02:43](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=3763) board init and board_deinit ( supervisor/port.c )
+* [1:08:30](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=4110) back to the schematic -
+* [1:11:59](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=4319) make and test one more time - perfect!
+* [1:13:27](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=4407) not to Atmel SAMD
+* [1:18:32](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=4712) Serial/by-id  in linux /dev/ as argument to tio
+* [1:21:19](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=4879) git commit support  multiple status neopixels fix #5039
+* [1:23:20](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=5000) Should be Blue for Bluetototh?
+* [1:24:35](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=5075) Refactor pulseout
+* [1:26:20](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=5180) monitor CI ( continuous integration ) in the background
+* [1:26:50](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=5210) CP 6.3 readthedocs / pulseio.pulseout
+* [1:28:00](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=5280) pull/3279/files pull request
+* [1:32:40](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=5560) - not quite backwards compatible
+* [1:33:50](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=5630) need to test a bunch of ports
+* [1:35:54](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=5754) fetch the test program from other board
+* [1:37:34](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=5854) connect new board
+* [1:38:30](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=5910) there are other things in CP 7.0 that will be changes
+* [1:39:20](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=5960) would love people to make the CI faster
+* [1:41:11](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=6071) this test was even more accurate
+* [1:42:40](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=6160) STM32f405_express  feather boot loader
+* [1:43:40](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=6220) that PR had a bug in it - need to fix that - add a default value for the count
+* [1:47:15](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=6435) pulseout_switch testing after git rebase
+* [1:47:50](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=6470) return to the learn guide for STM32F405 - Enabling DFU bootloader mode
+* [1:48:40](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=6520) dfu-util command ( in fish history! )
+* [1:49:15](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=6555) dfu vs. uf2 for updates
+* [1:50:07](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=6607) is there support for stm32 in tinyuf2
+* [1:50:58](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=6658) now we are in safe mode - again tio /dev/serial/by-id provides value!
+* [1:53:10](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=6790) this is the problem with having the source code on the device :-)
+* [1:55:40](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=6940) - back to the Logic 2 - see that the deinit didn’t work
+* [1:57:05](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=7025) plug for discotool
+* [2:04:08](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=7448) save code.py
+* [2:08:18](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=7698) wrapping up / rambling :-)
+* [2:11:21](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=7881) have a great one…

--- a/2021/2021-07-23.md
+++ b/2021/2021-07-23.md
@@ -13,66 +13,66 @@ Housekeeping
 
 
 Plan
-* 
+*
 
 Timestamps
-* 0:05:00 - what made it into CP 7.0
-* 0:07:52 housekeeping
-* 0:11:02  2 x Arduino Nano RP2040 Connect, BLE device to device. As soon as the BLE obj on the Central is active it appears the RGB led cannot be controlled ( not CP )
-* 013:36 keboardio 
-* 0:16:31 CP 7.0 - pull request review and issues
-* 0:20:30 If Native CP on the Pi was a thing, would we get real multi-core support? And would that gain multi-core support on the Pico?
-* 0:23:55 trying to do a pull from main, get the issue with ports/raspberrypi/sdk/lib/tinyusb has moved to some new point in time. what's the best way to get it all straight
-* 0:24:50 “git status” always
-* 0:25:22 RP2040 flash size fix
-* 0:29:44 ScanEntry.matches fix
-* 0:31:00 Don’t blink blue….
-* 0:32:11 Fix crash when UART construct fails
-* 0:34:00 only push main to S3
-* 0:34:20 Remove OSError(0) and old network modules
-* 0:35:18 nrf52840 build not booting 
-* 0:35:40 refactor pulseout to no take PWMOut
-* 0:36:00 Ctrl-C is not interrupting deep sleep
-* 0:37:36 start with pulseout_switch ( git commands )
-* 0:40:34 source code in sublime 
-* 0:45:17 in terms of microcontroller support, do you think we're coming to the point where the SAMD21 is just too small to be productive for future CircuitPython releases?
-* 0:46:30 practical metrics on RAM usage in 6 versus 7
-* 0:47:50 finding adafruit schematics - NEOSENSE_SWITCH
-* 0:52:00 overhead camera)
-* 0:54:00 oh look - it works :-)
-* 0:54:25 Adafruit board) Circuit playground bluefruit revisions rev (G)
-* 0:58:23 board.c - reset_board - turning off power switch
-* 1:00:01 Is there a description of the different board revisions? I have a Circuit Playground Bluefruit Rev D and I'm not seeing anything here: https://github.com/adafruit/Adafruit-Circuit-Playground-Bluefruit-PCB
-* 1:00:00 review the product page description
-* 1:02:43 board init and board_deinit ( supervisor/port.c )
-* 1:08:30 back to the schematic - 
-* 1:11:59 make and test one more time - perfect!
-* 1:13:27 not to Atmel SAMD
-* 1:18:32 Serial/by-id  in linux /dev/ as argument to tio
-* 1:21:19 git commit support  multiple status neopixels fix #5039
-* 1:23:20 Should be Blue for Bluetototh?
-* 1:24:35 Refactor pulseout
-* 1:26:20 monitor CI ( continuous integration ) in the background
-* 1:26:50 CP 6.3 readthedocs / pulseio.pulseout  
-* 1:28:00 pull/3279/files pull request 
-* 1:32:40 - not quite backwards compatible
-* 1:33:50 need to test a bunch of ports
-* 1:35:54 fetch the test program from other board
-* 1:37:34 connect new board 
-* 1:38:30 there are other things in CP 7.0 that will be changes
-* 1:39:20 would love people to make the CI faster
-* 1:41:11 this test was even more accurate
-* 1:42:40 STM32f405_express  feather boot loader 
-* 1:43:40 that PR had a bug in it - need to fix that - add a default value for the count
-* 1:47:15 pulseout_switch testing after git rebase
-* 1:47:50 return to the learn guide for STM32F405 - Enabling DFU bootloader mode
-* 1:48:40 dfu-util command ( in fish history! )
-* 1:49:15 dfu vs. uf2 for updates
-* 1:50:07 is there support for stm32 in tinyuf2
-* 1:50:58 now we are in safe mode - again tio /dev/serial/by-id provides value!
-* 1:53:10 this is the problem with having the source code on the device :-)
-* 1:55:40 - back to the Logic 2 - see that the deinit didn’t work
-* 1:57:05 plug for discotool
-* 2:04:08 save code.py
-* 2:08:18 wrapping up / rambling :-)
-* 2:11:21 have a great one…
+* [0:05:00](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=300) - what made it into CP 7.0
+* [0:07:52](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=472) housekeeping
+* [0:11:02](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=662)  2 x Arduino Nano RP2040 Connect, BLE device to device. As soon as the BLE obj on the Central is active it appears the RGB led cannot be controlled ( not CP )
+* 013:36 keboardio
+* [0:16:31](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=991) CP 7.0 - pull request review and issues
+* [0:20:30](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=1230) If Native CP on the Pi was a thing, would we get real multi-core support? And would that gain multi-core support on the Pico?
+* [0:23:55](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=1435) trying to do a pull from main, get the issue with ports/raspberrypi/sdk/lib/tinyusb has moved to some new point in time. what's the best way to get it all straight
+* [0:24:50](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=1490) “git status” always
+* [0:25:22](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=1522) RP2040 flash size fix
+* [0:29:44](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=1784) ScanEntry.matches fix
+* [0:31:00](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=1860) Don’t blink blue….
+* [0:32:11](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=1931) Fix crash when UART construct fails
+* [0:34:00](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2040) only push main to S3
+* [0:34:20](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2060) Remove OSError(0) and old network modules
+* [0:35:18](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2118) nrf52840 build not booting
+* [0:35:40](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2140) refactor pulseout to no take PWMOut
+* [0:36:00](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2160) Ctrl-C is not interrupting deep sleep
+* [0:37:36](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2256) start with pulseout_switch ( git commands )
+* [0:40:34](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2434) source code in sublime
+* [0:45:17](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2717) in terms of microcontroller support, do you think we're coming to the point where the SAMD21 is just too small to be productive for future CircuitPython releases?
+* [0:46:30](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2790) practical metrics on RAM usage in 6 versus 7
+* [0:47:50](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=2870) finding adafruit schematics - NEOSENSE_SWITCH
+* [0:52:00](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=3120) overhead camera)
+* [0:54:00](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=3240) oh look - it works :-)
+* [0:54:25](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=3265) Adafruit board) Circuit playground bluefruit revisions rev (G)
+* [0:58:23](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=3503) board.c - reset_board - turning off power switch
+* [1:00:01](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=3601) Is there a description of the different board revisions? I have a Circuit Playground Bluefruit Rev D and I'm not seeing anything here: https://github.com/adafruit/Adafruit-Circuit-Playground-Bluefruit-PCB
+* [1:00:00](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=3600) review the product page description
+* [1:02:43](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=3763) board init and board_deinit ( supervisor/port.c )
+* [1:08:30](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=4110) back to the schematic -
+* [1:11:59](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=4319) make and test one more time - perfect!
+* [1:13:27](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=4407) not to Atmel SAMD
+* [1:18:32](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=4712) Serial/by-id  in linux /dev/ as argument to tio
+* [1:21:19](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=4879) git commit support  multiple status neopixels fix #5039
+* [1:23:20](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5000) Should be Blue for Bluetototh?
+* [1:24:35](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5075) Refactor pulseout
+* [1:26:20](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5180) monitor CI ( continuous integration ) in the background
+* [1:26:50](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5210) CP 6.3 readthedocs / pulseio.pulseout
+* [1:28:00](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5280) pull/3279/files pull request
+* [1:32:40](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5560) - not quite backwards compatible
+* [1:33:50](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5630) need to test a bunch of ports
+* [1:35:54](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5754) fetch the test program from other board
+* [1:37:34](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5854) connect new board
+* [1:38:30](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5910) there are other things in CP 7.0 that will be changes
+* [1:39:20](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=5960) would love people to make the CI faster
+* [1:41:11](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6071) this test was even more accurate
+* [1:42:40](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6160) STM32f405_express  feather boot loader
+* [1:43:40](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6220) that PR had a bug in it - need to fix that - add a default value for the count
+* [1:47:15](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6435) pulseout_switch testing after git rebase
+* [1:47:50](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6470) return to the learn guide for STM32F405 - Enabling DFU bootloader mode
+* [1:48:40](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6520) dfu-util command ( in fish history! )
+* [1:49:15](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6555) dfu vs. uf2 for updates
+* [1:50:07](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6607) is there support for stm32 in tinyuf2
+* [1:50:58](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6658) now we are in safe mode - again tio /dev/serial/by-id provides value!
+* [1:53:10](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6790) this is the problem with having the source code on the device :-)
+* [1:55:40](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=6940) - back to the Logic 2 - see that the deinit didn’t work
+* [1:57:05](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=7025) plug for discotool
+* [2:04:08](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=7448) save code.py
+* [2:08:18](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=7698) wrapping up / rambling :-)
+* [2:11:21](https://www.youtube.com/watch?v=VIDEO_2021_07_23?t=7881) have a great one…

--- a/2021/2021-07-23.md
+++ b/2021/2021-07-23.md
@@ -38,9 +38,9 @@ Timestamps
 * [0:45:17](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=2717) in terms of microcontroller support, do you think we're coming to the point where the SAMD21 is just too small to be productive for future CircuitPython releases?
 * [0:46:30](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=2790) practical metrics on RAM usage in 6 versus 7
 * [0:47:50](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=2870) finding adafruit schematics - NEOSENSE_SWITCH
-* [0:52:00](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=3120) overhead camera)
+* [0:52:00](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=3120) overhead camera
 * [0:54:00](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=3240) oh look - it works :-)
-* [0:54:25](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=3265) Adafruit board) Circuit playground bluefruit revisions rev (G)
+* [0:54:25](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=3265) Adafruit board: Circuit playground bluefruit revisions rev (G)
 * [0:58:23](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=3503) board.c - reset_board - turning off power switch
 * [1:00:01](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=3601) Is there a description of the different board revisions? I have a Circuit Playground Bluefruit Rev D and I'm not seeing anything here: https://github.com/adafruit/Adafruit-Circuit-Playground-Bluefruit-PCB
 * [1:00:00](https://www.youtube.com/watch?v=LkvRkUkPwPs&t=3600) review the product page description

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,74 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at support@adafruit.com. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/README.md
+++ b/README.md
@@ -2,3 +2,17 @@
 
 ## Schedule
 Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome. Next week will be on Friday as well.
+
+## Formatting Episodes notes with add_yt_links.py
+
+Add Direct YT links to Timestamped Markdown Files
+Example YT URL "https://www.youtube.com/watch?v=VIDEO_ID?t=seconds"
+
+Examples:
+`python add_yt_links VIDEO_ID`
+>VIDEO_ID is the YT video parameter from the watch url v=VIDEO_ID
+If episode_data is not supplied, today's date is used.
+
+`python add_yt_links VIDEO_ID YYYY-MM-DD`
+> VIDEO_ID is the YT video parameter from the watch url v=VIDEO_ID
+Specify an EPISODE_DATE to process files for other dates.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# Deep Dive with Scott
+
+## Schedule
+Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally shifted to Thursday at 2pm. Typically goes for two hours or more. Questions are welcome. Next week will be on Friday as well.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Deep Dive happens every week. Normally Fridays at 2pm Pacific but occasionally s
 ## Formatting Episodes notes with add_yt_links.py
 
 Add Direct YT links to Timestamped Markdown Files
-Example YT URL "https://www.youtube.com/watch?v=VIDEO_ID?t=seconds"
+Example YT URL "https://www.youtube.com/watch?v=VIDEO_ID&t=seconds"
 
 Examples:
 `python add_yt_links VIDEO_ID`

--- a/tools/add_yt_links.py
+++ b/tools/add_yt_links.py
@@ -1,0 +1,91 @@
+"""
+    Add Direct YT links to Timestamped Markdown Files
+    Example YT URL "https://www.youtube.com/watch?v=VIDEO_ID?t=seconds"
+
+    Example:
+        python add_yt_links VIDEO_ID
+            VIDEO_ID is the YT video parameter from the watch url v=VIDEO_ID
+            If episode_data is not supplied, today's date is used.
+
+        python add_yt_links VIDEO_ID EPISODE_DATE(YYYY-MM-DD)
+            VIDEO_ID is the YT video parameter from the watch url v=VIDEO_ID
+            Specify an episode date to process files for other dates.
+"""
+
+
+import datetime
+from pathlib import Path
+import re
+import sys
+import time
+
+# pylint: disable=anomalous-backslash-in-string
+# Matches * #:##:## or * ##:## or * #:##
+TIMESTAMP_PATTERN = re.compile("\*\s\d:\d\d:\d\d|\*\s\d\d:\d\d|\*\s\d:\d\d")
+
+
+def convert_elapsed_time_to_seconds(elapsed_time):
+    """Converts a  string of elapsed time to seconds
+
+    params:
+    elapsed_time (str)
+
+    return:
+    seconds (int)
+    """
+    print(f"convert_elapsed_time_to_seconds: {elapsed_time}")
+    _elapsed_time = time.strptime(elapsed_time, "%H:%M:%S")
+    return int(
+        datetime.timedelta(
+            hours=_elapsed_time.tm_hour,
+            minutes=_elapsed_time.tm_min,
+            seconds=_elapsed_time.tm_sec,
+        ).total_seconds()
+    )
+
+
+def process_episode(episode_notes):
+    """
+    params:
+    episode_notes (Path): File to be processed and re-written
+    """
+    with episode_notes.open() as file:
+        file_contents = file.read()
+        file_contents = re.sub(TIMESTAMP_PATTERN, yt_timestamp_url_repl, file_contents)
+        print(file_contents)
+        episode_notes.write_text(file_contents)
+
+
+def yt_timestamp_url_repl(match):
+    """
+    Regex REPL to go with sub command
+
+    Params:
+    match (regex match object)
+
+    Return:
+    new string (str)
+    """
+    elapsed_time = match.group(0).split(" ")[1]
+    if len(elapsed_time.split(":")) == 2:
+        elapsed_time = f"0:{elapsed_time}"
+    seconds = convert_elapsed_time_to_seconds(elapsed_time)
+    episode_url_ts = f"https://www.youtube.com/watch?v={VIDEO_ID}?t={seconds}"
+    print(episode_url_ts)
+    return f"* [{match.group(0).split(' ')[1]}]({episode_url_ts})"
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        raise ValueError("You must supply a YT video ID.")
+    VIDEO_ID = sys.argv[1]
+
+    if len(sys.argv) > 2:
+        EPISODE_DATE = sys.argv[2]
+    else:
+        EPISODE_DATE = datetime.datetime.now().strftime("%Y-%m-%d")
+
+    episode_file = Path(f"{EPISODE_DATE.split('-')[0]}/{EPISODE_DATE}.md")
+    if episode_file.exists() is not True:
+        raise ValueError(f"{episode_file} is not found.")
+    process_episode(episode_file)

--- a/tools/add_yt_links.py
+++ b/tools/add_yt_links.py
@@ -1,6 +1,6 @@
 """
     Add Direct YT links to Timestamped Markdown Files
-    Example YT URL "https://www.youtube.com/watch?v=VIDEO_ID?t=seconds"
+    Example YT URL "https://www.youtube.com/watch?v=VIDEO_ID&t=seconds"
 
     Example:
         python add_yt_links VIDEO_ID
@@ -70,7 +70,7 @@ def yt_timestamp_url_repl(match):
     if len(elapsed_time.split(":")) == 2:
         elapsed_time = f"0:{elapsed_time}"
     seconds = convert_elapsed_time_to_seconds(elapsed_time)
-    episode_url_ts = f"https://www.youtube.com/watch?v={VIDEO_ID}?t={seconds}"
+    episode_url_ts = f"https://www.youtube.com/watch?v={VIDEO_ID}&t={seconds}"
     print(episode_url_ts)
     return f"* [{match.group(0).split(' ')[1]}]({episode_url_ts})"
 


### PR DESCRIPTION
* `add_yt_links.py` can be run after recording an episode once you know the episode video_id and assuming an episode notes file exists.
* Updated the README with the instructions
* Updated all the files with the correct video_id and timestamps based on the episode notes


> Note: I didn't see any reason to check this part in, but this is how the files were bulk processed.

```python
from pathlib import Path
import add_yt_links

episode_files = sorted(Path("./2020").glob("*.md"))
episode_files += sorted(Path("./2021").glob("*.md"))
for episode_file in episode_files:
    add_yt_links.VIDEO_ID = f"VIDEO_{episode_file.stem.replace('-', '_')}"
    add_yt_links.EPISODE_DATE = episode_file.stem
    add_yt_links.process_episode(episode_file)
```

