### PR TITLE
Move requirements install

### DIFF
--- a/.github/workflows/show_notes.yml
+++ b/.github/workflows/show_notes.yml
@@ -21,12 +21,12 @@ jobs:
          python --version
          git --version
          gh version
-         pip install -r requirements.txt
       - name: Check for and generate new show notes
         env:
           YOUTUBE_API_KEY: ${{ secrets.YOUTUBE_API_KEY }}
           YOUTUBE_PLAYLIST_ID: "PLjF7R1fz_OOXBHlu9msoXq2jQN4JpCk8A"
         run: |
+          pip install -r requirements.txt
           python tools/yt_playlist_show_notes.py
       - name: Git Add & Commit
         if: ${{ env.NEWFILE_PATH }}


### PR DESCRIPTION
Huh, this must have worked for me in testing because the runner had it cached. I think moving it to the step as where I run the script will fix it.